### PR TITLE
Add #40: InputFields emit an event on text change

### DIFF
--- a/indigo/indigo-extras/src/test/scala/indigoextras/ui/InputFieldTests.scala
+++ b/indigo/indigo-extras/src/test/scala/indigoextras/ui/InputFieldTests.scala
@@ -14,6 +14,15 @@ import indigo.shared.datatypes.FontInfo
 import indigo.shared.AnimationsRegister
 import indigo.shared.time.GameTime
 import indigo.shared.datatypes.Point
+import indigo.shared.events.InputState
+import indigo.shared.dice.Dice
+import indigo.shared.FrameContext
+import indigo.shared.input.Mouse
+import indigo.shared.input.Keyboard
+import indigo.shared.input.Gamepad
+import indigo.shared.events.KeyboardEvent
+import indigo.shared.constants.Keys
+import indigo.shared.datatypes.BindingKey
 
 object InputFieldTests extends TestSuite {
 
@@ -192,7 +201,53 @@ object InputFieldTests extends TestSuite {
           actual ==> expected
         }
 
+        "Updated text emits an event" - {
+
+          "if the key is set" - {
+            val key =
+              BindingKey("test")
+
+            val field =
+              InputField("", assets).giveFocus.withKey(BindingKey("test"))
+
+            val actual =
+              field.update(context).flatMap(_.update(context))
+
+            actual.state.text ==> "ABCABC"
+            actual.globalEvents.head ==> InputFieldChange(key, "ABC")
+            actual.globalEvents(1) ==> InputFieldChange(key, "ABCABC")
+          }
+
+          "unless the key is unset" - {
+            val field =
+              InputField("", assets).giveFocus
+
+            val actual =
+              field.update(context).flatMap(_.update(context))
+
+            actual.state.text ==> "ABCABC"
+            actual.globalEvents ==> Nil
+          }
+
+        }
+
       }
+
+      val keysUp: List[KeyboardEvent.KeyUp] =
+        List(
+          KeyboardEvent.KeyUp(Keys.KEY_A),
+          KeyboardEvent.KeyUp(Keys.KEY_B),
+          KeyboardEvent.KeyUp(Keys.KEY_C)
+        )
+
+      def context: FrameContext[Unit] =
+        new FrameContext[Unit](
+          GameTime.zero,
+          Dice.loaded(1),
+          new InputState(Mouse.default, new Keyboard(keysUp, Nil, None), Gamepad.default),
+          new BoundaryLocator(new AnimationsRegister, new FontRegister),
+          ()
+        )
 
     }
 

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/SandboxGame.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/SandboxGame.scala
@@ -71,8 +71,8 @@ object SandboxGame extends IndigoDemo[SandboxBootData, SandboxStartupData, Sandb
 
     SandboxViewModel(
       Point.zero,
-      InputField("single", assets).makeSingleLine,
-      InputField("multi\nline", assets).makeMultiLine
+      InputField("single", assets).withKey(BindingKey("single")).makeSingleLine,
+      InputField("multi\nline", assets).withKey(BindingKey("multi")).makeMultiLine
     )
   }
 
@@ -100,13 +100,10 @@ object SandboxGame extends IndigoDemo[SandboxBootData, SandboxStartupData, Sandb
         }
 
       //more stuff
-      Outcome(
-        viewModel.copy(
-          offset = updateOffset,
-          single = viewModel.single.update(context),
-          multi = viewModel.multi.update(context)
-        )
-      )
+      for {
+        single <- viewModel.single.update(context)
+        multi  <- viewModel.multi.update(context)
+      } yield viewModel.copy(updateOffset, single, multi)
 
     case _ =>
       Outcome(viewModel)

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/SandboxModel.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/SandboxModel.scala
@@ -1,6 +1,7 @@
 package com.example.sandbox
 
 import indigo._
+import indigoextras.ui.InputFieldChange
 
 object SandboxModel {
 
@@ -14,6 +15,10 @@ object SandboxModel {
   def updateModel(state: SandboxGameModel): GlobalEvent => Outcome[SandboxGameModel] = {
     case rd @ RendererDetails(_, _, _) =>
       println(rd)
+      Outcome(state)
+
+    case InputFieldChange(key, value) =>
+      println(s"Input field '${key.toString()}' changed: " + value)
       Outcome(state)
 
     case FrameTick =>


### PR DESCRIPTION
As described in issue #40.

The main API impact that causes a breaking change is that updating an InputField now returns an `Outcome[InputField]` instead of an `InputField` so that we can capture the event.

Events are only emitted if you've given the input field an ID/Key so that you can track which input field the event came from.