### PR TITLE
Bringing back case classes...

### DIFF
--- a/examples/assetLoading/src/main/scala/com/example/assetloading/AssetLoadingExample.scala
+++ b/examples/assetLoading/src/main/scala/com/example/assetloading/AssetLoadingExample.scala
@@ -43,6 +43,7 @@ object AssetLoadingExample extends IndigoDemo[Unit, Unit, MyGameModel, MyViewMod
       }
     )
 
+  @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   def updateModel(context: FrameContext[Unit], model: MyGameModel): GlobalEvent => Outcome[MyGameModel] = {
     case AssetBundleLoaderEvent.Started(key) =>
       println("Load started! " + key.toString())

--- a/examples/inputfield/src/main/scala/indigoexamples/InputFieldExample.scala
+++ b/examples/inputfield/src/main/scala/indigoexamples/InputFieldExample.scala
@@ -40,12 +40,10 @@ object InputFieldExample extends IndigoDemo[Unit, Unit, Unit, MyViewModel] {
 
   def updateViewModel(context: FrameContext[Unit], model: Unit, viewModel: MyViewModel): GlobalEvent => Outcome[MyViewModel] = {
     case FrameTick =>
-      Outcome(
-        viewModel.copy(
-          singleLine = viewModel.singleLine.update(context),
-          multiLine = viewModel.multiLine.update(context)
-        )
-      )
+      for {
+        single <- viewModel.singleLine.update(context)
+        multi  <- viewModel.multiLine.update(context)
+      } yield viewModel.copy(singleLine = single, multiLine = multi)
 
     case _ =>
       Outcome(viewModel)

--- a/indigo/indigo-core/src/main/scala/indigo/package.scala
+++ b/indigo/indigo-core/src/main/scala/indigo/package.scala
@@ -72,12 +72,14 @@ package object indigo extends DataTypeAliases with SceneGraphTypeAliases with Ne
     * - No advanced settings enabled
     * @return A GameConfig instance
     */
-  val defaultGameConfig: indigo.shared.config.GameConfig = indigo.shared.config.GameConfig.default
+  val defaultGameConfig: indigo.shared.config.GameConfig =
+    indigo.shared.config.GameConfig.default
 
   /**
     * noRender Convenience value, alias for SceneUpdateFragment.empty
     * @return An Empty SceneUpdateFragment
     */
-  val noRender: indigo.shared.scenegraph.SceneUpdateFragment = indigo.shared.scenegraph.SceneUpdateFragment.empty
+  val noRender: indigo.shared.scenegraph.SceneUpdateFragment =
+    indigo.shared.scenegraph.SceneUpdateFragment.empty
 
 }

--- a/indigo/indigo-extras/src/main/scala/indigoextras/datatypes/TimeVaryingValue.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/datatypes/TimeVaryingValue.scala
@@ -4,7 +4,7 @@ import indigo.shared.time.Seconds
 import indigo.shared.EqualTo
 import indigo.shared.EqualTo._
 
-final class TimeVaryingValue[@specialized(Int, Long, Float, Double) T](val value: T, val startValue: T, val createdAt: Seconds)(implicit vot: ValueOverTime[T]) {
+final case class TimeVaryingValue[@specialized(Int, Long, Float, Double) T](value: T, startValue: T, createdAt: Seconds)(implicit vot: ValueOverTime[T]) {
 
   def increase(unitsPerSecond: T, runningTime: Seconds): TimeVaryingValue[T] =
     TimeVaryingValue.increase(this, unitsPerSecond, runningTime)
@@ -24,9 +24,6 @@ final class TimeVaryingValue[@specialized(Int, Long, Float, Double) T](val value
   def decreaseWrapAt(limit: T, unitsPerSecond: T, runningTime: Seconds): TimeVaryingValue[T] =
     TimeVaryingValue.decreaseWrapAt(this, limit, unitsPerSecond, runningTime)
 
-  override def toString(): String =
-    s"TimeVaryingValue(${vot.asString(value)}, ${vot.asString(startValue)}, ${createdAt.toString()})"
-
 }
 object TimeVaryingValue {
 
@@ -38,13 +35,13 @@ object TimeVaryingValue {
   import ValueOverTime._
 
   def apply[@specialized(Int, Long, Float, Double) T](value: T, createdAt: Seconds)(implicit vot: ValueOverTime[T]): TimeVaryingValue[T] =
-    new TimeVaryingValue(value, value, createdAt)
+    TimeVaryingValue(value, value, createdAt)
 
   def withStartingValue[@specialized(Int, Long, Float, Double) T](value: T, startValue: T, createdAt: Seconds)(implicit vot: ValueOverTime[T]): TimeVaryingValue[T] =
-    new TimeVaryingValue(value, startValue, createdAt)
+    TimeVaryingValue(value, startValue, createdAt)
 
   def modifyValue[@specialized(Int, Long, Float, Double) T](timeVaryingValue: TimeVaryingValue[T], newValue: T)(implicit vot: ValueOverTime[T]): TimeVaryingValue[T] =
-    new TimeVaryingValue(newValue, timeVaryingValue.startValue, timeVaryingValue.createdAt)
+    TimeVaryingValue(newValue, timeVaryingValue.startValue, timeVaryingValue.createdAt)
 
   def increase[@specialized(Int, Long, Float, Double) T](timeVaryingValue: TimeVaryingValue[T], unitsPerSecond: T, runningTime: Seconds)(
       implicit vot: ValueOverTime[T]

--- a/indigo/indigo-extras/src/main/scala/indigoextras/geometry/Bezier.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/geometry/Bezier.scala
@@ -30,6 +30,7 @@ final class Bezier(val vertices: List[Vertex]) extends AnyVal {
   def ===(other: Bezier): Boolean =
     implicitly[EqualTo[Bezier]].equal(this, other)
 
+  @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   override def toString: String =
     s"Bezier(vertices = ${vertices.map(_.toString()).mkString("[", ",", "]")})"
 

--- a/indigo/indigo-extras/src/main/scala/indigoextras/geometry/BoundingBox.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/geometry/BoundingBox.scala
@@ -6,7 +6,7 @@ import scala.annotation.tailrec
 import indigo.shared.datatypes.Rectangle
 import indigoextras.geometry.IntersectionResult.IntersectionVertex
 
-final class BoundingBox(val position: Vertex, val size: Vertex) {
+final case class BoundingBox(position: Vertex, size: Vertex) {
   val x: Double         = position.x
   val y: Double         = position.y
   val width: Double     = size.x
@@ -54,14 +54,14 @@ final class BoundingBox(val position: Vertex, val size: Vertex) {
   def overlaps(other: BoundingBox): Boolean =
     BoundingBox.overlapping(this, other)
 
-  def moveBy(point: Vertex): BoundingBox =
-    BoundingBox(x + point.x, y + point.y, width, height)
+  def moveBy(amount: Vertex): BoundingBox =
+    this.copy(position = position + amount)
 
-  def moveTo(point: Vertex): BoundingBox =
-    BoundingBox(point, size)
+  def moveTo(newPosition: Vertex): BoundingBox =
+    this.copy(position = newPosition)
 
-  def resize(point: Vertex): BoundingBox =
-    BoundingBox(position, point)
+  def resize(newSize: Vertex): BoundingBox =
+    this.copy(size = newSize)
 
   def toRectangle: Rectangle =
     Rectangle(position.toPoint, size.toPoint)
@@ -75,9 +75,6 @@ final class BoundingBox(val position: Vertex, val size: Vertex) {
   def ===(other: BoundingBox): Boolean =
     implicitly[EqualTo[BoundingBox]].equal(this, other)
 
-  override def toString: String =
-    s"""BoundingBox(Position(${x.toString()}, ${y.toString()}), Size(${width.toString()}, ${height.toString()}))"""
-
   @SuppressWarnings(Array("org.wartremover.warts.IsInstanceOf", "org.wartremover.warts.AsInstanceOf"))
   override def equals(obj: Any): Boolean =
     if (obj.isInstanceOf[BoundingBox])
@@ -89,14 +86,8 @@ object BoundingBox {
 
   val zero: BoundingBox = BoundingBox(0, 0, 0, 0)
 
-  def apply(position: Vertex, size: Vertex): BoundingBox =
-    new BoundingBox(position, size)
-
   def apply(x: Double, y: Double, width: Double, height: Double): BoundingBox =
     BoundingBox(Vertex(x, y), Vertex(width, height))
-
-  def unapply(rectangle: BoundingBox): Option[(Vertex, Vertex)] =
-    Option((rectangle.position, rectangle.size))
 
   def fromTwoVertices(pt1: Vertex, pt2: Vertex): BoundingBox = {
     val x = Math.min(pt1.x, pt2.x)

--- a/indigo/indigo-extras/src/main/scala/indigoextras/geometry/LineSegment.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/geometry/LineSegment.scala
@@ -45,6 +45,7 @@ final class LineSegment(val start: Vertex, val end: Vertex) {
   def ===(other: LineSegment): Boolean =
     implicitly[EqualTo[LineSegment]].equal(this, other)
 
+  @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   override def toString: String =
     s"LineSegment(start = ${start.toString()}, end = ${end.toString()})"
 

--- a/indigo/indigo-extras/src/main/scala/indigoextras/geometry/Vertex.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/geometry/Vertex.scala
@@ -5,12 +5,13 @@ import indigo.shared.EqualTo._
 import indigo.shared.datatypes.Point
 import indigo.shared.datatypes.Vector2
 
-final class Vertex(val x: Double, val y: Double) {
+final case class Vertex(x: Double, y: Double) {
 
   def withX(newX: Double): Vertex =
-    Vertex(newX, y)
+    this.copy(x = newX)
+
   def withY(newY: Double): Vertex =
-    Vertex(x, newY)
+    this.copy(y = newY)
 
   def invert: Vertex =
     Vertex(-x, -y)
@@ -52,9 +53,6 @@ final class Vertex(val x: Double, val y: Double) {
   def ~==(other: Vertex): Boolean =
     Vertex.equalEnough(this, other, 0.001)
 
-  override def toString: String =
-    s"Vertex(x = ${x.toString}, y = ${y.toString})"
-
   @SuppressWarnings(Array("org.wartremover.warts.IsInstanceOf", "org.wartremover.warts.AsInstanceOf"))
   override def equals(obj: Any): Boolean =
     if (obj.isInstanceOf[Vertex])
@@ -72,14 +70,8 @@ object Vertex {
     }
   }
 
-  def apply(x: Double, y: Double): Vertex =
-    new Vertex(x, y)
-
   def apply(d: Double): Vertex =
     Vertex(d, d)
-
-  def unapply(vertex: Vertex): Option[(Double, Double)] =
-    Some((vertex.x, vertex.y))
 
   def fromPoint(point: Point): Vertex =
     Vertex(point.x.toDouble, point.y.toDouble)
@@ -93,16 +85,16 @@ object Vertex {
   val zero: Vertex = Vertex(0d, 0d)
   val one: Vertex  = Vertex(1d, 1d)
 
-  def add(v1: Vertex, v2: Vertex): Vertex =
+  @inline def add(v1: Vertex, v2: Vertex): Vertex =
     Vertex(v1.x + v2.x, v1.y + v2.y)
 
-  def subtract(v1: Vertex, v2: Vertex): Vertex =
+  @inline def subtract(v1: Vertex, v2: Vertex): Vertex =
     Vertex(v1.x - v2.x, v1.y - v2.y)
 
-  def multiply(v1: Vertex, v2: Vertex): Vertex =
+  @inline def multiply(v1: Vertex, v2: Vertex): Vertex =
     Vertex(v1.x * v2.x, v1.y * v2.y)
 
-  def divide(v1: Vertex, v2: Vertex): Vertex =
+  @inline def divide(v1: Vertex, v2: Vertex): Vertex =
     Vertex(v1.x / v2.x, v1.y / v2.y)
 
   def twoVerticesToVector2(start: Vertex, end: Vertex): Vector2 =

--- a/indigo/indigo-extras/src/main/scala/indigoextras/subsystems/FPSCounter.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/subsystems/FPSCounter.scala
@@ -46,7 +46,7 @@ object FPSCounter {
     (_, model) => {
       SceneUpdateFragment.empty
         .addUiLayerNodes(
-          Text(s"""FPS: ${model.fps.toString}""", position.x, position.y, 1, fontKey)
+          Text(s"""FPS ${model.fps.toString}""", position.x, position.y, 1, fontKey)
             .withTint(pickTint(targetFPS, model.fps))
         )
     }

--- a/indigo/indigo/src/main/scala/indigo/scenes/Scene.scala
+++ b/indigo/indigo/src/main/scala/indigo/scenes/Scene.scala
@@ -41,11 +41,8 @@ object Scene {
 
 }
 
-final class SceneName(val name: String) extends AnyVal
+final case class SceneName(name: String) extends AnyVal
 object SceneName {
-
-  def apply(name: String): SceneName =
-    new SceneName(name)
 
   implicit val EqSceneName: EqualTo[SceneName] = {
     val eq = implicitly[EqualTo[String]]

--- a/indigo/indigo/src/main/scala/indigo/scenes/SceneFinder.scala
+++ b/indigo/indigo/src/main/scala/indigo/scenes/SceneFinder.scala
@@ -7,7 +7,7 @@ import indigo.shared.EqualTo._
 
 import scala.annotation.tailrec
 
-final class SceneFinder(val previous: List[ScenePosition], val current: ScenePosition, val next: List[ScenePosition]) {
+final case class SceneFinder(previous: List[ScenePosition], current: ScenePosition, next: List[ScenePosition]) {
 
   val sceneCount: Int =
     toList.length
@@ -90,9 +90,6 @@ object SceneFinder {
       eqL.equal(a.next, b.next)
     }
   }
-
-  def apply(previous: List[ScenePosition], current: ScenePosition, next: List[ScenePosition]): SceneFinder =
-    new SceneFinder(previous, current, next)
 
   def fromScenes[StartUpData, GameModel, ViewModel](scenesList: NonEmptyList[Scene[StartUpData, GameModel, ViewModel]]): SceneFinder = {
     val a = scenesList.map(_.name).zipWithIndex.map(p => ScenePosition(p._2, p._1))

--- a/indigo/indigo/src/test/scala/indigo/scenes/TestScenes.scala
+++ b/indigo/indigo/src/test/scala/indigo/scenes/TestScenes.scala
@@ -132,7 +132,7 @@ final case class TestSceneB() extends Scene[Unit, TestGameModel, TestViewModel] 
 final case class TestSceneModelB(count: Int)
 final case class TestSceneViewModelB()
 
-final case object TestSceneEvent1 extends GlobalEvent
-final case object TestSceneEvent2 extends GlobalEvent
-final case object TestSceneEvent3 extends GlobalEvent
-final case object TestSceneEvent4 extends GlobalEvent
+case object TestSceneEvent1 extends GlobalEvent
+case object TestSceneEvent2 extends GlobalEvent
+case object TestSceneEvent3 extends GlobalEvent
+case object TestSceneEvent4 extends GlobalEvent

--- a/indigo/perf/src/main/scala/com/example/perf/PerfView.scala
+++ b/indigo/perf/src/main/scala/com/example/perf/PerfView.scala
@@ -9,6 +9,7 @@ object PerfView {
 
   val cloneId: CloneId = CloneId("Dude")
 
+  @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   def updateView(model: DudeModel, inputState: InputState): SceneUpdateFragment = {
     inputState.mouse.mouseClickAt match {
       case Some(position) => println("Mouse clicked at: " + position.toString())

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/SandboxModel.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/SandboxModel.scala
@@ -126,9 +126,9 @@ case object DudeDown  extends DudeDirection { val cycleName: CycleLabel = CycleL
 // States of a state machine - could use Phantom types to force order but...
 sealed trait SaveLoadPhase
 object SaveLoadPhases {
-  final case object NotStarted   extends SaveLoadPhase
-  final case object InitialClear extends SaveLoadPhase
-  final case object SaveIt       extends SaveLoadPhase
-  final case object LoadIt       extends SaveLoadPhase
-  final case object Complete     extends SaveLoadPhase
+  case object NotStarted   extends SaveLoadPhase
+  case object InitialClear extends SaveLoadPhase
+  case object SaveIt       extends SaveLoadPhase
+  case object LoadIt       extends SaveLoadPhase
+  case object Complete     extends SaveLoadPhase
 }

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/SandboxModel.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/SandboxModel.scala
@@ -12,6 +12,7 @@ object SandboxModel {
       None
     )
 
+  @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   def updateModel(state: SandboxGameModel): GlobalEvent => Outcome[SandboxGameModel] = {
     case rd @ RendererDetails(_, _, _) =>
       println(rd)

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/SandboxView.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/SandboxView.scala
@@ -6,6 +6,7 @@ object SandboxView {
 
   val dudeCloneId: CloneId = CloneId("Dude")
 
+  @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   def updateView(model: SandboxGameModel, viewModel: SandboxViewModel, inputState: InputState): SceneUpdateFragment = {
     inputState.mouse.mouseClickAt match {
       case Some(position) => println("Mouse clicked at: " + position.toString())

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/SandboxView.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/SandboxView.scala
@@ -75,7 +75,7 @@ object SandboxView {
   val fontKey: FontKey = FontKey("Sandbox font")
 
   val fontInfo: FontInfo =
-    FontInfo(fontKey, SandboxAssets.smallFontNameMaterial, 320, 230, FontChar("a", 3, 78, 23, 23)).isCaseInSensitive
+    FontInfo(fontKey, SandboxAssets.smallFontNameMaterial, 320, 230, FontChar(" ", 145, 52, 23, 23)).isCaseInSensitive
       .addChar(FontChar("A", 3, 78, 23, 23))
       .addChar(FontChar("B", 26, 78, 23, 23))
       .addChar(FontChar("C", 50, 78, 23, 23))

--- a/indigo/shared/src/main/scala/indigo/shared/BoundaryLocator.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/BoundaryLocator.scala
@@ -75,6 +75,7 @@ final class BoundaryLocator(animationsRegister: AnimationsRegister, fontRegister
         Rectangle(0, 0, acc.width + curr.width, Math.max(acc.height, curr.height))
       }
 
+  @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   def textAsLinesWithBounds(text: String, fontKey: FontKey): List[TextLine] =
     QuickCache(s"""text-lines-${fontKey.key}-${text}""") {
       fontRegister

--- a/indigo/shared/src/main/scala/indigo/shared/BoundaryLocator.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/BoundaryLocator.scala
@@ -52,6 +52,7 @@ final class BoundaryLocator(animationsRegister: AnimationsRegister, fontRegister
   def graphicBounds(graphic: Graphic): Rectangle =
     graphic.lazyBounds
 
+  @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   def spriteBounds(sprite: Sprite): Rectangle =
     QuickCache(s"""sprite-${sprite.bindingKey.value}-${sprite.animationKey.value}""") {
       animationsRegister.fetchAnimationInLastState(sprite.bindingKey, sprite.animationKey) match {

--- a/indigo/shared/src/main/scala/indigo/shared/animation/Animation.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/animation/Animation.scala
@@ -18,9 +18,7 @@ final case class Animation(
 
   def withAnimationKey(animationKey: AnimationKey): Animation =
     this.copy(animationKey = animationKey)
-
-  override def toString(): String =
-    s"Animation(${animationKey.toString()}, ${material.toString()}, ${currentCycleLabel.toString()}, ${cycles.toString()})"
+  
 }
 
 object Animation {

--- a/indigo/shared/src/main/scala/indigo/shared/animation/AnimationKey.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/animation/AnimationKey.scala
@@ -4,10 +4,7 @@ import indigo.shared.EqualTo
 import indigo.shared.EqualTo._
 import indigo.shared.dice.Dice
 
-final class AnimationKey(val value: String) extends AnyVal {
-  override def toString(): String =
-    s"AnimationKey($value)"
-}
+final case class AnimationKey(value: String) extends AnyVal
 
 object AnimationKey {
 
@@ -15,9 +12,6 @@ object AnimationKey {
     EqualTo.create { (a, b) =>
       a.value === b.value
     }
-
-  def apply(key: String): AnimationKey =
-    new AnimationKey(key)
 
   def fromDice(dice: Dice): AnimationKey =
     AnimationKey(dice.rollAlphaNumeric)

--- a/indigo/shared/src/main/scala/indigo/shared/animation/AnimationRef.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/animation/AnimationRef.scala
@@ -153,10 +153,7 @@ object CycleRef {
     }
 }
 
-final class AnimationMemento(val bindingKey: BindingKey, val currentCycleLabel: CycleLabel, val currentCycleMemento: CycleMemento) {
-
-  override def toString: String =
-    s"""AnimationMemento(bindingKey = ${bindingKey.toString()}, cycleLabel = ${currentCycleLabel.toString()}, cycleMemento = ${currentCycleMemento.toString()})"""
+final case class AnimationMemento(bindingKey: BindingKey, currentCycleLabel: CycleLabel, currentCycleMemento: CycleMemento) {
 
   def ===(other: AnimationMemento): Boolean =
     implicitly[EqualTo[AnimationMemento]].equal(this, other)

--- a/indigo/shared/src/main/scala/indigo/shared/animation/Cycle.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/animation/Cycle.scala
@@ -5,13 +5,10 @@ import indigo.shared.EqualTo
 import indigo.shared.EqualTo._
 import indigo.shared.time.Millis
 
-final class Cycle(val label: CycleLabel, val frames: NonEmptyList[Frame], val playheadPosition: Int, val lastFrameAdvance: Millis) {
+final case class Cycle(label: CycleLabel, frames: NonEmptyList[Frame], playheadPosition: Int, lastFrameAdvance: Millis) {
 
   def addFrame(newFrame: Frame): Cycle =
-    Cycle(label, frames :+ newFrame, playheadPosition, lastFrameAdvance)
-
-  override def toString(): String =
-    s"Cycle(${label.toString()}, ${frames.toString()}, ${playheadPosition.toString()}, ${lastFrameAdvance.toString()})"
+    this.copy(frames = frames :+ newFrame)
 
 }
 
@@ -33,25 +30,17 @@ object Cycle {
 
 }
 
-final class CycleLabel(val value: String) extends AnyVal {
-  override def toString(): String =
-    s"CycleLabel($value)"
-}
+final case class CycleLabel(value: String) extends AnyVal
+
 object CycleLabel {
 
   implicit val cycleLabelEqualTo: EqualTo[CycleLabel] =
     EqualTo.create { (a, b) =>
       a.value === b.value
     }
-
-  def apply(value: String): CycleLabel =
-    new CycleLabel(value)
 }
 
-final class CycleMemento(val playheadPosition: Int, val lastFrameAdvance: Millis) {
-
-  override def toString: String =
-    s"CycleMemento(${playheadPosition.toString()}, ${lastFrameAdvance.toString()})"
+final case class CycleMemento(playheadPosition: Int, lastFrameAdvance: Millis) {
 
   def ===(other: CycleMemento): Boolean =
     implicitly[EqualTo[CycleMemento]].equal(this, other)
@@ -70,6 +59,4 @@ object CycleMemento {
       a.playheadPosition === b.playheadPosition && a.lastFrameAdvance === b.lastFrameAdvance
     }
 
-  def apply(playheadPosition: Int, lastFrameAdvance: Millis): CycleMemento =
-    new CycleMemento(playheadPosition, lastFrameAdvance)
 }

--- a/indigo/shared/src/main/scala/indigo/shared/animation/Frame.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/animation/Frame.scala
@@ -6,12 +6,7 @@ import indigo.shared.EqualTo
 import indigo.shared.time.Millis
 import indigo.shared.datatypes.Material
 
-final class Frame(val crop: Rectangle, val duration: Millis, val frameMaterial: Option[Material]) {
-
-  @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-  override def toString(): String =
-    s"Frame(${crop.toString()}, ${duration.toString()}, ${frameMaterial.toString()})"
-}
+final case class Frame(crop: Rectangle, duration: Millis, frameMaterial: Option[Material])
 
 object Frame {
 
@@ -21,10 +16,7 @@ object Frame {
     }
 
   def apply(crop: Rectangle, duration: Millis): Frame =
-    new Frame(crop, duration, None)
-
-  def apply(crop: Rectangle, duration: Millis, frameMaterial: Material): Frame =
-    new Frame(crop, duration, Some(frameMaterial))
+    Frame(crop, duration, None)
 
   def fromBounds(x: Int, y: Int, width: Int, height: Int): Frame =
     Frame(Rectangle(Point(x, y), Point(width, height)), Millis(1))

--- a/indigo/shared/src/main/scala/indigo/shared/assets/AssetName.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/assets/AssetName.scala
@@ -2,9 +2,8 @@ package indigo.shared.assets
 
 import indigo.shared.EqualTo
 
-final class AssetName(val value: String) extends AnyVal {
-  override def toString(): String = s"AssetName($value)"
-}
+final case class AssetName(value: String) extends AnyVal
+
 object AssetName {
 
   implicit val equalTo: EqualTo[AssetName] = {
@@ -14,9 +13,4 @@ object AssetName {
     }
   }
 
-  def apply(value: String): AssetName =
-    new AssetName(value)
-
-  def unapply(a: AssetName): Option[String] =
-    Some(a.value)
 }

--- a/indigo/shared/src/main/scala/indigo/shared/assets/AssetPath.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/assets/AssetPath.scala
@@ -2,9 +2,8 @@ package indigo.shared.assets
 
 import indigo.shared.EqualTo
 
-final class AssetPath(val value: String) extends AnyVal {
-  override def toString(): String = s"AssetPath($value)"
-}
+final case class AssetPath(value: String) extends AnyVal
+
 object AssetPath {
 
   implicit val equalTo: EqualTo[AssetPath] = {
@@ -14,6 +13,4 @@ object AssetPath {
     }
   }
 
-  def apply(value: String): AssetPath =
-    new AssetPath(value)
 }

--- a/indigo/shared/src/main/scala/indigo/shared/assets/AssetTag.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/assets/AssetTag.scala
@@ -2,9 +2,8 @@ package indigo.shared.assets
 
 import indigo.shared.EqualTo
 
-final class AssetTag(val value: String) extends AnyVal {
-  override def toString(): String = s"AssetTag($value)"
-}
+final case class AssetTag(value: String) extends AnyVal
+
 object AssetTag {
 
   implicit val equalTo: EqualTo[AssetTag] = {
@@ -14,9 +13,4 @@ object AssetTag {
     }
   }
 
-  def apply(value: String): AssetTag =
-    new AssetTag(value)
-
-  def unapply(a: AssetTag): Option[String] =
-    Some(a.value)
 }

--- a/indigo/shared/src/main/scala/indigo/shared/assets/AssetType.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/assets/AssetType.scala
@@ -44,40 +44,26 @@ object AssetType {
       Some(tagged.toList)
   }
 
-  final class Text(val name: AssetName, val path: AssetPath) extends AssetTypePrimitive {
+  final case class Text(name: AssetName, path: AssetPath) extends AssetTypePrimitive {
     def toList: List[AssetType] = List(this)
-
-    override def toString: String =
-      s"AssetType.Text(${name.toString()}, ${path.toString})"
-  }
-  object Text {
-    def apply(name: AssetName, path: AssetPath): Text = new Text(name, path)
   }
 
-  final class Image(val name: AssetName, val path: AssetPath, val tag: Option[AssetTag]) extends AssetTypePrimitive {
+  final case class Image(name: AssetName, path: AssetPath, tag: Option[AssetTag]) extends AssetTypePrimitive {
     def withTag(tag: AssetTag): Image =
-      new Image(name, path, Option(tag))
+      this.copy(tag = Option(tag))
 
     def noTag: Image =
-      new Image(name, path, None)
+      this.copy(tag = None)
 
-    def toList: List[AssetType] = List(this)
-
-    override def toString: String =
-      s"AssetType.Image(${name.toString()}, ${path.toString})"
+    def toList: List[AssetType] =
+      List(this)
   }
   object Image {
-    def apply(name: AssetName, path: AssetPath): Image = new Image(name, path, None)
+    def apply(name: AssetName, path: AssetPath): Image = Image(name, path, None)
   }
 
-  final class Audio(val name: AssetName, val path: AssetPath) extends AssetTypePrimitive {
+  final case class Audio(name: AssetName, path: AssetPath) extends AssetTypePrimitive {
     def toList: List[AssetType] = List(this)
-
-    override def toString: String =
-      s"AssetType.Audio(${name.toString()}, ${path.toString})"
-  }
-  object Audio {
-    def apply(name: AssetName, path: AssetPath): Audio = new Audio(name, path)
   }
 
 }

--- a/indigo/shared/src/main/scala/indigo/shared/audio/Volume.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/audio/Volume.scala
@@ -2,7 +2,10 @@ package indigo.shared.audio
 
 final class Volume(val amount: Double) extends AnyVal {
   def *(other: Volume): Volume =
-    Volume.product(this, other)
+    Volume(this.amount * other.amount)
+
+  override def toString(): String =
+    s"Volume(${amount.toString})"
 }
 object Volume {
   val Min: Volume = Volume(0)
@@ -10,7 +13,4 @@ object Volume {
 
   def apply(volume: Double): Volume =
     new Volume(if (volume < 0) 0 else if (volume > 1) 1 else volume)
-
-  def product(a: Volume, b: Volume): Volume =
-    Volume(a.amount * b.amount)
 }

--- a/indigo/shared/src/main/scala/indigo/shared/datatypes/BindingKey.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/datatypes/BindingKey.scala
@@ -3,19 +3,15 @@ package indigo.shared.datatypes
 import indigo.shared.EqualTo
 import indigo.shared.dice.Dice
 
-final class BindingKey(val value: String) extends AnyVal {
-  override def toString: String =
-    s"""BindingKey(${value.toString()})"""
+final case class BindingKey(value: String) extends AnyVal {
 
   @SuppressWarnings(Array("org.wartremover.warts.Equals"))
   def ===(other: BindingKey): Boolean =
     implicitly[EqualTo[BindingKey]].equal(this, other)
+    
 }
 
 object BindingKey {
-
-  def apply(value: String): BindingKey =
-    new BindingKey(value)
 
   def fromDice(dice: Dice): BindingKey =
     BindingKey(dice.rollAlphaNumeric)

--- a/indigo/shared/src/main/scala/indigo/shared/datatypes/Depth.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/datatypes/Depth.scala
@@ -1,17 +1,11 @@
 package indigo.shared.datatypes
 
-final class Depth(val zIndex: Int) extends AnyVal {
+final case class Depth(zIndex: Int) extends AnyVal {
   def +(other: Depth): Depth =
-    Depth.append(this, other)
+    Depth(this.zIndex + other.zIndex)
 }
 object Depth {
   val Zero: Depth = Depth(0)
   val Base: Depth = Depth(1)
   val one: Depth = Base
-
-  def apply(zIndex: Int): Depth =
-    new Depth(zIndex)
-
-  def append(a: Depth, b: Depth): Depth =
-    Depth(a.zIndex + b.zIndex)
 }

--- a/indigo/shared/src/main/scala/indigo/shared/datatypes/Effects.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/datatypes/Effects.scala
@@ -26,6 +26,12 @@ final case class Effects(
   def withFlip(newFlip: Flip): Effects =
     this.copy(flip = newFlip)
 
+  def withHorizontalFlip(isFlipped: Boolean): Effects =
+    this.copy(flip = flip.withHorizontalFlip(isFlipped))
+
+  def withVerticalFlip(isFlipped: Boolean): Effects =
+    this.copy(flip = flip.withVerticalFlip(isFlipped))
+
   def hash: String =
     tint.hash +
       overlay.hash +

--- a/indigo/shared/src/main/scala/indigo/shared/datatypes/Effects.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/datatypes/Effects.scala
@@ -1,30 +1,30 @@
 package indigo.shared.datatypes
 
-final class Effects(
-    val tint: RGBA,
-    val overlay: Overlay,
-    val border: Border,
-    val glow: Glow,
-    val alpha: Double,
-    val flip: Flip
+final case class Effects(
+    tint: RGBA,
+    overlay: Overlay,
+    border: Border,
+    glow: Glow,
+    alpha: Double,
+    flip: Flip
 ) {
-  def withTint(newValue: RGBA): Effects =
-    Effects(newValue, overlay, border, glow, alpha, flip)
+  def withTint(newTint: RGBA): Effects =
+    this.copy(tint = newTint)
 
   def withOverlay(newOverlay: Overlay): Effects =
-    Effects(tint, newOverlay, border, glow, alpha, flip)
+    this.copy(overlay = newOverlay)
 
-  def withBorder(newValue: Border): Effects =
-    Effects(tint, overlay, newValue, glow, alpha, flip)
+  def withBorder(newBorder: Border): Effects =
+    this.copy(border = newBorder)
 
-  def withGlow(newValue: Glow): Effects =
-    Effects(tint, overlay, border, newValue, alpha, flip)
+  def withGlow(newGlow: Glow): Effects =
+    this.copy(glow = newGlow)
 
-  def withAlpha(newValue: Double): Effects =
-    Effects(tint, overlay, border, glow, newValue, flip)
+  def withAlpha(newAlpha: Double): Effects =
+    this.copy(alpha = newAlpha)
 
-  def withFlip(newValue: Flip): Effects =
-    Effects(tint, overlay, border, glow, alpha, newValue)
+  def withFlip(newFlip: Flip): Effects =
+    this.copy(flip = newFlip)
 
   def hash: String =
     tint.hash +
@@ -47,22 +47,6 @@ object Effects {
     )
   )
 
-  def apply(
-      tint: RGBA,
-      overlay: Overlay,
-      border: Border,
-      glow: Glow,
-      alpha: Double,
-      flip: Flip
-  ): Effects =
-    new Effects(
-      tint,
-      overlay,
-      border,
-      glow,
-      alpha,
-      flip
-    )
 }
 
 sealed trait Overlay {
@@ -70,26 +54,20 @@ sealed trait Overlay {
 }
 object Overlay {
 
-  final class Color(val color: RGBA) extends Overlay {
+  final case class Color(color: RGBA) extends Overlay {
     def hash: String =
       color.hash
   }
   object Color {
-    def apply(color: RGBA): Color =
-      new Color(color)
-
-    def unapply(c: Color): Option[RGBA] =
-      Some(c.color)
-
     val default: Color =
-      new Color(RGBA.Zero)
+      Color(RGBA.Zero)
   }
 
-  final class LinearGradiant(
-      val fromPoint: Point,
-      val fromColor: RGBA,
-      val toPoint: Point,
-      val toColor: RGBA
+  final case class LinearGradiant(
+      fromPoint: Point,
+      fromColor: RGBA,
+      toPoint: Point,
+      toColor: RGBA
   ) extends Overlay {
     lazy val hash: String =
       fromPoint.x.toString +
@@ -100,37 +78,31 @@ object Overlay {
         toColor.hash
   }
   object LinearGradiant {
-    def apply(fromPoint: Point, fromColor: RGBA, toPoint: Point, toColor: RGBA): LinearGradiant =
-      new LinearGradiant(fromPoint, fromColor, toPoint, toColor)
-
-    def unapply(lg: LinearGradiant): Option[(Point, RGBA, Point, RGBA)] =
-      Some((lg.fromPoint, lg.fromColor, lg.toPoint, lg.toColor))
-
     val default: LinearGradiant =
       LinearGradiant(Point.zero, RGBA.Zero, Point.zero, RGBA.Zero)
   }
 }
 
-final class Border(val color: RGBA, val innerThickness: Thickness, val outerThickness: Thickness) {
+final case class Border(color: RGBA, innerThickness: Thickness, outerThickness: Thickness) {
+
+  def withColor(newColor: RGBA): Border =
+    this.copy(color = newColor)
 
   def withInnerThickness(thickness: Thickness): Border =
-    new Border(color, thickness, outerThickness)
+    this.copy(innerThickness = thickness)
 
   def withOuterThickness(thickness: Thickness): Border =
-    new Border(color, innerThickness, thickness)
+    this.copy(outerThickness = thickness)
 
   def hash: String =
     color.hash + innerThickness.hash + outerThickness.hash
 }
 object Border {
-  def apply(color: RGBA, innerThickness: Thickness, outerThickness: Thickness): Border =
-    new Border(color, innerThickness, outerThickness)
-
   def inside(color: RGBA): Border =
-    new Border(color, Thickness.Thin, Thickness.None)
+    Border(color, Thickness.Thin, Thickness.None)
 
   def outside(color: RGBA): Border =
-    new Border(color, Thickness.None, Thickness.Thin)
+    Border(color, Thickness.None, Thickness.Thin)
 
   val default: Border =
     Border(RGBA.Zero, Thickness.None, Thickness.None)
@@ -150,28 +122,25 @@ object Thickness {
   case object Thick extends Thickness
 }
 
-final class Glow(val color: RGBA, val innerGlowAmount: Double, val outerGlowAmount: Double) {
+final case class Glow(color: RGBA, innerGlowAmount: Double, outerGlowAmount: Double) {
   def withColor(newColor: RGBA): Glow =
-    new Glow(newColor, innerGlowAmount, outerGlowAmount)
+    this.copy(color = newColor)
 
   def withInnerGlowAmount(amount: Double): Glow =
-    new Glow(color, Math.max(0, amount), outerGlowAmount)
+    this.copy(innerGlowAmount = Math.max(0, amount))
 
   def withOuterGlowAmount(amount: Double): Glow =
-    new Glow(color, innerGlowAmount, Math.max(0, amount))
+    this.copy(outerGlowAmount = Math.max(0, amount))
 
   def hash: String =
     color.hash + innerGlowAmount.toString + outerGlowAmount.toString()
 }
 object Glow {
-  def apply(color: RGBA, innerGlowAmount: Double, outerGlowAmount: Double): Glow =
-    new Glow(color, innerGlowAmount, outerGlowAmount)
-
   def inside(color: RGBA): Glow =
-    new Glow(color, 1d, 0d)
+    Glow(color, 1d, 0d)
 
   def outside(color: RGBA): Glow =
-    new Glow(color, 0d, 1d)
+    Glow(color, 0d, 1d)
 
   val default: Glow =
     Glow(RGBA.Zero, 0d, 0d)

--- a/indigo/shared/src/main/scala/indigo/shared/datatypes/Flip.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/datatypes/Flip.scala
@@ -1,18 +1,18 @@
 package indigo.shared.datatypes
 
-final class Flip(val horizontal: Boolean, val vertical: Boolean) {
+final case class Flip(horizontal: Boolean, vertical: Boolean) {
   
   def flipH: Flip =
-    new Flip(!horizontal, vertical)
+    this.copy(horizontal = !horizontal)
 
   def flipV: Flip =
-    new Flip(horizontal, !vertical)
+    this.copy(vertical = !vertical)
 
   def withFlipH(value: Boolean): Flip =
-    new Flip(value, vertical)
+    this.copy(horizontal = value)
 
   def withFlipV(value: Boolean): Flip =
-    new Flip(horizontal, value)
+    this.copy(vertical = value)
 
   def hash: String =
     (horizontal, vertical) match {
@@ -21,8 +21,4 @@ final class Flip(val horizontal: Boolean, val vertical: Boolean) {
       case (false, true)  => "01"
       case (true, true)   => "11"
     }
-}
-object Flip {
-  def apply(horizontal: Boolean, vertical: Boolean): Flip =
-    new Flip(horizontal, vertical)
 }

--- a/indigo/shared/src/main/scala/indigo/shared/datatypes/Flip.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/datatypes/Flip.scala
@@ -1,18 +1,18 @@
 package indigo.shared.datatypes
 
 final case class Flip(horizontal: Boolean, vertical: Boolean) {
-  
+
   def flipH: Flip =
     this.copy(horizontal = !horizontal)
 
   def flipV: Flip =
     this.copy(vertical = !vertical)
 
-  def withFlipH(value: Boolean): Flip =
-    this.copy(horizontal = value)
+  def withHorizontalFlip(isFlipped: Boolean): Flip =
+    this.copy(horizontal = isFlipped)
 
-  def withFlipV(value: Boolean): Flip =
-    this.copy(vertical = value)
+  def withVerticalFlip(isFlipped: Boolean): Flip =
+    this.copy(vertical = isFlipped)
 
   def hash: String =
     (horizontal, vertical) match {

--- a/indigo/shared/src/main/scala/indigo/shared/datatypes/Flip.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/datatypes/Flip.scala
@@ -2,10 +2,10 @@ package indigo.shared.datatypes
 
 final case class Flip(horizontal: Boolean, vertical: Boolean) {
 
-  def flipH: Flip =
+  def flipHorizontally: Flip =
     this.copy(horizontal = !horizontal)
 
-  def flipV: Flip =
+  def flipVertically: Flip =
     this.copy(vertical = !vertical)
 
   def withHorizontalFlip(isFlipped: Boolean): Flip =

--- a/indigo/shared/src/main/scala/indigo/shared/datatypes/Material.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/datatypes/Material.scala
@@ -10,16 +10,6 @@ sealed trait Material {
   def lit: Material
   def unlit: Material
   def hash: String
-
-  @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-  override def toString(): String =
-    this match {
-      case t: Material.Textured =>
-        s"""Textured(${t.diffuse.toString()}, ${t.isLit.toString()})"""
-
-      case l: Material.Lit =>
-        s"""Lit(${l.albedo.toString()}, ${l.emissive.toString()}, ${l.normal.toString()}, ${l.specular.toString()}, ${l.isLit.toString()})"""
-    }
 }
 
 object Material {
@@ -40,17 +30,17 @@ object Material {
         false
     }
 
-  final class Textured(val diffuse: AssetName, val isLit: Boolean) extends Material {
+  final case class Textured(diffuse: AssetName, isLit: Boolean) extends Material {
     val default: AssetName = diffuse
 
     def withDiffuse(newDiffuse: AssetName): Textured =
-      new Textured(newDiffuse, isLit)
+      this.copy(diffuse = newDiffuse)
 
     def lit: Textured =
-      new Textured(diffuse, true)
+      this.copy(isLit = true)
 
     def unlit: Textured =
-      new Textured(diffuse, false)
+      this.copy(isLit = false)
 
     lazy val hash: String =
       diffuse.value + (if (isLit) "1" else "0")
@@ -63,32 +53,32 @@ object Material {
       Some((t.diffuse, t.isLit))
   }
 
-  final class Lit(
-      val albedo: AssetName,
-      val emissive: Option[Texture],
-      val normal: Option[Texture],
-      val specular: Option[Texture],
-      val isLit: Boolean
+  final case class Lit(
+      albedo: AssetName,
+      emissive: Option[Texture],
+      normal: Option[Texture],
+      specular: Option[Texture],
+      isLit: Boolean
   ) extends Material {
     val default: AssetName = albedo
 
     def withAlbedo(newAlbedo: AssetName): Lit =
-      new Lit(newAlbedo, emissive, normal, specular, isLit)
+      this.copy(albedo = newAlbedo)
 
     def withEmission(emissiveAssetName: AssetName, amount: Double): Lit =
-      new Lit(albedo, Some(Texture(emissiveAssetName, amount)), normal, specular, isLit)
+      this.copy(emissive = Some(Texture(emissiveAssetName, amount)))
 
     def withNormal(normalAssetName: AssetName, amount: Double): Lit =
-      new Lit(albedo, emissive, Some(Texture(normalAssetName, amount)), specular, isLit)
+      this.copy(normal = Some(Texture(normalAssetName, amount)))
 
     def withSpecular(specularAssetName: AssetName, amount: Double): Lit =
-      new Lit(albedo, emissive, normal, Some(Texture(specularAssetName, amount)), isLit)
+      this.copy(specular = Some(Texture(specularAssetName, amount)))
 
     def lit: Lit =
-      new Lit(albedo, emissive, normal, specular, true)
+      this.copy(isLit = true)
 
     def unlit: Lit =
-      new Lit(albedo, emissive, normal, specular, false)
+      this.copy(isLit = false)
 
     lazy val hash: String =
       albedo.value +
@@ -150,21 +140,15 @@ object Material {
         true
       )
 
-    def unapply(l: Lit): Option[(AssetName, Option[Texture], Option[Texture], Option[Texture], Boolean)] =
-      Some((l.albedo, l.emissive, l.normal, l.specular, l.isLit))
-
     def fromAlbedo(albedo: AssetName): Lit =
       new Lit(albedo, None, None, None, true)
   }
 
 }
 
-final class Texture(val assetName: AssetName, val amount: Double) {
+final case class Texture(assetName: AssetName, amount: Double) {
   def hash: String =
     assetName.value + amount.toString()
-
-  override def toString(): String =
-    s"""Texture(${assetName.toString()}, ${amount.toString()})"""
 }
 object Texture {
 
@@ -175,9 +159,4 @@ object Texture {
           a.amount === b.amount
     }
 
-  def apply(assetName: AssetName, amount: Double): Texture =
-    new Texture(assetName, amount)
-
-  def unapply(t: Texture): Option[(AssetName, Double)] =
-    Some((t.assetName, t.amount))
 }

--- a/indigo/shared/src/main/scala/indigo/shared/datatypes/Matrix4.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/datatypes/Matrix4.scala
@@ -2,7 +2,7 @@ package indigo.shared.datatypes
 
 import indigo.shared.EqualTo
 
-final class Matrix4(val mat: List[Double]) {
+final case class Matrix4(mat: List[Double]) {
 
   def row1: List[Double] = List(mat(0), mat(1), mat(2), mat(3))
   def row2: List[Double] = List(mat(4), mat(5), mat(6), mat(7))
@@ -35,9 +35,6 @@ final class Matrix4(val mat: List[Double]) {
   def flip(horizontal: Boolean, vertical: Boolean): Matrix4 =
     this * Matrix4.flip(horizontal, vertical)
 
-  override def toString(): String =
-    s"Matrix4(${row1.toString()}, ${row2.toString()}, ${row3.toString()}, ${row4.toString()})"
-
 }
 
 object Matrix4 {
@@ -49,9 +46,6 @@ object Matrix4 {
       ev.equal(a.mat, b.mat)
     }
   }
-
-  def apply(mat: List[Double]): Matrix4 =
-    new Matrix4(mat)
 
   def identity: Matrix4 =
     Matrix4(

--- a/indigo/shared/src/main/scala/indigo/shared/datatypes/Point.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/datatypes/Point.scala
@@ -3,7 +3,7 @@ package indigo.shared.datatypes
 import indigo.shared.EqualTo
 import indigo.shared.EqualTo._
 
-final class Point(val x: Int, val y: Int) {
+final case class Point(x: Int, y: Int) {
   def +(pt: Point): Point = Point(x + pt.x, y + pt.y)
   def +(i: Int): Point    = Point(x + i, y + i)
   def -(pt: Point): Point = Point(x - pt.x, y - pt.y)
@@ -13,8 +13,8 @@ final class Point(val x: Int, val y: Int) {
   def /(pt: Point): Point = Point(x / pt.x, y / pt.y)
   def /(i: Int): Point    = Point(x / i, y / i)
 
-  def withX(newX: Int): Point = Point(newX, y)
-  def withY(newY: Int): Point = Point(x, newY)
+  def withX(newX: Int): Point = this.copy(x = newX)
+  def withY(newY: Int): Point = this.copy(y = newY)
 
   def invert: Point =
     Point(-x, -y)
@@ -24,9 +24,6 @@ final class Point(val x: Int, val y: Int) {
 
   def toVector: Vector2 =
     Vector2(x.toDouble, y.toDouble)
-
-  override def toString: String =
-    s"""Point(${x.toString()}, ${y.toString()})"""
 
   def ===(other: Point): Boolean =
     implicitly[EqualTo[Point]].equal(this, other)
@@ -41,12 +38,6 @@ final class Point(val x: Int, val y: Int) {
 }
 
 object Point {
-
-  def apply(x: Int, y: Int): Point =
-    new Point(x, y)
-
-  def unapply(pt: Point): Option[(Int, Int)] =
-    Option((pt.x, pt.y))
 
   val zero: Point = Point(0, 0)
 

--- a/indigo/shared/src/main/scala/indigo/shared/datatypes/RGB.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/datatypes/RGB.scala
@@ -2,29 +2,23 @@ package indigo.shared.datatypes
 
 import indigo.shared.EqualTo
 
-final class RGB(val r: Double, val g: Double, val b: Double) {
+final case class RGB(r: Double, g: Double, b: Double) {
   def +(other: RGB): RGB =
     RGB.combine(this, other)
 
   def withRed(newRed: Double): RGB =
-    RGB(newRed, g, b)
+    this.copy(r = newRed)
 
   def withGreen(newGreen: Double): RGB =
-    RGB(r, newGreen, b)
+    this.copy(g = newGreen)
 
   def withBlue(newBlue: Double): RGB =
-    RGB(r, g, newBlue)
+    this.copy(b = newBlue)
 
   def hash: String =
     r.toString() + g.toString() + b.toString()
-
-  override def toString: String =
-    s"RGB(${r.toString()}, ${g.toString()}, ${b.toString()})"
 }
 object RGB {
-
-  def apply(red: Double, green: Double, blue: Double): RGB =
-    new RGB(red, green, blue)
 
   implicit val eq: EqualTo[RGB] = {
     val ev = implicitly[EqualTo[Double]]
@@ -58,4 +52,3 @@ object RGB {
     }
 
 }
-

--- a/indigo/shared/src/main/scala/indigo/shared/datatypes/RGBA.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/datatypes/RGBA.scala
@@ -3,21 +3,21 @@ package indigo.shared.datatypes
 import indigo.shared.EqualTo
 import indigo.shared.ClearColor
 
-final class RGBA(val r: Double, val g: Double, val b: Double, val a: Double) {
+final case class RGBA(r: Double, g: Double, b: Double, a: Double) {
   def +(other: RGBA): RGBA =
     RGBA.combine(this, other)
 
   def withRed(newRed: Double): RGBA =
-    RGBA(newRed, g, b, a)
+    this.copy(r = newRed)
 
   def withGreen(newGreen: Double): RGBA =
-    RGBA(r, newGreen, b, a)
+    this.copy(g = newGreen)
 
   def withBlue(newBlue: Double): RGBA =
-    RGBA(r, g, newBlue, a)
+    this.copy(b = newBlue)
 
   def withAmount(amount: Double): RGBA =
-    RGBA(r, g, b, amount)
+    this.copy(a = amount)
 
   def toClearColor: ClearColor =
     ClearColor(r * a, g * a, b * a, 1)
@@ -27,14 +27,8 @@ final class RGBA(val r: Double, val g: Double, val b: Double, val a: Double) {
 
   def hash: String =
     r.toString() + g.toString() + b.toString() + a.toString()
-
-  override def toString: String =
-    s"RGBA(${r.toString()}, ${g.toString()}, ${b.toString()}, ${a.toString()})"
 }
 object RGBA {
-
-  def apply(red: Double, green: Double, blue: Double, amount: Double): RGBA =
-    new RGBA(red, green, blue, amount)
 
   implicit val eq: EqualTo[RGBA] = {
     val ev = implicitly[EqualTo[Double]]
@@ -68,4 +62,3 @@ object RGBA {
     }
 
 }
-

--- a/indigo/shared/src/main/scala/indigo/shared/datatypes/Radians.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/datatypes/Radians.scala
@@ -4,7 +4,7 @@ import indigo.shared.EqualTo
 import indigo.shared.EqualTo._
 import indigo.shared.time.Seconds
 
-final class Radians(val value: Double) extends AnyVal {
+final case class Radians(value: Double) extends AnyVal {
 
   def +(other: Radians): Radians =
     Radians.add(this, other)
@@ -20,9 +20,6 @@ final class Radians(val value: Double) extends AnyVal {
 
   def hash: String =
     value.toString()
-
-  override def toString: String =
-    s"""Radians(${value.toString()})"""
 
   def ===(other: Radians): Boolean =
     implicitly[EqualTo[Radians]].equal(this, other)
@@ -47,19 +44,16 @@ object Radians {
   def zero: Radians =
     Radians(0)
 
-  def apply(value: Double): Radians =
-    new Radians(value)
-
-  def add(a: Radians, b: Radians): Radians =
+  @inline def add(a: Radians, b: Radians): Radians =
     Radians(a.value + b.value)
 
-  def subtract(a: Radians, b: Radians): Radians =
+  @inline def subtract(a: Radians, b: Radians): Radians =
     Radians(a.value - b.value)
 
-  def multiply(a: Radians, b: Radians): Radians =
+  @inline def multiply(a: Radians, b: Radians): Radians =
     Radians(a.value * b.value)
 
-  def divide(a: Radians, b: Radians): Radians =
+  @inline def divide(a: Radians, b: Radians): Radians =
     Radians(a.value / b.value)
 
   def fromDegrees(degrees: Double): Radians =

--- a/indigo/shared/src/main/scala/indigo/shared/datatypes/Rectangle.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/datatypes/Rectangle.scala
@@ -4,11 +4,11 @@ import indigo.shared.EqualTo
 
 import scala.annotation.tailrec
 
-final class Rectangle(val position: Point, val size: Point) {
-  val x: Int            = position.x
-  val y: Int            = position.y
-  val width: Int        = size.x
-  val height: Int       = size.y
+final case class Rectangle(position: Point, size: Point) {
+  lazy val x: Int       = position.x
+  lazy val y: Int       = position.y
+  lazy val width: Int   = size.x
+  lazy val height: Int  = size.y
   lazy val hash: String = s"${x.toString()}${y.toString()}${width.toString()}${height.toString()}"
 
   lazy val left: Int   = x
@@ -56,39 +56,25 @@ final class Rectangle(val position: Point, val size: Point) {
     Rectangle.overlapping(this, other)
 
   def moveBy(point: Point): Rectangle =
-    Rectangle(x + point.x, y + point.y, width, height)
+    this.copy(position = position + point)
 
   def moveTo(point: Point): Rectangle =
-    Rectangle(point, size)
+    this.copy(position = point)
 
-  def resize(point: Point): Rectangle =
-    Rectangle(position, point)
-
-  override def toString: String =
-    s"""Rectangle(Position(${x.toString()}, ${y.toString()}), Size(${width.toString()}, ${height.toString()}))"""
+  def resize(newSize: Point): Rectangle =
+    this.copy(size = newSize)
 
   def ===(other: Rectangle): Boolean =
     implicitly[EqualTo[Rectangle]].equal(this, other)
 
-  @SuppressWarnings(Array("org.wartremover.warts.IsInstanceOf", "org.wartremover.warts.AsInstanceOf"))
-  override def equals(obj: Any): Boolean =
-    if (obj.isInstanceOf[Rectangle])
-      this === obj.asInstanceOf[Rectangle]
-    else false
 }
 
 object Rectangle {
 
   val zero: Rectangle = Rectangle(0, 0, 0, 0)
 
-  def apply(position: Point, size: Point): Rectangle =
-    new Rectangle(position, size)
-
   def apply(x: Int, y: Int, width: Int, height: Int): Rectangle =
     Rectangle(Point(x, y), Point(width, height))
-
-  def unapply(rectangle: Rectangle): Option[(Point, Point)] =
-    Option((rectangle.position, rectangle.size))
 
   def fromTwoPoints(pt1: Point, pt2: Point): Rectangle = {
     val x = Math.min(pt1.x, pt2.x)

--- a/indigo/shared/src/main/scala/indigo/shared/datatypes/TextDataTypes.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/datatypes/TextDataTypes.scala
@@ -6,16 +6,16 @@ import indigo.shared.EqualTo._
 import indigo.shared.QuickCache
 import indigo.shared.datatypes.Material
 
-final class FontInfo(val fontKey: FontKey, val fontSpriteSheet: FontSpriteSheet, val unknownChar: FontChar, val fontChars: List[FontChar], val caseSensitive: Boolean) {
-  import FontInfo._
+final case class FontInfo(fontKey: FontKey, fontSpriteSheet: FontSpriteSheet, unknownChar: FontChar, fontChars: List[FontChar], caseSensitive: Boolean) {
+  import FontInfo.fontCharCache
 
   private val nonEmptyChars: List[FontChar] = unknownChar +: fontChars
 
   def addChar(fontChar: FontChar): FontInfo =
-    FontInfo(fontKey, fontSpriteSheet, fontChar, nonEmptyChars, caseSensitive)
+    this.copy(fontChars = nonEmptyChars :+ fontChar)
 
   def addChars(chars: List[FontChar]): FontInfo =
-    FontInfo(fontKey, fontSpriteSheet, unknownChar, fontChars ++ chars, caseSensitive)
+    this.copy(fontChars = fontChars ++ chars)
 
   def addChars(chars: FontChar*): FontInfo =
     addChars(chars.toList)
@@ -32,7 +32,7 @@ final class FontInfo(val fontKey: FontKey, val fontSpriteSheet: FontSpriteSheet,
     findByCharacter(character.toString)
 
   def makeCaseSensitive(sensitive: Boolean): FontInfo =
-    FontInfo(fontKey, fontSpriteSheet, unknownChar, fontChars, sensitive)
+    this.copy(caseSensitive = sensitive)
 
   def isCaseSensitive: FontInfo =
     makeCaseSensitive(true)
@@ -44,9 +44,6 @@ object FontInfo {
 
   implicit val fontCharCache: QuickCache[FontChar] = QuickCache.empty
 
-  def apply(fontKey: FontKey, fontSpriteSheet: FontSpriteSheet, unknownChar: FontChar, fontChars: List[FontChar], caseSensitive: Boolean): FontInfo =
-    new FontInfo(fontKey, fontSpriteSheet, unknownChar, fontChars, caseSensitive)
-
   def apply(fontKey: FontKey, material: Material, sheetWidth: Int, sheetHeight: Int, unknownChar: FontChar, chars: FontChar*): FontInfo =
     FontInfo(
       fontKey = fontKey,
@@ -57,10 +54,7 @@ object FontInfo {
     )
 }
 
-final class FontKey(val key: String) extends AnyVal {
-  override def toString(): String =
-    s"FontKey($key)"
-}
+final case class FontKey(key: String) extends AnyVal
 object FontKey {
 
   implicit val eq: EqualTo[FontKey] = {
@@ -70,18 +64,11 @@ object FontKey {
     }
   }
 
-  def apply(key: String): FontKey =
-    new FontKey(key)
-
 }
 
-final class FontSpriteSheet(val material: Material, val size: Point)
-object FontSpriteSheet {
-  def apply(material: Material, size: Point): FontSpriteSheet =
-    new FontSpriteSheet(material, size)
-}
+final case class FontSpriteSheet(material: Material, size: Point)
 
-final case class FontChar(val character: String, val bounds: Rectangle)
+final case class FontChar(character: String, bounds: Rectangle)
 object FontChar {
   def apply(character: String, x: Int, y: Int, width: Int, height: Int): FontChar =
     FontChar(character, Rectangle(x, y, width, height))

--- a/indigo/shared/src/main/scala/indigo/shared/datatypes/Vector2.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/datatypes/Vector2.scala
@@ -3,12 +3,13 @@ package indigo.shared.datatypes
 import indigo.shared.EqualTo
 import indigo.shared.EqualTo._
 
-final class Vector2(val x: Double, val y: Double) {
+final case class Vector2(x: Double, y: Double) {
 
   def withX(newX: Double): Vector2 =
-    Vector2(newX, y)
+    this.copy(x = newX)
+
   def withY(newY: Double): Vector2 =
-    Vector2(x, newY)
+    this.copy(y = newY)
 
   def invert: Vector2 =
     Vector2(-x, -y)
@@ -52,9 +53,6 @@ final class Vector2(val x: Double, val y: Double) {
 
   def applyMatrix4(matrix4: Matrix4): Vector2 = Vector2.applyMatrix4(this, matrix4)
 
-  override def toString: String =
-    s"Vector2(x = ${x.toString()}, y = ${y.toString()})"
-
   @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf", "org.wartremover.warts.IsInstanceOf"))
   override def equals(obj: Any): Boolean =
     if (obj.isInstanceOf[Vector2])
@@ -78,9 +76,6 @@ object Vector2 {
     }
   }
 
-  def apply(x: Double, y: Double): Vector2 =
-    new Vector2(x, y)
-
   def apply(i: Int): Vector2 =
     Vector2(i.toDouble, i.toDouble)
 
@@ -91,16 +86,16 @@ object Vector2 {
   def fromPoints(start: Point, end: Point): Vector2 =
     Vector2((end.x - start.x).toDouble, (end.y - start.y).toDouble)
 
-  def add(vec1: Vector2, vec2: Vector2): Vector2 =
+  @inline def add(vec1: Vector2, vec2: Vector2): Vector2 =
     Vector2(vec1.x + vec2.x, vec1.y + vec2.y)
 
-  def subtract(vec1: Vector2, vec2: Vector2): Vector2 =
+  @inline def subtract(vec1: Vector2, vec2: Vector2): Vector2 =
     Vector2(vec1.x - vec2.x, vec1.y - vec2.y)
 
-  def multiply(vec1: Vector2, vec2: Vector2): Vector2 =
+  @inline def multiply(vec1: Vector2, vec2: Vector2): Vector2 =
     Vector2(vec1.x * vec2.x, vec1.y * vec2.y)
 
-  def divide(vec1: Vector2, vec2: Vector2): Vector2 =
+  @inline def divide(vec1: Vector2, vec2: Vector2): Vector2 =
     Vector2(vec1.x / vec2.x, vec1.y / vec2.y)
 
   def dotProduct(vec1: Vector2, vec2: Vector2): Double =

--- a/indigo/shared/src/main/scala/indigo/shared/datatypes/Vector3.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/datatypes/Vector3.scala
@@ -3,7 +3,16 @@ package indigo.shared.datatypes
 import indigo.shared.EqualTo
 import indigo.shared.EqualTo._
 
-final class Vector3(val x: Double, val y: Double, val z: Double) {
+final case class Vector3(x: Double, y: Double, z: Double) {
+
+  def withX(newX: Double): Vector3 =
+    this.copy(x = newX)
+
+  def withY(newY: Double): Vector3 =
+    this.copy(y = newY)
+
+  def withZ(newZ: Double): Vector3 =
+    this.copy(z = newZ)
 
   def translate(vec: Vector3): Vector3 =
     Vector3.add(this, vec)
@@ -42,9 +51,6 @@ final class Vector3(val x: Double, val y: Double, val z: Double) {
   def toVector2: Vector2 =
     Vector2(x, y)
 
-  override def toString: String =
-    s"Vector3(x = ${x.toString()}, y = ${y.toString()}, z = ${z.toString()})"
-
   def ===(other: Vector3): Boolean =
     implicitly[EqualTo[Vector3]].equal(this, other)
 }
@@ -59,25 +65,22 @@ object Vector3 {
     }
   }
 
-  def apply(x: Double, y: Double, z: Double): Vector3 =
-    new Vector3(x, y, z)
-
   def apply(i: Int): Vector3 =
     Vector3(i.toDouble, i.toDouble, i.toDouble)
 
   val zero: Vector3 = Vector3(0d, 0d, 0d)
   val one: Vector3  = Vector3(1d, 1d, 1d)
 
-  def add(vec1: Vector3, vec2: Vector3): Vector3 =
+  @inline def add(vec1: Vector3, vec2: Vector3): Vector3 =
     Vector3(vec1.x + vec2.x, vec1.y + vec2.y, vec1.z + vec2.z)
 
-  def subtract(vec1: Vector3, vec2: Vector3): Vector3 =
+  @inline def subtract(vec1: Vector3, vec2: Vector3): Vector3 =
     Vector3(vec1.x - vec2.x, vec1.y - vec2.y, vec1.z - vec2.z)
 
-  def multiply(vec1: Vector3, vec2: Vector3): Vector3 =
+  @inline def multiply(vec1: Vector3, vec2: Vector3): Vector3 =
     Vector3(vec1.x * vec2.x, vec1.y * vec2.y, vec1.z * vec2.z)
 
-  def divide(vec1: Vector3, vec2: Vector3): Vector3 =
+  @inline def divide(vec1: Vector3, vec2: Vector3): Vector3 =
     Vector3(vec1.x / vec2.x, vec1.y / vec2.y, vec1.z / vec2.z)
 
   def dotProduct(vec1: Vector3, vec2: Vector3): Double =

--- a/indigo/shared/src/main/scala/indigo/shared/datatypes/Vector4.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/datatypes/Vector4.scala
@@ -3,7 +3,19 @@ package indigo.shared.datatypes
 import indigo.shared.EqualTo
 import indigo.shared.EqualTo._
 
-final class Vector4(val x: Double, val y: Double, val z: Double, val w: Double) {
+final case class Vector4(x: Double, y: Double, z: Double, w: Double) {
+
+  def withX(newX: Double): Vector4 =
+    this.copy(x = newX)
+
+  def withY(newY: Double): Vector4 =
+    this.copy(y = newY)
+
+  def withZ(newZ: Double): Vector4 =
+    this.copy(z = newZ)
+
+  def withW(newW: Double): Vector4 =
+    this.copy(w = newW)
 
   def translate(vec: Vector4): Vector4 =
     Vector4.add(this, vec)
@@ -63,25 +75,22 @@ object Vector4 {
     }
   }
 
-  def apply(x: Double, y: Double, z: Double, w: Double): Vector4 =
-    new Vector4(x, y, z, w)
-
   def apply(i: Int): Vector4 =
     Vector4(i.toDouble, i.toDouble, i.toDouble, i.toDouble)
 
   val zero: Vector4 = Vector4(0d, 0d, 0d, 0d)
   val one: Vector4  = Vector4(1d, 1d, 1d, 1d)
 
-  def add(vec1: Vector4, vec2: Vector4): Vector4 =
+  @inline def add(vec1: Vector4, vec2: Vector4): Vector4 =
     Vector4(vec1.x + vec2.x, vec1.y + vec2.y, vec1.z + vec2.z, vec1.w + vec2.w)
 
-  def subtract(vec1: Vector4, vec2: Vector4): Vector4 =
+  @inline def subtract(vec1: Vector4, vec2: Vector4): Vector4 =
     Vector4(vec1.x - vec2.x, vec1.y - vec2.y, vec1.z - vec2.z, vec1.w - vec2.w)
 
-  def multiply(vec1: Vector4, vec2: Vector4): Vector4 =
+  @inline def multiply(vec1: Vector4, vec2: Vector4): Vector4 =
     Vector4(vec1.x * vec2.x, vec1.y * vec2.y, vec1.z * vec2.z, vec1.w * vec2.w)
 
-  def divide(vec1: Vector4, vec2: Vector4): Vector4 =
+  @inline def divide(vec1: Vector4, vec2: Vector4): Vector4 =
     Vector4(vec1.x / vec2.x, vec1.y / vec2.y, vec1.z / vec2.z, vec1.w / vec2.w)
 
   def position(x: Double, y: Double, z: Double): Vector4 =

--- a/indigo/shared/src/main/scala/indigo/shared/display/SpriteSheetFrame.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/display/SpriteSheetFrame.scala
@@ -20,12 +20,9 @@ object SpriteSheetFrame {
   val defaultOffset: SpriteSheetFrameCoordinateOffsets =
     calculateFrameOffset(Vector2(1.0, 1.0), Rectangle(0, 0, 1, 1), Vector2.zero)
 
-  final class SpriteSheetFrameCoordinateOffsets(val scale: Vector2, val translate: Vector2, translateCoords: Vector2 => Vector2) {
+  final case class SpriteSheetFrameCoordinateOffsets(scale: Vector2, translate: Vector2, translateCoords: Vector2 => Vector2) {
     def offsetToCoords(textureOffset: Vector2): Vector2 =
       translateCoords(textureOffset)
-
-    override def toString(): String =
-      s"SpriteSheetFrameCoordinateOffsets(scale = ${scale.toString()}, translate = ${translate.toString()})"
   }
   object SpriteSheetFrameCoordinateOffsets {
 

--- a/indigo/shared/src/main/scala/indigo/shared/events/GlobalEvent.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/events/GlobalEvent.scala
@@ -175,7 +175,7 @@ object StorageEvent {
   /**
     * Clears all local data
     */
-  final case object DeleteAll extends StorageEvent
+  case object DeleteAll extends StorageEvent
 
   /**
     * Data load response,

--- a/indigo/shared/src/main/scala/indigo/shared/events/InputMapping.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/events/InputMapping.scala
@@ -123,22 +123,22 @@ object Combo {
 
 sealed trait GamepadInput
 object GamepadInput {
-  final object DPAD_UP    extends GamepadInput
-  final object DPAD_LEFT  extends GamepadInput
-  final object DPAD_RIGHT extends GamepadInput
-  final object DPAD_DOWN  extends GamepadInput
-  final object Cross      extends GamepadInput
-  final object Circle     extends GamepadInput
-  final object Square     extends GamepadInput
-  final object Triangle   extends GamepadInput
-  final object L1         extends GamepadInput
-  final object L2         extends GamepadInput
-  final object R1         extends GamepadInput
-  final object R2         extends GamepadInput
-  final object Options    extends GamepadInput
-  final object Share      extends GamepadInput
-  final object PS         extends GamepadInput
-  final object TouchPad   extends GamepadInput
+  object DPAD_UP    extends GamepadInput
+  object DPAD_LEFT  extends GamepadInput
+  object DPAD_RIGHT extends GamepadInput
+  object DPAD_DOWN  extends GamepadInput
+  object Cross      extends GamepadInput
+  object Circle     extends GamepadInput
+  object Square     extends GamepadInput
+  object Triangle   extends GamepadInput
+  object L1         extends GamepadInput
+  object L2         extends GamepadInput
+  object R1         extends GamepadInput
+  object R2         extends GamepadInput
+  object Options    extends GamepadInput
+  object Share      extends GamepadInput
+  object PS         extends GamepadInput
+  object TouchPad   extends GamepadInput
   final case class LEFT_ANALOG(
       x: Double => Boolean,
       y: Double => Boolean,

--- a/indigo/shared/src/main/scala/indigo/shared/platform/DisplayObjectConversions.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/platform/DisplayObjectConversions.scala
@@ -127,7 +127,7 @@ final class DisplayObjectConversions(
   @SuppressWarnings(Array("org.wartremover.warts.Var"))
   private val accDisplayObjects: ListBuffer[DisplayEntity] = new ListBuffer()
 
-  @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
+  @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements", "org.wartremover.warts.ToString"))
   def sceneNodesToDisplayObjects(
       sceneNodes: List[SceneGraphNode],
       gameTime: GameTime,

--- a/indigo/shared/src/main/scala/indigo/shared/platform/DisplayObjectConversions.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/platform/DisplayObjectConversions.scala
@@ -113,7 +113,7 @@ final class DisplayObjectConversions(
           )
         }
       )
-    batch.staticBatchId match {
+    batch.staticBatchKey match {
       case None =>
         convert()
 

--- a/indigo/shared/src/main/scala/indigo/shared/scenegraph/Light.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/scenegraph/Light.scala
@@ -4,8 +4,6 @@ import indigo.shared.datatypes.Point
 import indigo.shared.datatypes.Radians
 import indigo.shared.datatypes.RGB
 import indigo.shared.datatypes.Vector2
-import indigo.shared.EqualTo._
-import indigo.shared.EqualTo
 
 sealed trait Light {
   val height: Int
@@ -13,67 +11,48 @@ sealed trait Light {
   val power: Double
 }
 
-final class PointLight(
-    val position: Point,
-    val height: Int,
-    val color: RGB,
-    val power: Double,
-    val attenuation: Int
+final case class PointLight(
+    position: Point,
+    height: Int,
+    color: RGB,
+    power: Double,
+    attenuation: Int
 ) extends Light {
   def moveTo(newPosition: Point): PointLight =
-    new PointLight(newPosition, height, color, power, attenuation)
+    this.copy(position = newPosition)
 
   def moveBy(amount: Point): PointLight =
-    new PointLight(position + amount, height, color, power, attenuation)
+    this.copy(position = position + amount)
 
   def withHeight(newHeight: Int): PointLight =
-    new PointLight(position, newHeight, color, power, attenuation)
+    this.copy(height = newHeight)
 
   def withColor(newColor: RGB): PointLight =
-    new PointLight(position, height, newColor, power, attenuation)
+    this.copy(color = newColor)
 
   def withPower(newPower: Double): PointLight =
-    new PointLight(position, height, color, newPower, attenuation)
+    this.copy(power = newPower)
 
   def withAttenuation(distance: Int): PointLight =
-    new PointLight(position, height, color, power, distance)
-
-  override def toString: String =
-    s"PointLight(${position.toString()}, ${height.toString()}, ${color.toString()}, ${power.toString()}, ${attenuation.toString()})"
-
-  @SuppressWarnings(Array("org.wartremover.warts.IsInstanceOf", "org.wartremover.warts.AsInstanceOf"))
-  override def equals(obj: Any): Boolean =
-    if (obj.isInstanceOf[PointLight])
-      this === obj.asInstanceOf[PointLight]
-    else false
+    this.copy(attenuation = distance)
 }
 object PointLight {
-  def apply(position: Point, height: Int, color: RGB, power: Double, attenuation: Int): PointLight =
-    new PointLight(position, height, color, power, attenuation)
 
   val default: PointLight =
     apply(Point.zero, 100, RGB.White, 1.5d, 100)
 
-  implicit val equalTo: EqualTo[PointLight] =
-    EqualTo.create { (a, b) =>
-      a.position === b.position &&
-      a.height === b.height &&
-      a.color === b.color &&
-      a.power === b.power &&
-      a.attenuation === b.attenuation
-    }
 }
 
-final class SpotLight(
-    val position: Point,
-    val height: Int,
-    val color: RGB,
-    val power: Double,
-    val attenuation: Int,
-    val angle: Radians,
-    val rotation: Radians,
-    val near: Int,
-    val far: Int
+final case class SpotLight(
+    position: Point,
+    height: Int,
+    color: RGB,
+    power: Double,
+    attenuation: Int,
+    angle: Radians,
+    rotation: Radians,
+    near: Int,
+    far: Int
 ) extends Light {
   def moveTo(newPosition: Point): SpotLight =
     new SpotLight(newPosition, height, color, power, attenuation, angle, rotation, near, far)
@@ -116,80 +95,40 @@ final class SpotLight(
     rotateTo(Radians(if (r < 0) Math.abs(r) + Math.PI else r))
   }
 
-  override def toString: String =
-    s"SpotLight(${position.toString()}, ${height.toString()}, ${color.toString()}, ${power.toString()}, ${attenuation.toString()}, ${angle.value.toString()}, ${rotation.value
-      .toString()}, ${near
-      .toString()}, ${far.toString()})"
-
-  @SuppressWarnings(Array("org.wartremover.warts.IsInstanceOf", "org.wartremover.warts.AsInstanceOf"))
-  override def equals(obj: Any): Boolean =
-    if (obj.isInstanceOf[SpotLight])
-      this === obj.asInstanceOf[SpotLight]
-    else false
 }
 object SpotLight {
-  def apply(position: Point, height: Int, color: RGB, power: Double, attenuation: Int, angle: Radians, rotation: Radians, near: Int, far: Int): SpotLight =
-    new SpotLight(position, height, color, power, attenuation, angle, rotation, near, far)
 
   val default: SpotLight =
     apply(Point.zero, 100, RGB.White, 1.5, 100, Radians.fromDegrees(45), Radians.zero, 10, 300)
 
-  implicit val equalTo: EqualTo[SpotLight] =
-    EqualTo.create { (a, b) =>
-      a.position === b.position &&
-      a.height === b.height &&
-      a.color === b.color &&
-      a.power === b.power &&
-      a.attenuation === b.attenuation &&
-      a.angle === b.angle &&
-      a.rotation === b.rotation &&
-      a.near === b.near &&
-      a.far === b.far
-    }
 }
 
-final class DirectionLight(
-    val height: Int,
-    val color: RGB,
-    val power: Double,
-    val rotation: Radians
+final case class DirectionLight(
+    height: Int,
+    color: RGB,
+    power: Double,
+    rotation: Radians
 ) extends Light {
+
   def withHeight(newHeight: Int): DirectionLight =
-    new DirectionLight(newHeight, color, power, rotation)
+    this.copy(height = newHeight)
 
   def withColor(newColor: RGB): DirectionLight =
-    new DirectionLight(height, newColor, power, rotation)
+    this.copy(color = newColor)
 
   def withPower(newPower: Double): DirectionLight =
-    new DirectionLight(height, color, newPower, rotation)
+    this.copy(power = newPower)
 
   def rotateTo(newRotation: Radians): DirectionLight =
-    new DirectionLight(height, color, power, newRotation)
+    this.copy(rotation = newRotation)
 
   def rotateBy(amount: Radians): DirectionLight =
-    new DirectionLight(height, color, power, rotation + amount)
+    this.copy(rotation = rotation + amount)
 
-  override def toString: String =
-    s"DirectionLight(${height.toString()}, ${color.toString()}, ${power.toString()}, ${rotation.toString()})"
-
-  @SuppressWarnings(Array("org.wartremover.warts.IsInstanceOf", "org.wartremover.warts.AsInstanceOf"))
-  override def equals(obj: Any): Boolean =
-    if (obj.isInstanceOf[DirectionLight])
-      this === obj.asInstanceOf[DirectionLight]
-    else false
 }
 object DirectionLight {
-  def apply(height: Int, color: RGB, power: Double, rotation: Radians): DirectionLight =
-    new DirectionLight(height, color, power, rotation)
 
   val default: DirectionLight =
     apply(100, RGB.White, 1.0, Radians.zero)
 
-  implicit val equalTo: EqualTo[DirectionLight] =
-    EqualTo.create { (a, b) =>
-      a.height === b.height &&
-      a.color === b.color &&
-      a.power === b.power &&
-      a.rotation === b.rotation
-    }
 }

--- a/indigo/shared/src/main/scala/indigo/shared/scenegraph/SceneGraphNode.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/scenegraph/SceneGraphNode.scala
@@ -14,7 +14,7 @@ object SceneGraphNode {
   def empty: Group = Group.empty
 }
 
-sealed trait SceneGraphNode {
+sealed trait SceneGraphNode extends Product with Serializable {
   val depth: Depth
   def x: Int
   def y: Int

--- a/indigo/shared/src/main/scala/indigo/shared/scenegraph/SceneLayer.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/scenegraph/SceneLayer.scala
@@ -3,7 +3,7 @@ package indigo.shared.scenegraph
 import indigo.shared.datatypes.RGBA
 import scala.annotation.tailrec
 
-final class SceneLayer(val nodes: List[SceneGraphNode], val tint: RGBA, val saturation: Double, val magnification: Option[Int]) {
+final case class SceneLayer(nodes: List[SceneGraphNode], tint: RGBA, saturation: Double, magnification: Option[Int]) {
 
   def |+|(other: SceneLayer): SceneLayer = {
     val newSaturation: Double =
@@ -51,9 +51,6 @@ object SceneLayer {
 
   def apply(nodes: List[SceneGraphNode]): SceneLayer =
     new SceneLayer(nodes, RGBA.None, 1.0d, Option.empty[Int])
-
-  def apply(nodes: List[SceneGraphNode], tint: RGBA, saturation: Double, magnification: Option[Int]): SceneLayer =
-    new SceneLayer(nodes, tint, saturation, magnification.flatMap(sanitiseMagnification))
 
   def None: SceneLayer =
     SceneLayer(Nil, RGBA.None, 1.0d, Option.empty[Int])

--- a/indigo/shared/src/main/scala/indigo/shared/scenegraph/SceneUpdateFragment.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/scenegraph/SceneUpdateFragment.scala
@@ -3,17 +3,17 @@ package indigo.shared.scenegraph
 import indigo.shared.events.GlobalEvent
 import indigo.shared.datatypes.RGBA
 
-final class SceneUpdateFragment(
-    val gameLayer: SceneLayer,
-    val lightingLayer: SceneLayer,
-    val distortionLayer: SceneLayer,
-    val uiLayer: SceneLayer,
-    val ambientLight: RGBA,
-    val lights: List[Light],
-    val globalEvents: List[GlobalEvent],
-    val audio: SceneAudio,
-    val screenEffects: ScreenEffects,
-    val cloneBlanks: List[CloneBlank],
+final case class SceneUpdateFragment(
+    gameLayer: SceneLayer,
+    lightingLayer: SceneLayer,
+    distortionLayer: SceneLayer,
+    uiLayer: SceneLayer,
+    ambientLight: RGBA,
+    lights: List[Light],
+    globalEvents: List[GlobalEvent],
+    audio: SceneAudio,
+    screenEffects: ScreenEffects,
+    cloneBlanks: List[CloneBlank]
 ) {
   def |+|(other: SceneUpdateFragment): SceneUpdateFragment =
     SceneUpdateFragment.append(this, other)
@@ -22,205 +22,127 @@ final class SceneUpdateFragment(
     addGameLayerNodes(nodes.toList)
 
   def addGameLayerNodes(nodes: List[SceneGraphNode]): SceneUpdateFragment =
-    SceneUpdateFragment(gameLayer ++ nodes, lightingLayer, distortionLayer, uiLayer, ambientLight, lights, globalEvents, audio, screenEffects, cloneBlanks)
+    this.copy(gameLayer = gameLayer ++ nodes)
 
   def addLightingLayerNodes(nodes: SceneGraphNode*): SceneUpdateFragment =
     addLightingLayerNodes(nodes.toList)
 
   def addLightingLayerNodes(nodes: List[SceneGraphNode]): SceneUpdateFragment =
-    SceneUpdateFragment(gameLayer, lightingLayer ++ nodes, distortionLayer, uiLayer, ambientLight, lights, globalEvents, audio, screenEffects, cloneBlanks)
+    this.copy(lightingLayer = lightingLayer ++ nodes)
 
   def addDistortionLayerNodes(nodes: SceneGraphNode*): SceneUpdateFragment =
     addDistortionLayerNodes(nodes.toList)
 
   def addDistortionLayerNodes(nodes: List[SceneGraphNode]): SceneUpdateFragment =
-    SceneUpdateFragment(gameLayer, lightingLayer, distortionLayer ++ nodes, uiLayer, ambientLight, lights, globalEvents, audio, screenEffects, cloneBlanks)
+    this.copy(distortionLayer = distortionLayer ++ nodes)
 
   def addUiLayerNodes(nodes: SceneGraphNode*): SceneUpdateFragment =
     addUiLayerNodes(nodes.toList)
 
   def addUiLayerNodes(nodes: List[SceneGraphNode]): SceneUpdateFragment =
-    SceneUpdateFragment(gameLayer, lightingLayer, distortionLayer, uiLayer ++ nodes, ambientLight, lights, globalEvents, audio, screenEffects, cloneBlanks)
+    this.copy(uiLayer = uiLayer ++ nodes)
 
   def withAmbientLight(light: RGBA): SceneUpdateFragment =
-    SceneUpdateFragment(gameLayer, lightingLayer, distortionLayer, uiLayer, light, lights, globalEvents, audio, screenEffects, cloneBlanks)
+    this.copy(ambientLight = light)
 
   def withAmbientLightAmount(amount: Double): SceneUpdateFragment =
-    SceneUpdateFragment(gameLayer, lightingLayer, distortionLayer, uiLayer, ambientLight.withAmount(amount), lights, globalEvents, audio, screenEffects, cloneBlanks)
+    this.copy(ambientLight = ambientLight.withAmount(amount))
 
   def withAmbientLightTint(r: Double, g: Double, b: Double): SceneUpdateFragment =
-    SceneUpdateFragment(gameLayer, lightingLayer, distortionLayer, uiLayer, RGBA(r, g, b, 1), lights, globalEvents, audio, screenEffects, cloneBlanks)
+    withAmbientLight(RGBA(r, g, b, 1))
 
   def noLights: SceneUpdateFragment =
-    SceneUpdateFragment(gameLayer, lightingLayer, distortionLayer, uiLayer, ambientLight, Nil, globalEvents, audio, screenEffects, cloneBlanks)
+    this.copy(lights = Nil)
 
   def withLights(newLights: Light*): SceneUpdateFragment =
     withLights(newLights.toList)
 
   def withLights(newLights: List[Light]): SceneUpdateFragment =
-    SceneUpdateFragment(gameLayer, lightingLayer, distortionLayer, uiLayer, ambientLight, newLights, globalEvents, audio, screenEffects, cloneBlanks)
+    this.copy(lights = newLights)
 
   def addLights(newLights: Light*): SceneUpdateFragment =
     addLights(newLights.toList)
 
   def addLights(newLights: List[Light]): SceneUpdateFragment =
-    SceneUpdateFragment(gameLayer, lightingLayer, distortionLayer, uiLayer, ambientLight, lights ++ newLights.toList, globalEvents, audio, screenEffects, cloneBlanks)
+    withLights(lights ++ newLights)
 
   def addGlobalEvents(events: GlobalEvent*): SceneUpdateFragment =
     addGlobalEvents(events.toList)
 
   def addGlobalEvents(events: List[GlobalEvent]): SceneUpdateFragment =
-    SceneUpdateFragment(gameLayer, lightingLayer, distortionLayer, uiLayer, ambientLight, lights, globalEvents ++ events, audio, screenEffects, cloneBlanks)
+    this.copy(globalEvents = globalEvents ++ events)
 
   def withAudio(sceneAudio: SceneAudio): SceneUpdateFragment =
-    SceneUpdateFragment(gameLayer, lightingLayer, distortionLayer, uiLayer, ambientLight, lights, globalEvents, sceneAudio, screenEffects, cloneBlanks)
+    this.copy(audio = sceneAudio)
 
   def addCloneBlanks(blanks: CloneBlank*): SceneUpdateFragment =
     addCloneBlanks(blanks.toList)
 
   def addCloneBlanks(blanks: List[CloneBlank]): SceneUpdateFragment =
-    SceneUpdateFragment(gameLayer, lightingLayer, distortionLayer, uiLayer, ambientLight, lights, globalEvents, audio, screenEffects, cloneBlanks ++ blanks)
+    this.copy(cloneBlanks = cloneBlanks ++ blanks)
 
   def withSaturationLevel(amount: Double): SceneUpdateFragment =
-    SceneUpdateFragment(
-      gameLayer.withSaturationLevel(amount),
-      lightingLayer.withSaturationLevel(amount),
-      distortionLayer,
-      uiLayer.withSaturationLevel(amount),
-      ambientLight,
-      lights,
-      globalEvents,
-      audio,
-      screenEffects,
-      cloneBlanks
+    this.copy(
+      gameLayer = gameLayer.withSaturationLevel(amount),
+      lightingLayer = lightingLayer.withSaturationLevel(amount),
+      uiLayer = uiLayer.withSaturationLevel(amount)
     )
 
   def withGameLayerSaturationLevel(amount: Double): SceneUpdateFragment =
-    SceneUpdateFragment(gameLayer.withSaturationLevel(amount), lightingLayer, distortionLayer, uiLayer, ambientLight, lights, globalEvents, audio, screenEffects, cloneBlanks)
+    this.copy(gameLayer = gameLayer.withSaturationLevel(amount))
 
   def withLightingLayerSaturationLevel(amount: Double): SceneUpdateFragment =
-    SceneUpdateFragment(gameLayer, lightingLayer.withSaturationLevel(amount), distortionLayer, uiLayer, ambientLight, lights, globalEvents, audio, screenEffects, cloneBlanks)
+    this.copy(lightingLayer = lightingLayer.withSaturationLevel(amount))
 
   def withUiLayerSaturationLevel(amount: Double): SceneUpdateFragment =
-    SceneUpdateFragment(gameLayer, lightingLayer, distortionLayer, uiLayer.withSaturationLevel(amount), ambientLight, lights, globalEvents, audio, screenEffects, cloneBlanks)
+    this.copy(uiLayer = uiLayer.withSaturationLevel(amount))
 
   def withColorOverlay(overlay: RGBA): SceneUpdateFragment =
-    SceneUpdateFragment(
-      gameLayer,
-      lightingLayer,
-      distortionLayer,
-      uiLayer,
-      ambientLight,
-      lights,
-      globalEvents,
-      audio,
-      ScreenEffects(overlay, overlay),
-      cloneBlanks
-    )
+    this.copy(screenEffects = ScreenEffects(overlay, overlay))
 
   def withGameColorOverlay(overlay: RGBA): SceneUpdateFragment =
-    SceneUpdateFragment(gameLayer, lightingLayer, distortionLayer, uiLayer, ambientLight, lights, globalEvents, audio, screenEffects.withGameColorOverlay(overlay), cloneBlanks)
+    this.copy(screenEffects = screenEffects.withGameColorOverlay(overlay))
 
   def withUiColorOverlay(overlay: RGBA): SceneUpdateFragment =
-    SceneUpdateFragment(gameLayer, lightingLayer, distortionLayer, uiLayer, ambientLight, lights, globalEvents, audio, screenEffects.withUiColorOverlay(overlay), cloneBlanks)
+    this.copy(screenEffects = screenEffects.withUiColorOverlay(overlay))
 
   def withTint(tint: RGBA): SceneUpdateFragment =
-    SceneUpdateFragment(gameLayer.withTint(tint), lightingLayer.withTint(tint), distortionLayer, uiLayer.withTint(tint), ambientLight, lights, globalEvents, audio, screenEffects, cloneBlanks)
+    this.copy(
+      gameLayer = gameLayer.withTint(tint),
+      lightingLayer = lightingLayer.withTint(tint),
+      uiLayer = uiLayer.withTint(tint)
+    )
 
   def withGameLayerTint(tint: RGBA): SceneUpdateFragment =
-    SceneUpdateFragment(gameLayer.withTint(tint), lightingLayer, distortionLayer, uiLayer, ambientLight, lights, globalEvents, audio, screenEffects, cloneBlanks)
+    this.copy(gameLayer = gameLayer.withTint(tint))
 
   def withLightingLayerTint(tint: RGBA): SceneUpdateFragment =
-    SceneUpdateFragment(gameLayer, lightingLayer.withTint(tint), distortionLayer, uiLayer, ambientLight, lights, globalEvents, audio, screenEffects, cloneBlanks)
+    this.copy(lightingLayer = lightingLayer.withTint(tint))
 
   def withUiLayerTint(tint: RGBA): SceneUpdateFragment =
-    SceneUpdateFragment(gameLayer, lightingLayer, distortionLayer, uiLayer.withTint(tint), ambientLight, lights, globalEvents, audio, screenEffects, cloneBlanks)
+    this.copy(uiLayer = uiLayer.withTint(tint))
 
   def withMagnification(level: Int): SceneUpdateFragment =
-    SceneUpdateFragment(
-      gameLayer.withMagnification(level),
-      lightingLayer.withMagnification(level),
-      distortionLayer.withMagnification(level),
-      uiLayer.withMagnification(level),
-      ambientLight,
-      lights,
-      globalEvents,
-      audio,
-      screenEffects,
-      cloneBlanks
+    this.copy(
+      gameLayer = gameLayer.withMagnification(level),
+      lightingLayer = lightingLayer.withMagnification(level),
+      distortionLayer = distortionLayer.withMagnification(level),
+      uiLayer = uiLayer.withMagnification(level)
     )
 
   def withGameLayerMagnification(level: Int): SceneUpdateFragment =
-    SceneUpdateFragment(
-      gameLayer.withMagnification(level),
-      lightingLayer,
-      distortionLayer,
-      uiLayer,
-      ambientLight,
-      lights,
-      globalEvents,
-      audio,
-      screenEffects,
-      cloneBlanks
-    )
+    this.copy(gameLayer = gameLayer.withMagnification(level))
 
   def withLightingLayerMagnification(level: Int): SceneUpdateFragment =
-    SceneUpdateFragment(
-      gameLayer,
-      lightingLayer.withMagnification(level),
-      distortionLayer,
-      uiLayer,
-      ambientLight,
-      lights,
-      globalEvents,
-      audio,
-      screenEffects,
-      cloneBlanks
-    )
+    this.copy(lightingLayer = lightingLayer.withMagnification(level))
 
   def withDistortionLayerMagnification(level: Int): SceneUpdateFragment =
-    SceneUpdateFragment(
-      gameLayer,
-      lightingLayer,
-      distortionLayer.withMagnification(level),
-      uiLayer,
-      ambientLight,
-      lights,
-      globalEvents,
-      audio,
-      screenEffects,
-      cloneBlanks
-    )
+    this.copy(distortionLayer = distortionLayer.withMagnification(level))
 
   def withUiLayerMagnification(level: Int): SceneUpdateFragment =
-    SceneUpdateFragment(
-      gameLayer,
-      lightingLayer,
-      distortionLayer,
-      uiLayer.withMagnification(level),
-      ambientLight,
-      lights,
-      globalEvents,
-      audio,
-      screenEffects,
-      cloneBlanks
-    )
+    this.copy(uiLayer = uiLayer.withMagnification(level))
 }
 object SceneUpdateFragment {
-
-  def apply(
-      gameLayer: SceneLayer,
-      lightingLayer: SceneLayer,
-      distortionLayer: SceneLayer,
-      uiLayer: SceneLayer,
-      ambientLight: RGBA,
-      lights: List[Light],
-      globalEvents: List[GlobalEvent],
-      audio: SceneAudio,
-      screenEffects: ScreenEffects,
-      cloneBlanks: List[CloneBlank]
-  ): SceneUpdateFragment =
-    new SceneUpdateFragment(gameLayer, lightingLayer, distortionLayer, uiLayer, ambientLight, lights, globalEvents, audio, screenEffects, cloneBlanks)
 
   def apply(
       gameLayer: List[SceneGraphNode],
@@ -234,7 +156,18 @@ object SceneUpdateFragment {
       screenEffects: ScreenEffects,
       cloneBlanks: List[CloneBlank]
   ): SceneUpdateFragment =
-    new SceneUpdateFragment(SceneLayer(gameLayer), SceneLayer(lightingLayer), SceneLayer(distortionLayer), SceneLayer(uiLayer), ambientLight, lights, globalEvents, audio, screenEffects, cloneBlanks)
+    SceneUpdateFragment(
+      SceneLayer(gameLayer),
+      SceneLayer(lightingLayer),
+      SceneLayer(distortionLayer),
+      SceneLayer(uiLayer),
+      ambientLight,
+      lights,
+      globalEvents,
+      audio,
+      screenEffects,
+      cloneBlanks
+    )
 
   def apply(gameLayer: SceneGraphNode*): SceneUpdateFragment =
     SceneUpdateFragment(gameLayer.toList, Nil, Nil, Nil, RGBA.None, Nil, Nil, SceneAudio.None, ScreenEffects.None, Nil)

--- a/indigo/shared/src/main/scala/indigo/shared/scenegraph/ScreenEffects.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/scenegraph/ScreenEffects.scala
@@ -2,23 +2,20 @@ package indigo.shared.scenegraph
 
 import indigo.shared.datatypes.RGBA
 
-final class ScreenEffects(val gameColorOverlay: RGBA, val uiColorOverlay: RGBA) {
+final case class ScreenEffects(gameColorOverlay: RGBA, uiColorOverlay: RGBA) {
 
   def |+|(other: ScreenEffects): ScreenEffects =
     ScreenEffects(gameColorOverlay + other.gameColorOverlay, uiColorOverlay + other.uiColorOverlay)
 
   def withGameColorOverlay(overlay: RGBA): ScreenEffects =
-    ScreenEffects(overlay, uiColorOverlay)
+    this.copy(gameColorOverlay = overlay)
 
   def withUiColorOverlay(overlay: RGBA): ScreenEffects =
-    ScreenEffects(gameColorOverlay, overlay)
+    this.copy(uiColorOverlay = overlay)
 
 }
 
 object ScreenEffects {
-
-  def apply(gameColorOverlay: RGBA, uiColorOverlay: RGBA): ScreenEffects =
-    new ScreenEffects(gameColorOverlay, uiColorOverlay)
 
   def None: ScreenEffects =
     ScreenEffects(RGBA.Zero, RGBA.Zero)

--- a/indigo/shared/src/main/scala/indigo/shared/time/GameTime.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/time/GameTime.scala
@@ -2,7 +2,7 @@ package indigo.shared.time
 
 import indigo.shared.EqualTo
 
-final class GameTime(val running: Seconds, val delta: Seconds, val targetFPS: GameTime.FPS) {
+final case class GameTime(running: Seconds, delta: Seconds, targetFPS: GameTime.FPS) {
 
   lazy val frameDuration: Millis = Millis((1000d / targetFPS.asDouble).toLong)
   lazy val multiplier: Double    = delta.toDouble / frameDuration.toDouble
@@ -12,10 +12,8 @@ final class GameTime(val running: Seconds, val delta: Seconds, val targetFPS: Ga
   def doubleByTime(value: Double): Double = value * multiplier
 
   def setTargetFPS(fps: Int): GameTime =
-    new GameTime(running, delta, GameTime.FPS(fps))
+    this.copy(targetFPS = GameTime.FPS(fps))
 
-  override def toString(): String =
-    s"GameTime(running = ${running.toString()}, delta = ${delta.toString()}, fps = ${targetFPS.toString()})"
 }
 
 object GameTime {
@@ -31,20 +29,14 @@ object GameTime {
     GameTime(Seconds.zero, Seconds.zero, FPS.Default)
 
   def is(running: Seconds): GameTime =
-    new GameTime(running, Seconds.zero, FPS.Default)
+    GameTime(running, Seconds.zero, FPS.Default)
 
   def withDelta(running: Seconds, delta: Seconds): GameTime =
-    new GameTime(running, delta, FPS.Default)
+    GameTime(running, delta, FPS.Default)
 
-  def apply(running: Seconds, delta: Seconds, targetFPS: FPS): GameTime =
-    new GameTime(running, delta, targetFPS)
-
-  final class FPS(val value: Int) extends AnyVal {
+  final case class FPS(value: Int) extends AnyVal {
     def asLong: Long     = value.toLong
     def asDouble: Double = value.toDouble
-
-    override def toString(): String =
-      s"FPS(${value.toString()})"
   }
   object FPS {
 
@@ -56,9 +48,6 @@ object GameTime {
     val `30`: FPS    = FPS(30)
     val `60`: FPS    = FPS(60)
     val Default: FPS = `30`
-
-    def apply(value: Int): FPS =
-      new FPS(value)
 
   }
 

--- a/indigo/shared/src/main/scala/indigo/shared/time/Millis.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/time/Millis.scala
@@ -2,7 +2,7 @@ package indigo.shared.time
 
 import indigo.shared.EqualTo
 
-final class Millis(val value: Long) extends AnyVal {
+final case class Millis(value: Long) extends AnyVal {
 
   def +(other: Millis): Millis =
     Millis.plus(this, other)
@@ -46,9 +46,6 @@ final class Millis(val value: Long) extends AnyVal {
   def toSeconds: Seconds =
     Seconds(value.toDouble / 1000)
 
-  override def toString: String =
-    s"Millis(${value.toString()})"
-
   def ===(other: Millis): Boolean =
     implicitly[EqualTo[Millis]].equal(this, other)
 
@@ -63,31 +60,25 @@ object Millis {
       implicitly[EqualTo[Long]].equal(a.value, b.value)
     }
 
-  def apply(value: Long): Millis =
-    new Millis(value)
-
-  def unapply(millis: Millis): Option[Long] =
-    Some(millis.value)
-
-  def plus(a: Millis, b: Millis): Millis =
+  @inline def plus(a: Millis, b: Millis): Millis =
     Millis(a.value + b.value)
 
-  def minus(a: Millis, b: Millis): Millis =
+  @inline def minus(a: Millis, b: Millis): Millis =
     Millis(a.value - b.value)
 
-  def multiply(a: Millis, b: Millis): Millis =
+  @inline def multiply(a: Millis, b: Millis): Millis =
     Millis(a.value * b.value)
 
-  def divide(a: Millis, b: Millis): Millis =
+  @inline def divide(a: Millis, b: Millis): Millis =
     Millis(a.value / b.value)
 
-  def modulo(a: Millis, b: Millis): Millis =
+  @inline def modulo(a: Millis, b: Millis): Millis =
     Millis(a.value % b.value)
 
-  def greaterThan(a: Millis, b: Millis): Boolean =
+  @inline def greaterThan(a: Millis, b: Millis): Boolean =
     a.value > b.value
 
-  def lessThan(a: Millis, b: Millis): Boolean =
+  @inline def lessThan(a: Millis, b: Millis): Boolean =
     a.value < b.value
 
 }

--- a/indigo/shared/src/main/scala/indigo/shared/time/Seconds.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/time/Seconds.scala
@@ -2,7 +2,7 @@ package indigo.shared.time
 
 import indigo.shared.EqualTo
 
-final class Seconds(val value: Double) extends AnyVal {
+final case class Seconds(value: Double) extends AnyVal {
 
   def +(other: Seconds): Seconds =
     Seconds.plus(this, other)
@@ -46,9 +46,6 @@ final class Seconds(val value: Double) extends AnyVal {
   def toMillis: Millis =
     Millis(Math.floor(value * 1000).toLong)
 
-  override def toString: String =
-    s"Seconds(${value.toString()})"
-
   def ===(other: Seconds): Boolean =
     implicitly[EqualTo[Seconds]].equal(this, other)
 
@@ -63,28 +60,25 @@ object Seconds {
       implicitly[EqualTo[Double]].equal(a.value, b.value)
     }
 
-  def apply(value: Double): Seconds =
-    new Seconds(value)
-
-  def plus(a: Seconds, b: Seconds): Seconds =
+  @inline def plus(a: Seconds, b: Seconds): Seconds =
     Seconds(a.value + b.value)
 
-  def minus(a: Seconds, b: Seconds): Seconds =
+  @inline def minus(a: Seconds, b: Seconds): Seconds =
     Seconds(a.value - b.value)
 
-  def multiply(a: Seconds, b: Seconds): Seconds =
+  @inline def multiply(a: Seconds, b: Seconds): Seconds =
     Seconds(a.value * b.value)
 
-  def divide(a: Seconds, b: Seconds): Seconds =
+  @inline def divide(a: Seconds, b: Seconds): Seconds =
     Seconds(a.value / b.value)
 
-  def modulo(a: Seconds, b: Seconds): Seconds =
+  @inline def modulo(a: Seconds, b: Seconds): Seconds =
     Seconds(a.value % b.value)
 
-  def greaterThan(a: Seconds, b: Seconds): Boolean =
+  @inline def greaterThan(a: Seconds, b: Seconds): Boolean =
     a.value > b.value
 
-  def lessThan(a: Seconds, b: Seconds): Boolean =
+  @inline def lessThan(a: Seconds, b: Seconds): Boolean =
     a.value < b.value
 
 }

--- a/localpublish.sh
+++ b/localpublish.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Indigo Plugin
+echo ">>> Indigo Plugin"
+cd indigo-plugin
+bash build.sh
+cd ..
+
+# SBT Indigo
+echo ">>> SBT-Indigo"
+cd sbt-indigo
+bash build.sh
+cd ..
+
+# Mill Indigo
+echo ">>> Mill-Indigo"
+cd mill-indigo
+bash build.sh
+cd ..
+
+# Indigo
+echo ">>> Indigo"
+cd indigo
+bash build.sh
+cd ..
+


### PR DESCRIPTION
## Introduction

Some time ago in the ancient past, I banished case classes from the Indigo code base. I cannot now remember why I did this, other than a vague idea that I thought I was helping performance. I'm confident that I had no concrete evidence to base that decision on.

I've been wondering about the (lack of?) wisdom of that decision ever since, and after recent discussions with @drsimonmiles I have decided to get to the bottom of the matter in a _slightly but hardly conclusively_ scientific way.

## Hypothesis

1. In the worst case, case classes will be no less performant than classes. The additional methods case classes generate, and the persisted fields they have will have barely any impact on a fully optimised Indigo game.

2. In the best case, the implementation of case classes and their use of shallow cloning may have a positive impact on memory usage and garbage collection.

## Method

We will test three versions of Indigo against the Cursed Pirate Demo.

The cursed pirate demo is the only Indigo game that does any real work every frame without requiring user input, which could affect the results because I'd need to do the same kinds of actions over and over again fairly consistently.

The three version we will test are:

1. The current public release 0.3.0
2. The "master" branch, which has no case classes on hot code paths.
3. The "case-classes" branch, where most of the public API has been converted to case classes - as you can see for yourself in this Pull Request.

The public release is our baseline, but it's important to test the master branch since some changes have already been made there, and they may affect performance.

We will test each version three times, by:

1. Rebuilding the demo with `sbt clean compile fullOptJS indigoBuildFull`
2. Opening a Firefox window and its performance window.
3. Running the game for 30 seconds to let the JS engine warm up.
4. Taking a memory snapshot.
5. Recording the performance for 30 seconds, and then stopping.
6. Where we need to look at time series values, we will only sample from the second 10 seconds in recorded 30 second window, to reduce the effects of starting and stopping the profiler. I also picked frames at random from periods where the game seemed to be running nominally (i.e. not right next to a big GC pause...)

This was difficult to measure, particularly since the profiler has an observable effect on performance, but I looked at:

1. File size
2. Memory footprint
3. Average frame duration
4. Observed GC pattern

## Results

I ran each three times as described above, but actually found them to be reassuringly consistent between builds/runs. The values below are averages, and all taken from the same computer.

All of the big GC blocks followed a near identical pattern at regular intervals. Mostly NonIncremental GC, some CC graph reduction, and one-off Minor GC's and Cycle collections. The only thing that varied was the interval.

### Published version

Least stable frame rate, periodically bouncing between 59/60 FPS. Others were stable at 60.

- File size: 834KB
- Memory: 93.88MB
- Average frame duration: 8ms
- GC interval: 5 seconds

### Master

Smallest file size, _slightly_ better performance than master.

- File size: 820KB
- Memory: 93.36MB
- Average frame duration: 7ms
- GC interval: 5 seconds


### Case classes

Weirdly same file size as the published version. My hunch is that this has nothing to do with the code (which I checked was definitely the right version) and more to do with the closure compiler hitting some sort of complexity cut off. But I'm just guessing.

- File size: 834KB
- Memory: 93.46MB
- Average frame duration: 7ms
- GC interval: 7 seconds

## Conclusion

There's very little in it.

There appears to be no apparent performance difference between the current "master" and "case class" branches, and improvements over the published version seem due to commits that live on both branches.

The only value that has moved an any interesting way is the GC interval, where GC pauses are consistently further apart in the new version. This could actually be a bad thing, since in games the ideal would be to have a very regular, frequent, predictable, and small GC penalty. However it's hardly conclusive because it could have been doing the amount of clean up but simply not needing to do it as often. Certainly there was no observable frame duration penalty to suggest it was struggling.

What does this all mean?

Since there is no obvious performance reason not to use case classes, even if there's no performance improvement; Moving to case classes is still worth doing since it's cleans up the code base and presents more usable objects to the end user.

So if we're happy with the PR, we should go ahead and merge it.