### PR TITLE
Radio Buttons - API revision

### DIFF
--- a/examples/radio/src/main/scala/indigoexamples/RadioButtonExample.scala
+++ b/examples/radio/src/main/scala/indigoexamples/RadioButtonExample.scala
@@ -48,10 +48,10 @@ object RadioButtonExample extends IndigoDemo[Unit, Unit, MyGameModel, MyViewMode
       RadioButtonGroup(buttonAssets, 16, 16)
         .withRadioButtons(
           RadioButton(Point(5, 5))
-            .withSelectedAction(MyRadioButtonEvent(RGBA.Red))
+            .withSelectedActions(MyRadioButtonEvent(RGBA.Red))
             .selected,
-          RadioButton(Point(25, 5)).withSelectedAction(MyRadioButtonEvent(RGBA.Green)),
-          RadioButton(Point(45, 5)).withSelectedAction(MyRadioButtonEvent(RGBA.Blue))
+          RadioButton(Point(25, 5)).withSelectedActions(MyRadioButtonEvent(RGBA.Green)),
+          RadioButton(Point(45, 5)).withSelectedActions(MyRadioButtonEvent(RGBA.Blue))
         ),
       background
     )

--- a/examples/radio/src/main/scala/indigoexamples/RadioButtonExample.scala
+++ b/examples/radio/src/main/scala/indigoexamples/RadioButtonExample.scala
@@ -31,37 +31,39 @@ object RadioButtonExample extends IndigoDemo[Unit, Unit, MyGameModel, MyViewMode
       down = Graphic(0, 0, 16, 16, 2, Material.Textured(radioButtonGraphic)).withCrop(32, 0, 16, 16)
     )
 
-  val background: Graphic = Graphic(0, 0, 66, 26, 3, Material.Textured(AssetName("background")))
+  val background: Graphic =
+    Graphic(0, 0, 66, 26, 3, Material.Textured(AssetName("background")))
 
   def setup(bootData: Unit, assetCollection: AssetCollection, dice: Dice): Startup[Unit] =
     Startup.Success(())
 
   def initialModel(startupData: Unit): MyGameModel =
-    MyGameModel(0.0)
+    MyGameModel(RGBA.Black)
 
-  def initialViewModel(startupData: Unit, model: MyGameModel): MyViewModel = {
+  def initialViewModel(startupData: Unit, model: MyGameModel): MyViewModel =
     // Create three radio option buttons, each firing an event to tint the background differently
-    val option1 = RadioButton(Point(5, 5)).withSelectedAction(() => List(MyButtonEvent(0.0)))
-    val option2 = RadioButton(Point(25, 5)).withSelectedAction(() => List(MyButtonEvent(0.5)))
-    val option3 = RadioButton(Point(45, 5)).withSelectedAction(() => List(MyButtonEvent(1.0)))
-
     // Group the radio buttons and present them using loaded graphics
     // Button option1 is selected initially
     MyViewModel(
-      button = RadioButtonGroup(
-        buttonAssets = buttonAssets,
-        width = 16,
-        height = 16,
-        options = List(option1, option2, option3),
-        depth = Depth(2),
-        selected = Some(option1)
-      ),
+      RadioButtonGroup(buttonAssets, 16, 16)
+        .addRadioButton(
+          RadioButton(Point(5, 5))
+            .withSelectedAction(List(MyRadioButtonEvent(RGBA.Red)))
+            .selected
+        )
+        .addRadioButton(
+          RadioButton(Point(25, 5))
+            .withSelectedAction(List(MyRadioButtonEvent(RGBA.Green)))
+        )
+        .addRadioButton(
+          RadioButton(Point(45, 5))
+            .withSelectedAction(List(MyRadioButtonEvent(RGBA.Blue)))
+        ),
       background
     )
-  }
 
   def updateModel(context: FrameContext[Unit], model: MyGameModel): GlobalEvent => Outcome[MyGameModel] = {
-    case MyButtonEvent(newTint) =>
+    case MyRadioButtonEvent(newTint) =>
       Outcome(MyGameModel(newTint))
 
     case _ =>
@@ -74,8 +76,8 @@ object RadioButtonExample extends IndigoDemo[Unit, Unit, MyGameModel, MyViewMode
       viewModel: MyViewModel
   ): GlobalEvent => Outcome[MyViewModel] = {
     case FrameTick =>
-      viewModel.button.update(context.inputState.mouse).map { btn =>
-        viewModel.copy(button = btn)
+      viewModel.radioButtons.update(context.inputState.mouse).map { radioBtns =>
+        viewModel.copy(radioButtons = radioBtns)
       }
 
     case _ =>
@@ -83,12 +85,12 @@ object RadioButtonExample extends IndigoDemo[Unit, Unit, MyGameModel, MyViewMode
   }
 
   def present(context: FrameContext[Unit], model: MyGameModel, viewModel: MyViewModel): SceneUpdateFragment =
-    SceneUpdateFragment(viewModel.button.draw, viewModel.background.withTint(model.tint, 0.0, 0.0))
+    SceneUpdateFragment(viewModel.radioButtons.draw, viewModel.background.withTint(model.tint))
 }
 
 // The game model says how to tint the background
-final case class MyGameModel(tint: Double)
+final case class MyGameModel(tint: RGBA)
 // The view model contains the current state of the radio button group and the background graphic
-final case class MyViewModel(button: RadioButtonGroup, background: Graphic)
+final case class MyViewModel(radioButtons: RadioButtonGroup, background: Graphic)
 // This event is fired when a new radio button option is selected
-final case class MyButtonEvent(tint: Double) extends GlobalEvent
+final case class MyRadioButtonEvent(tint: RGBA) extends GlobalEvent

--- a/examples/radio/src/main/scala/indigoexamples/RadioButtonExample.scala
+++ b/examples/radio/src/main/scala/indigoexamples/RadioButtonExample.scala
@@ -46,18 +46,12 @@ object RadioButtonExample extends IndigoDemo[Unit, Unit, MyGameModel, MyViewMode
     // Button option1 is selected initially
     MyViewModel(
       RadioButtonGroup(buttonAssets, 16, 16)
-        .addRadioButton(
+        .withRadioButtons(
           RadioButton(Point(5, 5))
-            .withSelectedAction(List(MyRadioButtonEvent(RGBA.Red)))
-            .selected
-        )
-        .addRadioButton(
-          RadioButton(Point(25, 5))
-            .withSelectedAction(List(MyRadioButtonEvent(RGBA.Green)))
-        )
-        .addRadioButton(
-          RadioButton(Point(45, 5))
-            .withSelectedAction(List(MyRadioButtonEvent(RGBA.Blue)))
+            .withSelectedAction(MyRadioButtonEvent(RGBA.Red))
+            .selected,
+          RadioButton(Point(25, 5)).withSelectedAction(MyRadioButtonEvent(RGBA.Green)),
+          RadioButton(Point(45, 5)).withSelectedAction(MyRadioButtonEvent(RGBA.Blue))
         ),
       background
     )

--- a/indigo/indigo-extras/src/main/scala/indigoextras/ui/RadioButtonGroup.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/ui/RadioButtonGroup.scala
@@ -26,24 +26,24 @@ final case class RadioButton(
     onHoverOut: () => List[GlobalEvent],
     state: RadioButtonState
 ) {
-  def withSelectedAction(actions: GlobalEvent*): RadioButton =
-    withSelectedAction(actions.toList)
-  def withSelectedAction(actions: => List[GlobalEvent]): RadioButton =
+  def withSelectedActions(actions: GlobalEvent*): RadioButton =
+    withSelectedActions(actions.toList)
+  def withSelectedActions(actions: => List[GlobalEvent]): RadioButton =
     this.copy(onSelected = () => actions)
 
-  def withUnselectedAction(actions: GlobalEvent*): RadioButton =
-    withUnselectedAction(actions.toList)
-  def withUnselectedAction(actions: => List[GlobalEvent]): RadioButton =
+  def withUnselectedActions(actions: GlobalEvent*): RadioButton =
+    withUnselectedActions(actions.toList)
+  def withUnselectedActions(actions: => List[GlobalEvent]): RadioButton =
     this.copy(onUnselected = () => actions)
 
-  def withHoverOverAction(actions: GlobalEvent*): RadioButton =
-    withHoverOverAction(actions.toList)
-  def withHoverOverAction(actions: => List[GlobalEvent]): RadioButton =
+  def withHoverOverActions(actions: GlobalEvent*): RadioButton =
+    withHoverOverActions(actions.toList)
+  def withHoverOverActions(actions: => List[GlobalEvent]): RadioButton =
     this.copy(onHoverOver = () => actions)
 
-  def withHoverOutAction(actions: GlobalEvent*): RadioButton =
-    withHoverOutAction(actions.toList)
-  def withHoverOutAction(actions: => List[GlobalEvent]): RadioButton =
+  def withHoverOutActions(actions: GlobalEvent*): RadioButton =
+    withHoverOutActions(actions.toList)
+  def withHoverOutActions(actions: => List[GlobalEvent]): RadioButton =
     this.copy(onHoverOut = () => actions)
 
   def selected: RadioButton =

--- a/indigo/indigo-extras/src/main/scala/indigoextras/ui/RadioButtonGroup.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/ui/RadioButtonGroup.scala
@@ -5,6 +5,7 @@ import indigo.shared.datatypes.{Depth, Point, Rectangle}
 import indigo.shared.events.GlobalEvent
 import indigo.shared.input.Mouse
 import indigo.shared.scenegraph.Group
+import scala.annotation.tailrec
 
 /**
   * Represents an individual option button in a radio button group. This class just containing the distinct information
@@ -48,6 +49,9 @@ final case class RadioButton(
   def selected: RadioButton =
     this.copy(state = RadioButtonState.Selected)
 
+  def deselected: RadioButton =
+    this.copy(state = RadioButtonState.Normal)
+
   def inSelectedState: Boolean =
     state.inSelectedState
 
@@ -67,42 +71,106 @@ object RadioButton {
 }
 
 /**
-  * The state of a group of mutually exclusive radio buttons.
+  * A group of mutually exclusive radio buttons.
   *
   * @param buttonAssets The graphics to use identically for all of the options: up (unselected), down (selected) and over
-  * @param width The width of each option button graphic
-  * @param height The height of each option button graphic
+  * @param hitArea The hit area of the radio button relative to the button's position
   * @param options A list individual radio buttons that comprise this group
   * @param depth The depth at which to present the buttons
   */
 final case class RadioButtonGroup(
     buttonAssets: ButtonAssets,
-    size: Point,
-    options: List[RadioButton],
-    depth: Depth
+    hitArea: Rectangle,
+    depth: Depth,
+    options: List[RadioButton]
 ) {
 
-  def withSize(newSize: Point): RadioButtonGroup =
-    this.copy(size = newSize)
+  /**
+    * Specify a new hit area for the radio buttons
+    *
+    * @param newHitArea the new hit area
+    * @return RadioButtonGroup
+    */
+  def withHitArea(newHitArea: Rectangle): RadioButtonGroup =
+    this.copy(hitArea = newHitArea)
 
+  /**
+    * Specify a new depth to draw the radio buttons at.
+    *
+    * @param newDepth the new depth to render the radio buttons at
+    * @return RadioButtonGroup
+    */
   def withDepth(newDepth: Depth): RadioButtonGroup =
     this.copy(depth = newDepth)
 
-  def addRadioButton(radioButton: RadioButton): RadioButtonGroup =
-    this.copy(options = options :+ radioButton)
+  /**
+    * Replace the radio buttons in this group
+    *
+    * @param radioButtons a variable number of radio buttons to use
+    * @return RadioButtonGroup
+    */
+  def withRadioButtons(radioButtons: RadioButton*): RadioButtonGroup =
+    withRadioButtons(radioButtons.toList)
+
+  /**
+    * Replace the radio buttons in this group
+    *
+    * @param radioButtons a list of radio buttons to use
+    * @return RadioButtonGroup
+    */
+  def withRadioButtons(radioButtons: List[RadioButton]): RadioButtonGroup =
+    this.copy(options = selectFirstOnly(radioButtons))
+
+  /**
+    * Append radio buttons to this group
+    *
+    * @param radioButtons a variable number of radio buttons to add
+    * @return RadioButtonGroup
+    */
+  def addRadioButtons(radioButtons: RadioButton*): RadioButtonGroup =
+    addRadioButtons(radioButtons.toList)
+
+  /**
+    * Append radio buttons to this group
+    *
+    * @param radioButtons a list of radio buttons to add
+    * @return RadioButtonGroup
+    */
+  def addRadioButtons(radioButtons: List[RadioButton]): RadioButtonGroup =
+    this.copy(options = selectFirstOnly(options ++ radioButtons))
+
+  private def selectFirstOnly(radioButtons: List[RadioButton]): List[RadioButton] = {
+    @tailrec
+    def rec(remaining: List[RadioButton], foundSelected: Boolean, acc: List[RadioButton]): List[RadioButton] =
+      remaining match {
+        case Nil =>
+          acc.reverse
+
+        case head :: next if head.inSelectedState && !foundSelected =>
+          rec(next, true, head :: acc)
+
+        case head :: next if head.inSelectedState && foundSelected =>
+          rec(next, foundSelected, head.deselected :: acc)
+
+        case head :: next =>
+          rec(next, foundSelected, head :: acc)
+      }
+
+    rec(radioButtons, false, Nil)
+  }
 
   /**
     * Update all the option buttons according to the newest state of mouse input.
     *
     * @param mouse The current mouse state
-    * @return An Outcome with this radio button's new state
+    * @return An Outcome[RadioButtonGroup] with this radio button's new state
     */
   def update(mouse: Mouse): Outcome[RadioButtonGroup] = {
     val indexedOptions = options.zipWithIndex
 
     val selected: Option[Int] =
       indexedOptions.flatMap {
-        case (o, i) if mouse.leftMouseIsDown && Rectangle(o.position, size).isPointWithin(mouse.position) =>
+        case (o, i) if mouse.leftMouseIsDown && hitArea.moveBy(o.position).isPointWithin(mouse.position) =>
           List(i)
 
         case _ =>
@@ -128,7 +196,7 @@ final case class RadioButtonGroup(
           Outcome(o.copy(state = RadioButtonState.Normal), o.onUnselected())
 
         // Not selected, no mouse click, mouse within, should be in hover state.
-        case (o, _) if !o.inSelectedState && !mouse.leftMouseIsDown && Rectangle(o.position, size).isPointWithin(mouse.position) =>
+        case (o, _) if !o.inSelectedState && !mouse.leftMouseIsDown && hitArea.moveBy(o.position).isPointWithin(mouse.position) =>
           Outcome(o.copy(state = RadioButtonState.Hover), o.onHoverOver())
 
         // Hovered, but mouse outside so revert to normal
@@ -146,7 +214,7 @@ final case class RadioButtonGroup(
   /**
     * Returns graphics to present the current state of the radio button.
     *
-    * @return A group of scene update primitives collecting the graphics for all options
+    * @return A Group of scene update primitives collecting the graphics for all options
     */
   def draw: Group =
     Group(options.map { option =>
@@ -166,40 +234,33 @@ final case class RadioButtonGroup(
 object RadioButtonGroup {
 
   /**
-    * Construct a radio button group without yet specifying the events fired on selection, hover, and so on,
-    * with the bounds of each option being specified by the top-left position of each plus the
-    * width and height to use for them all.
-    *
-    * @param buttonAssets The button assets to use to present each option button
-    * @param width The width of the radio button hit area, identical for all
-    * @param height The height of the radio button hit area, identical for all
-    * @param options The top-left position of each option button by index
-    * @param depth The display depth at which to present the radio button
-    * @return The constructed radio button
-    */
-  def apply(
-      buttonAssets: ButtonAssets,
-      width: Int,
-      height: Int,
-      options: List[RadioButton],
-      depth: Depth
-  ): RadioButtonGroup =
-    RadioButtonGroup(buttonAssets, Point(width, height), options, depth /*, selected, None*/ )
-
-  /**
     * Construct a bare bones radio button group, with no buttons in it.
     *
     * @param buttonAssets The button assets to use to present each option button
     * @param width The width of the radio button hit area, identical for all
     * @param height The height of the radio button hit area, identical for all
-    * @return
+    * @return RadioButtonGroup
     */
   def apply(
       buttonAssets: ButtonAssets,
       width: Int,
       height: Int
   ): RadioButtonGroup =
-    RadioButtonGroup(buttonAssets, Point(width, height), Nil, Depth(1) /*, selected, None*/ )
+    RadioButtonGroup(buttonAssets, Rectangle(0, 0, width, height), Depth(1), Nil)
+
+  /**
+    * Construct a bare bones radio button group, with no buttons in it.
+    *
+    * @param buttonAssets The button assets to use to present each option button
+    * @param hitArea The hit area of the radio button relative to the button's position
+    * @return RadioButtonGroup
+    */
+  def apply(
+      buttonAssets: ButtonAssets,
+      hitArea: Rectangle
+  ): RadioButtonGroup =
+    RadioButtonGroup(buttonAssets, hitArea, Depth(1), Nil)
+
 }
 
 sealed trait RadioButtonState {

--- a/indigo/indigo-extras/src/test/scala/indigoextras/ui/RadioButtonGroupTests.scala
+++ b/indigo/indigo-extras/src/test/scala/indigoextras/ui/RadioButtonGroupTests.scala
@@ -49,9 +49,7 @@ object RadioButtonGroupTests extends TestSuite {
 
         val radioButtons =
           RadioButtonGroup(assets, 10, 10)
-            .addRadioButton(option1)
-            .addRadioButton(option2)
-            .addRadioButton(option3)
+            .withRadioButtons(option1, option2, option3)
 
         "No mouse interaction" - {
 
@@ -107,7 +105,7 @@ object RadioButtonGroupTests extends TestSuite {
             radioButtons.copy(
               options = List(
                 option1,
-                option2.copy(state = RadioButtonState.Normal),
+                option2.deselected,
                 option3
               )
             )
@@ -125,7 +123,7 @@ object RadioButtonGroupTests extends TestSuite {
             radioButtons
               .copy(
                 options = List(
-                  option1.copy(state = RadioButtonState.Normal),
+                  option1.deselected,
                   option2.copy(state = RadioButtonState.Hover),
                   option3
                 )
@@ -135,8 +133,8 @@ object RadioButtonGroupTests extends TestSuite {
           val expected =
             radioButtons.copy(
               options = List(
-                option1.copy(state = RadioButtonState.Normal),
-                option2.copy(state = RadioButtonState.Selected),
+                option1.deselected,
+                option2.selected,
                 option3
               )
             )
@@ -153,7 +151,7 @@ object RadioButtonGroupTests extends TestSuite {
             radioButtons
               .copy(
                 options = List(
-                  option1.copy(state = RadioButtonState.Selected),
+                  option1.selected,
                   option2.copy(state = RadioButtonState.Hover),
                   option3
                 )
@@ -163,8 +161,8 @@ object RadioButtonGroupTests extends TestSuite {
           val expected =
             radioButtons.copy(
               options = List(
-                option1.copy(state = RadioButtonState.Normal),
-                option2.copy(state = RadioButtonState.Selected),
+                option1.deselected,
+                option2.selected,
                 option3
               )
             )

--- a/indigo/indigo-extras/src/test/scala/indigoextras/ui/RadioButtonGroupTests.scala
+++ b/indigo/indigo-extras/src/test/scala/indigoextras/ui/RadioButtonGroupTests.scala
@@ -28,24 +28,24 @@ object RadioButtonGroupTests extends TestSuite {
 
         val option1 =
           RadioButton(Point(0, 0)).selected
-            .withSelectedAction(RadioTestEvent("option 1 selected"))
-            .withUnselectedAction(RadioTestEvent("option 1 unselected"))
-            .withHoverOverAction(RadioTestEvent("option 1 hover over"))
-            .withHoverOutAction(RadioTestEvent("option 1 hover out"))
+            .withSelectedActions(RadioTestEvent("option 1 selected"))
+            .withUnselectedActions(RadioTestEvent("option 1 unselected"))
+            .withHoverOverActions(RadioTestEvent("option 1 hover over"))
+            .withHoverOutActions(RadioTestEvent("option 1 hover out"))
 
         val option2 =
           RadioButton(Point(0, 20))
-            .withSelectedAction(RadioTestEvent("option 2 selected"))
-            .withUnselectedAction(RadioTestEvent("option 2 unselected"))
-            .withHoverOverAction(RadioTestEvent("option 2 hover over"))
-            .withHoverOutAction(RadioTestEvent("option 2 hover out"))
+            .withSelectedActions(RadioTestEvent("option 2 selected"))
+            .withUnselectedActions(RadioTestEvent("option 2 unselected"))
+            .withHoverOverActions(RadioTestEvent("option 2 hover over"))
+            .withHoverOutActions(RadioTestEvent("option 2 hover out"))
 
         val option3 =
           RadioButton(Point(0, 40))
-            .withSelectedAction(RadioTestEvent("option 3 selected"))
-            .withUnselectedAction(RadioTestEvent("option 3 unselected"))
-            .withHoverOverAction(RadioTestEvent("option 3 hover over"))
-            .withHoverOutAction(RadioTestEvent("option 3 hover out"))
+            .withSelectedActions(RadioTestEvent("option 3 selected"))
+            .withUnselectedActions(RadioTestEvent("option 3 unselected"))
+            .withHoverOverActions(RadioTestEvent("option 3 hover over"))
+            .withHoverOutActions(RadioTestEvent("option 3 hover out"))
 
         val radioButtons =
           RadioButtonGroup(assets, 10, 10)

--- a/indigo/indigo-extras/src/test/scala/indigoextras/ui/RadioButtonGroupTests.scala
+++ b/indigo/indigo-extras/src/test/scala/indigoextras/ui/RadioButtonGroupTests.scala
@@ -1,0 +1,180 @@
+package indigoextras.ui
+
+import utest._
+import indigo.shared.scenegraph.Graphic
+import indigo.shared.datatypes.Rectangle
+import indigo.shared.datatypes.Material
+import indigo.shared.assets.AssetName
+import indigo.shared.datatypes.Point
+import indigo.shared.events.GlobalEvent
+import indigo.shared.input.Mouse
+import indigo.shared.events.MouseEvent
+
+object RadioButtonGroupTests extends TestSuite {
+
+  val tests: Tests =
+    Tests {
+
+      "Radio button group update" - {
+
+        final case class RadioTestEvent(message: String) extends GlobalEvent
+
+        val assets =
+          ButtonAssets(
+            Graphic(Rectangle(0, 0, 10, 10), 1, Material.Textured(AssetName("up"))),
+            Graphic(Rectangle(0, 0, 10, 10), 1, Material.Textured(AssetName("over"))),
+            Graphic(Rectangle(0, 0, 10, 10), 1, Material.Textured(AssetName("down")))
+          )
+
+        val option1 =
+          RadioButton(Point(0, 0)).selected
+            .withSelectedAction(RadioTestEvent("option 1 selected"))
+            .withUnselectedAction(RadioTestEvent("option 1 unselected"))
+            .withHoverOverAction(RadioTestEvent("option 1 hover over"))
+            .withHoverOutAction(RadioTestEvent("option 1 hover out"))
+
+        val option2 =
+          RadioButton(Point(0, 20))
+            .withSelectedAction(RadioTestEvent("option 2 selected"))
+            .withUnselectedAction(RadioTestEvent("option 2 unselected"))
+            .withHoverOverAction(RadioTestEvent("option 2 hover over"))
+            .withHoverOutAction(RadioTestEvent("option 2 hover out"))
+
+        val option3 =
+          RadioButton(Point(0, 40))
+            .withSelectedAction(RadioTestEvent("option 3 selected"))
+            .withUnselectedAction(RadioTestEvent("option 3 unselected"))
+            .withHoverOverAction(RadioTestEvent("option 3 hover over"))
+            .withHoverOutAction(RadioTestEvent("option 3 hover out"))
+
+        val radioButtons =
+          RadioButtonGroup(assets, 10, 10)
+            .addRadioButton(option1)
+            .addRadioButton(option2)
+            .addRadioButton(option3)
+
+        "No mouse interaction" - {
+
+          val mouse =
+            new Mouse(Nil, Point(-10, -10), false)
+
+          val actual = radioButtons.update(mouse)
+
+          val expected = radioButtons
+
+          actual.state ==> expected
+          actual.globalEvents ==> Nil
+
+        }
+
+        "hover over unselected button" - {
+
+          val mouse =
+            new Mouse(Nil, Point(5, 25), false)
+
+          val actual = radioButtons.update(mouse)
+
+          val expected =
+            radioButtons.copy(
+              options = List(
+                option1,
+                option2.copy(state = RadioButtonState.Hover),
+                option3
+              )
+            )
+
+          actual.state ==> expected
+          actual.globalEvents ==> List(RadioTestEvent("option 2 hover over"))
+        }
+
+        "hover out unselected button" - {
+
+          val mouse =
+            new Mouse(Nil, Point(-5, 25), false)
+
+          val actual =
+            radioButtons
+              .copy(
+                options = List(
+                  option1,
+                  option2.copy(state = RadioButtonState.Hover),
+                  option3
+                )
+              )
+              .update(mouse)
+
+          val expected =
+            radioButtons.copy(
+              options = List(
+                option1,
+                option2.copy(state = RadioButtonState.Normal),
+                option3
+              )
+            )
+
+          actual.state ==> expected
+          actual.globalEvents ==> List(RadioTestEvent("option 2 hover out"))
+        }
+
+        "selecting a hovered button" - {
+
+          val mouse =
+            new Mouse(List(MouseEvent.Click(5, 25)), Point(5, 25), true)
+
+          val actual =
+            radioButtons
+              .copy(
+                options = List(
+                  option1.copy(state = RadioButtonState.Normal),
+                  option2.copy(state = RadioButtonState.Hover),
+                  option3
+                )
+              )
+              .update(mouse)
+
+          val expected =
+            radioButtons.copy(
+              options = List(
+                option1.copy(state = RadioButtonState.Normal),
+                option2.copy(state = RadioButtonState.Selected),
+                option3
+              )
+            )
+
+          actual.state.options.map(_.state) ==> expected.options.map(_.state)
+          actual.globalEvents ==> List(RadioTestEvent("option 2 selected"))
+        }
+
+        "selecting a hovered button, existing selected is de-selected" - {
+          val mouse =
+            new Mouse(List(MouseEvent.Click(5, 25)), Point(5, 25), true)
+
+          val actual =
+            radioButtons
+              .copy(
+                options = List(
+                  option1.copy(state = RadioButtonState.Selected),
+                  option2.copy(state = RadioButtonState.Hover),
+                  option3
+                )
+              )
+              .update(mouse)
+
+          val expected =
+            radioButtons.copy(
+              options = List(
+                option1.copy(state = RadioButtonState.Normal),
+                option2.copy(state = RadioButtonState.Selected),
+                option3
+              )
+            )
+
+          actual.state.options.map(_.state) ==> expected.options.map(_.state)
+          actual.globalEvents ==> List(RadioTestEvent("option 1 unselected"), RadioTestEvent("option 2 selected"))
+        }
+
+      }
+
+    }
+
+}


### PR DESCRIPTION
This is a follow up to the work by @drsimonmiles in PR https://github.com/PurpleKingdomGames/indigo/pull/60

After merging the new Radio Buttons component I started playing with the example. Everything worked perfectly, but I was very mildly irked by user experience of having to declare the same option twice to mark it as being initially set:

```scala
RadioButtonGroup(
  ...,
  options = List(option1, option2, option3),
  ...,
  selected = Some(option1)
)
```

...and thought it would be nice if you could do something like:

```scala
RadioButtonGroup(assets, 10, 10)
  .addRadioButton(option1.selected)
  .addRadioButton(option2)
  .addRadioButton(option3)
```

Pulling that seemingly small harmless thread ...lead to a fair bit of rejigging. :-)

The structure is the same, but the user experience is a bit different (I hope cleaner), and the guts of the update logic is a rewrite to avoid using an object equality test (because we don't store the selected anymore, so we can't do that). I also added some very basic tests for a measure of confidence.