### PR TITLE
BoundingCircle geometry primitive ...and other improvements

### DIFF
--- a/demos/snake/snake/src/snake/model/quadtrees/QuadBounds.scala
+++ b/demos/snake/snake/src/snake/model/quadtrees/QuadBounds.scala
@@ -1,7 +1,7 @@
 package snake.model.quadtrees
 
 import indigo.shared.datatypes.{Point, Rectangle}
-import indigoextras.geometry.{IntersectionResult, LineSegment}
+import indigoextras.geometry.LineSegment
 
 import indigo.shared.EqualTo
 import indigo.shared.EqualTo._
@@ -147,28 +147,13 @@ object QuadBounds {
 
   def rayCollisionCheck(bounds: QuadBounds, line: LineSegment): Boolean =
     bounds.edges.exists { edge =>
-      line.intersectWith(edge) match {
-        case ip: IntersectionResult.IntersectionVertex =>
-          line.containsVertex(ip.toVertex)
-
-        case IntersectionResult.NoIntersection =>
-          false
-      }
+      line.intersectsWithLine(edge)
     }
 
   def rayCollisionPosition(bounds: QuadBounds, line: LineSegment): Option[Point] =
     bounds.edges
       .map { edge =>
-        line.intersectWith(edge) match {
-          case ip @ IntersectionResult.IntersectionVertex(_, _) if line.containsVertex(ip.toVertex) =>
-            Some(ip.toVertex)
-
-          case IntersectionResult.IntersectionVertex(_, _) =>
-            None
-
-          case IntersectionResult.NoIntersection =>
-            None
-        }
+        line.intersectsAt(edge)
       }
       .collect { case Some(s) => s }
       .sortWith((p1, p2) => line.start.distanceTo(p1) < line.start.distanceTo(p2))

--- a/demos/snake/snake/src/snake/model/quadtrees/QuadTree.scala
+++ b/demos/snake/snake/src/snake/model/quadtrees/QuadTree.scala
@@ -301,11 +301,11 @@ object QuadTree {
         case QuadLeaf(bounds, value) if lineSegment.end.toPoint === bounds.position.toPoint =>
           List(value)
 
-        case QuadLeaf(bounds, value) if LineSegment.lineContainsVertex(lineSegment, bounds.centerAsVertex, 0.15d) =>
+        case QuadLeaf(bounds, value) if LineSegment.lineSegmentContainsVertex(lineSegment, bounds.centerAsVertex, 0.15d) =>
           List(value)
 
         case QuadLeaf(bounds, value)
-            if LineSegment.lineContainsVertex(lineSegment, Vertex.fromPoint(bounds.position.toPoint), 0.25f) =>
+            if LineSegment.lineSegmentContainsVertex(lineSegment, Vertex.fromPoint(bounds.position.toPoint), 0.25f) =>
           List(value)
 
         case _ =>

--- a/indigo/indigo-extras/src/main/scala/indigoextras/geometry/BoundingBox.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/geometry/BoundingBox.scala
@@ -46,8 +46,12 @@ final case class BoundingBox(position: Vertex, size: Vertex) {
   def /(rect: BoundingBox): BoundingBox = BoundingBox(x / rect.x, y / rect.y, width / rect.width, height / rect.height)
   def /(d: Double): BoundingBox         = BoundingBox(x / d, y / d, width / d, height / d)
 
-  def sdf(vertex: Vertex): Double =
-    BoundingBox.signedDistanceFunction(vertex - position, halfSize)
+  def sdf(vertex: Vertex): Double = {
+    val p: Vertex = vertex - center
+    val d: Vertex     = p.abs - halfSize
+    d.max(0.0).length + Math.min(Math.max(d.x, d.y), 0.0)
+  }
+
   def distanceToBoundary(vertex: Vertex): Double =
     sdf(vertex)
 
@@ -213,11 +217,5 @@ object BoundingBox {
         else acc
       }
       ._1
-
-  // Centered at the origin
-  def signedDistanceFunction(point: Vertex, halfSize: Vertex): Double = {
-    val d: Vertex = point.abs - halfSize
-    d.max(0.0).length + Math.min(Math.max(d.x, d.y), 0.0)
-  }
 
 }

--- a/indigo/indigo-extras/src/main/scala/indigoextras/geometry/BoundingBox.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/geometry/BoundingBox.scala
@@ -197,7 +197,7 @@ object BoundingBox {
             case r @ IntersectionVertex(_, _) =>
               val v = r.toVertex
 
-              if (line.containsVertex(v) && bbLine.containsVertex(v))
+              if (line.contains(v) && bbLine.contains(v))
                 Some(v)
               else
                 None

--- a/indigo/indigo-extras/src/main/scala/indigoextras/geometry/BoundingBox.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/geometry/BoundingBox.scala
@@ -4,7 +4,6 @@ import indigo.shared.EqualTo
 
 import scala.annotation.tailrec
 import indigo.shared.datatypes.Rectangle
-import indigoextras.geometry.LineIntersectionResult
 
 final case class BoundingBox(position: Vertex, size: Vertex) {
   lazy val x: Double      = position.x
@@ -197,7 +196,7 @@ object BoundingBox {
         case Nil =>
           false
 
-        case x :: xs if x.intersectsAt(line).isDefined =>
+        case x :: _ if x.intersectsAt(line).isDefined =>
           true
 
         case _ :: xs =>

--- a/indigo/indigo-extras/src/main/scala/indigoextras/geometry/BoundingBox.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/geometry/BoundingBox.scala
@@ -7,11 +7,11 @@ import indigo.shared.datatypes.Rectangle
 import indigoextras.geometry.IntersectionResult.IntersectionVertex
 
 final case class BoundingBox(position: Vertex, size: Vertex) {
-  val x: Double         = position.x
-  val y: Double         = position.y
-  val width: Double     = size.x
-  val height: Double    = size.y
-  lazy val hash: String = s"${x.toString()}${y.toString()}${width.toString()}${height.toString()}"
+  lazy val x: Double      = position.x
+  lazy val y: Double      = position.y
+  lazy val width: Double  = size.x
+  lazy val height: Double = size.y
+  lazy val hash: String   = s"${x.toString()}${y.toString()}${width.toString()}${height.toString()}"
 
   lazy val left: Double   = x
   lazy val right: Double  = x + width
@@ -38,13 +38,13 @@ final case class BoundingBox(position: Vertex, size: Vertex) {
     contains(Vertex(x, y))
 
   def +(rect: BoundingBox): BoundingBox = BoundingBox(x + rect.x, y + rect.y, width + rect.width, height + rect.height)
-  def +(i: Double): BoundingBox         = BoundingBox(x + i, y + i, width + i, height + i)
+  def +(d: Double): BoundingBox         = BoundingBox(x + d, y + d, width + d, height + d)
   def -(rect: BoundingBox): BoundingBox = BoundingBox(x - rect.x, y - rect.y, width - rect.width, height - rect.height)
-  def -(i: Double): BoundingBox         = BoundingBox(x - i, y - i, width - i, height - i)
+  def -(d: Double): BoundingBox         = BoundingBox(x - d, y - d, width - d, height - d)
   def *(rect: BoundingBox): BoundingBox = BoundingBox(x * rect.x, y * rect.y, width * rect.width, height * rect.height)
-  def *(i: Double): BoundingBox         = BoundingBox(x * i, y * i, width * i, height * i)
+  def *(d: Double): BoundingBox         = BoundingBox(x * d, y * d, width * d, height * d)
   def /(rect: BoundingBox): BoundingBox = BoundingBox(x / rect.x, y / rect.y, width / rect.width, height / rect.height)
-  def /(i: Double): BoundingBox         = BoundingBox(x / i, y / i, width / i, height / i)
+  def /(d: Double): BoundingBox         = BoundingBox(x / d, y / d, width / d, height / d)
 
   def expandToInclude(other: BoundingBox): BoundingBox =
     BoundingBox.expandToInclude(this, other)
@@ -74,6 +74,9 @@ final case class BoundingBox(position: Vertex, size: Vertex) {
   def toLineSegments: List[LineSegment] =
     BoundingBox.toLineSegments(this)
 
+  def lineIntersects(line: LineSegment): Boolean =
+    BoundingBox.lineIntersects(this, line)
+
   def lineIntersectsAt(line: LineSegment): Option[Vertex] =
     BoundingBox.lineIntersectsAt(this, line)
 
@@ -89,7 +92,8 @@ final case class BoundingBox(position: Vertex, size: Vertex) {
 
 object BoundingBox {
 
-  val zero: BoundingBox = BoundingBox(0, 0, 0, 0)
+  val zero: BoundingBox =
+    BoundingBox(0, 0, 0, 0)
 
   def apply(x: Double, y: Double, width: Double, height: Double): BoundingBox =
     BoundingBox(Vertex(x, y), Vertex(width, height))
@@ -170,6 +174,9 @@ object BoundingBox {
 
   def overlapping(a: BoundingBox, b: BoundingBox): Boolean =
     Math.abs(a.center.x - b.center.x) < a.halfSize.x + b.halfSize.x && Math.abs(a.center.y - b.center.y) < a.halfSize.y + b.halfSize.y
+
+  def lineIntersects(boundingBox: BoundingBox, line: LineSegment): Boolean =
+    lineIntersectsAt(boundingBox, line).isDefined
 
   def lineIntersectsAt(boundingBox: BoundingBox, line: LineSegment): Option[Vertex] = {
     val verts =

--- a/indigo/indigo-extras/src/main/scala/indigoextras/geometry/BoundingBox.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/geometry/BoundingBox.scala
@@ -46,6 +46,11 @@ final case class BoundingBox(position: Vertex, size: Vertex) {
   def /(rect: BoundingBox): BoundingBox = BoundingBox(x / rect.x, y / rect.y, width / rect.width, height / rect.height)
   def /(d: Double): BoundingBox         = BoundingBox(x / d, y / d, width / d, height / d)
 
+  def sdf(vertex: Vertex): Double =
+    BoundingBox.signedDistanceFunction(vertex - position, halfSize)
+  def distanceToBoundary(vertex: Vertex): Double =
+    sdf(vertex)
+
   def expandToInclude(other: BoundingBox): BoundingBox =
     BoundingBox.expandToInclude(this, other)
 
@@ -202,6 +207,12 @@ object BoundingBox {
         else acc
       }
       ._1
+  }
+
+  // Centered at the origin
+  def signedDistanceFunction(point: Vertex, halfSize: Vertex): Double = {
+    val d: Vertex = point.abs - halfSize
+    d.max(0.0).length + Math.min(Math.max(d.x, d.y), 0.0)
   }
 
 }

--- a/indigo/indigo-extras/src/main/scala/indigoextras/geometry/BoundingBox.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/geometry/BoundingBox.scala
@@ -76,6 +76,9 @@ final case class BoundingBox(position: Vertex, size: Vertex) {
   def toRectangle: Rectangle =
     Rectangle(position.toPoint, size.toPoint)
 
+  def toBoundingCircle: BoundingCircle =
+    BoundingCircle.fromBoundingBox(this)
+
   def toLineSegments: List[LineSegment] =
     BoundingBox.toLineSegments(this)
 
@@ -137,6 +140,9 @@ object BoundingBox {
 
   def fromRectangle(rectangle: Rectangle): BoundingBox =
     BoundingBox(Vertex.fromPoint(rectangle.position), Vertex.fromPoint(rectangle.size))
+
+  def fromBoundingCircle(boundingCircle: BoundingCircle): BoundingBox =
+    boundingCircle.toBoundingBox
 
   def toLineSegments(boundingBox: BoundingBox): List[LineSegment] =
     List(

--- a/indigo/indigo-extras/src/main/scala/indigoextras/geometry/BoundingCircle.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/geometry/BoundingCircle.scala
@@ -3,8 +3,6 @@ package indigoextras.geometry
 import indigo.shared.EqualTo
 import indigo.shared.datatypes.Vector2
 
-import scala.annotation.tailrec
-
 final case class BoundingCircle(position: Vertex, radius: Double) {
   lazy val x: Double        = position.x
   lazy val y: Double        = position.y

--- a/indigo/indigo-extras/src/main/scala/indigoextras/geometry/BoundingCircle.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/geometry/BoundingCircle.scala
@@ -3,6 +3,8 @@ package indigoextras.geometry
 import indigo.shared.EqualTo
 import indigo.shared.datatypes.Vector2
 
+import scala.annotation.tailrec
+
 final case class BoundingCircle(position: Vertex, radius: Double) {
   lazy val x: Double        = position.x
   lazy val y: Double        = position.y
@@ -78,37 +80,17 @@ object BoundingCircle {
   def apply(x: Double, y: Double, radius: Double): BoundingCircle =
     BoundingCircle(Vertex(x, y), radius)
 
-  // def fromTwoVertices(pt1: Vertex, pt2: Vertex): BoundingBox = {
-  //   val x = Math.min(pt1.x, pt2.x)
-  //   val y = Math.min(pt1.y, pt2.y)
-  //   val w = Math.max(pt1.x, pt2.x) - x
-  //   val h = Math.max(pt1.y, pt2.y) - y
+  def fromTwoVertices(center: Vertex, boundary: Vertex): BoundingCircle =
+    BoundingCircle(center, center.distanceTo(boundary))
 
-  //   BoundingBox(x, y, w, h)
-  // }
+  def fromVertices(vertices: List[Vertex]): BoundingCircle =
+    fromBoundingBox(BoundingBox.fromVertices(vertices))
 
-  // def fromVertices(vertices: List[Vertex]): BoundingBox = {
-  //   @tailrec
-  //   def rec(remaining: List[Vertex], left: Double, top: Double, right: Double, bottom: Double): BoundingBox =
-  //     remaining match {
-  //       case Nil =>
-  //         BoundingBox(left, top, right - left, bottom - top)
+  def fromVertexCloud(vertices: List[Vertex]): BoundingCircle =
+    fromVertices(vertices)
 
-  //       case p :: ps =>
-  //         rec(
-  //           ps,
-  //           Math.min(left, p.x),
-  //           Math.min(top, p.y),
-  //           Math.max(right, p.x),
-  //           Math.max(bottom, p.y)
-  //         )
-  //     }
-
-  //   rec(vertices, Double.MaxValue, Double.MaxValue, Double.MinValue, Double.MinValue)
-  // }
-
-  // def fromVertexCloud(vertices: List[Vertex]): BoundingBox =
-  //   fromVertices(vertices)
+  def fromBoundingBox(boundingBox: BoundingBox): BoundingCircle =
+    BoundingCircle(boundingBox.center, Math.max(boundingBox.halfSize.x, boundingBox.halfSize.y))
 
   implicit val bcEqualTo: EqualTo[BoundingCircle] = {
     val eq = implicitly[EqualTo[Vertex]]

--- a/indigo/indigo-extras/src/main/scala/indigoextras/geometry/BoundingCircle.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/geometry/BoundingCircle.scala
@@ -1,0 +1,150 @@
+package indigoextras.geometry
+
+import indigo.shared.EqualTo
+import indigo.shared.datatypes.Vector2
+
+final case class BoundingCircle(position: Vertex, radius: Double) {
+  lazy val x: Double        = position.x
+  lazy val y: Double        = position.y
+  lazy val diameter: Double = radius * 2
+
+  lazy val left: Double   = x - radius
+  lazy val right: Double  = x + radius
+  lazy val top: Double    = y - radius
+  lazy val bottom: Double = y + radius
+
+  def toBoundingBox: BoundingBox =
+    BoundingBox(Vertex(left, top), Vertex(diameter, diameter))
+
+  def contains(vertex: Vertex): Boolean =
+    vertex.distanceTo(position) <= radius
+
+  def contains(x: Double, y: Double): Boolean =
+    contains(Vertex(x, y))
+
+  def +(d: Double): BoundingCircle = resize(radius + d)
+  def -(d: Double): BoundingCircle = resize(radius - d)
+  def *(d: Double): BoundingCircle = resize(radius * d)
+  def /(d: Double): BoundingCircle = resize(radius / d)
+
+  def sdf(vertex: Vertex): Double =
+    BoundingCircle.signedDistanceFunction(vertex - position, radius)
+  def distanceToBoundary(vertex: Vertex): Double =
+    sdf(vertex)
+
+  def expandToInclude(other: BoundingCircle): BoundingCircle =
+    BoundingCircle.expandToInclude(this, other)
+
+  def encompasses(other: BoundingCircle): Boolean =
+    BoundingCircle.encompassing(this, other)
+
+  def overlaps(other: BoundingCircle): Boolean =
+    BoundingCircle.overlapping(this, other)
+
+  def moveBy(amount: Vertex): BoundingCircle =
+    this.copy(position = position + amount)
+  def moveBy(x: Double, y: Double): BoundingCircle =
+    moveBy(Vertex(x, y))
+
+  def moveTo(newPosition: Vertex): BoundingCircle =
+    this.copy(position = newPosition)
+  def moveTo(x: Double, y: Double): BoundingCircle =
+    moveTo(Vertex(x, y))
+
+  def resize(newRadius: Double): BoundingCircle =
+    this.copy(radius = newRadius)
+
+  def lineIntersects(line: LineSegment): Boolean =
+    BoundingCircle.lineIntersects(this, line)
+
+  def lineIntersectsAt(line: LineSegment): Option[Vertex] =
+    BoundingCircle.lineIntersectsAt(this, line)
+
+  def ===(other: BoundingCircle): Boolean =
+    implicitly[EqualTo[BoundingCircle]].equal(this, other)
+
+  @SuppressWarnings(Array("org.wartremover.warts.IsInstanceOf", "org.wartremover.warts.AsInstanceOf"))
+  override def equals(obj: Any): Boolean =
+    if (obj.isInstanceOf[BoundingCircle])
+      this === obj.asInstanceOf[BoundingCircle]
+    else false
+}
+
+object BoundingCircle {
+
+  val zero: BoundingCircle =
+    BoundingCircle(Vertex.zero, 0)
+
+  def apply(x: Double, y: Double, radius: Double): BoundingCircle =
+    BoundingCircle(Vertex(x, y), radius)
+
+  // def fromTwoVertices(pt1: Vertex, pt2: Vertex): BoundingBox = {
+  //   val x = Math.min(pt1.x, pt2.x)
+  //   val y = Math.min(pt1.y, pt2.y)
+  //   val w = Math.max(pt1.x, pt2.x) - x
+  //   val h = Math.max(pt1.y, pt2.y) - y
+
+  //   BoundingBox(x, y, w, h)
+  // }
+
+  // def fromVertices(vertices: List[Vertex]): BoundingBox = {
+  //   @tailrec
+  //   def rec(remaining: List[Vertex], left: Double, top: Double, right: Double, bottom: Double): BoundingBox =
+  //     remaining match {
+  //       case Nil =>
+  //         BoundingBox(left, top, right - left, bottom - top)
+
+  //       case p :: ps =>
+  //         rec(
+  //           ps,
+  //           Math.min(left, p.x),
+  //           Math.min(top, p.y),
+  //           Math.max(right, p.x),
+  //           Math.max(bottom, p.y)
+  //         )
+  //     }
+
+  //   rec(vertices, Double.MaxValue, Double.MaxValue, Double.MinValue, Double.MinValue)
+  // }
+
+  // def fromVertexCloud(vertices: List[Vertex]): BoundingBox =
+  //   fromVertices(vertices)
+
+  implicit val bcEqualTo: EqualTo[BoundingCircle] = {
+    val eq = implicitly[EqualTo[Vertex]]
+
+    EqualTo.create { (a, b) =>
+      eq.equal(a.position, b.position) && EqualTo.eqDouble.equal(a.radius, b.radius)
+    }
+  }
+
+  def expandToInclude(a: BoundingCircle, b: BoundingCircle): BoundingCircle =
+    a.resize(a.position.distanceTo(b.position) + Math.abs(b.radius))
+
+  def encompassing(a: BoundingCircle, b: BoundingCircle): Boolean =
+    a.position.distanceTo(b.position) < Math.abs(a.radius) - Math.abs(b.radius)
+
+  def overlapping(a: BoundingCircle, b: BoundingCircle): Boolean =
+    a.position.distanceTo(b.position) < Math.abs(a.radius) + Math.abs(b.radius)
+
+  def lineIntersects(boundingCircle: BoundingCircle, line: LineSegment): Boolean =
+    Math.abs(line.sdf(boundingCircle.position)) <= boundingCircle.radius
+
+  def lineIntersectsAt(boundingCircle: BoundingCircle, line: LineSegment): Option[Vertex] = {
+    val a: Vector2 = (boundingCircle.position - line.start).toVector2
+    val b: Vector2 = (line.end - line.start).toVector2
+    val c = a.dot(b) / b.length
+
+    val d = (a * c) + line.start.toVector2 //
+
+    if(d.distanceTo(boundingCircle.position.toVector2) <= boundingCircle.radius) {
+      //hit
+      ???
+    } else None
+  }
+
+  // Centered at the origin
+  def signedDistanceFunction(point: Vertex, radius: Double): Double =
+    point.length - radius
+
+}

--- a/indigo/indigo-extras/src/main/scala/indigoextras/geometry/Line.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/geometry/Line.scala
@@ -1,0 +1,105 @@
+package indigoextras.geometry
+
+import indigo.shared.EqualTo._
+
+/**
+ * Defines a line in terms of y = mx + b
+ */
+sealed trait Line
+object Line {
+  final case class Components(m: Double, b: Double) extends Line {
+
+    def slopeComparison(vertex: Vertex, tolerance: Double): Boolean = {
+      // This is a slope comparison.. Any point on the line should have the same slope as the line.
+      val m2: Double =
+        if (vertex.x === 0) 0
+        else (b - vertex.y) / (0 - vertex.x)
+
+      val mDelta: Double =
+        m - m2
+
+      mDelta >= -tolerance && mDelta <= tolerance
+    }
+
+  }
+  final case class ParallelToAxisY(xPosition: Double) extends Line
+  case object InvalidLine                             extends Line
+
+  /*
+  y = mx + b
+
+  We're trying to calculate m and b where
+  m is the slope i.e. number of y units per x unit
+  b is the y-intersect i.e. the point on the y-axis where the line passes through it
+   */
+  def fromLineSegment(lineSegment: LineSegment): Line =
+    (lineSegment.start, lineSegment.end) match {
+      case (Vertex(x1, y1), Vertex(x2, y2)) if x1 === x2 && y1 === y2 =>
+        Line.InvalidLine
+
+      case (Vertex(x1, _), Vertex(x2, _)) if x1 === x2 =>
+        Line.ParallelToAxisY(x1)
+
+      case (Vertex(x1, y1), Vertex(x2, y2)) =>
+        val m: Double = (y2 - y1) / (x2 - x1)
+
+        Line.Components(m, y1 - (m * x1))
+    }
+
+  def intersection(l1: Line, l2: Line): LineIntersectionResult =
+    /*
+    y-intercept = mx + b (i.e. y = mx + b)
+    x-intercept = -b/m   (i.e. x = -b/m where y is moved to 0)
+     */
+    (l1, l2) match {
+      case (Line.Components(m1, _), Line.Components(m2, _)) if m1 === m2 =>
+        // Same slope, so parallel
+        LineIntersectionResult.NoIntersection
+
+      case (Line.Components(m1, b1), Line.Components(m2, b2)) =>
+        //x = -b/m
+        val x: Double = (b2 - b1) / (m1 - m2)
+
+        //y = mx + b
+        val y: Double = (m1 * x) + b1
+
+        LineIntersectionResult.IntersectionVertex(x, y)
+
+      case (Line.ParallelToAxisY(x), Line.Components(m, b)) =>
+        LineIntersectionResult.IntersectionVertex(
+          x = x,
+          y = (m * x) + b
+        )
+
+      case (Line.Components(m, b), Line.ParallelToAxisY(x)) =>
+        LineIntersectionResult.IntersectionVertex(
+          x = x,
+          y = (m * x) + b
+        )
+
+      case _ =>
+        LineIntersectionResult.NoIntersection
+    }
+
+}
+
+sealed trait LineIntersectionResult {
+  def toOption: Option[Vertex]
+  def toList: List[Vertex]
+}
+object LineIntersectionResult {
+  final case class IntersectionVertex(x: Double, y: Double) extends LineIntersectionResult {
+    def toVertex: Vertex =
+      Vertex(x, y)
+
+    def toOption: Option[Vertex] =
+      Some(toVertex)
+
+    def toList: List[Vertex] =
+      List(toVertex)
+  }
+  case object NoIntersection extends LineIntersectionResult {
+    def toOption: Option[Vertex] = None
+    def toList: List[Vertex]     = Nil
+  }
+}

--- a/indigo/indigo-extras/src/main/scala/indigoextras/geometry/LineSegment.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/geometry/LineSegment.scala
@@ -16,6 +16,11 @@ final case class LineSegment(start: Vertex, end: Vertex) {
   def top: Double    = Math.min(start.y, end.y)
   def bottom: Double = Math.max(start.y, end.y)
 
+  def sdf(vertex: Vertex): Double =
+    LineSegment.signedDistanceFunction(vertex, start, end)
+  def distanceToBoundary(vertex: Vertex): Double =
+    sdf(vertex)
+
   def moveTo(newPosition: Vertex): LineSegment =
     this.copy(start = newPosition, end = newPosition + (end - start))
   def moveTo(x: Double, y: Double): LineSegment =
@@ -218,6 +223,22 @@ object LineSegment {
 
   def isFacingVertex(line: LineSegment, vertex: Vertex): Boolean =
     (line.normal dot Vertex.twoVerticesToVector2(vertex, line.center)) < 0
+
+  /*
+    float sdSegment( in vec2 p, in vec2 a, in vec2 b )
+    {
+        vec2 pa = p-a, ba = b-a;
+        float h = clamp( dot(pa,ba)/dot(ba,ba), 0.0, 1.0 );
+        return length( pa - ba*h );
+    }
+   */
+  // Centered at the origin
+  def signedDistanceFunction(point: Vertex, start: Vertex, end: Vertex): Double = {
+    val pa: Vertex = point - start
+    val ba: Vertex = end - start
+    val h: Double  = Math.min(1.0, Math.max(0.0, (pa.dot(ba) / ba.dot(ba))))
+    (pa - (ba * h)).length
+  }
 
 }
 

--- a/indigo/indigo-extras/src/main/scala/indigoextras/geometry/LineSegment.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/geometry/LineSegment.scala
@@ -1,7 +1,6 @@
 package indigoextras.geometry
 
 import indigo.shared.EqualTo
-import indigo.shared.EqualTo._
 import indigo.shared.datatypes.Vector2
 
 final case class LineSegment(start: Vertex, end: Vertex) {
@@ -140,7 +139,7 @@ object LineSegment {
       case Line.InvalidLine =>
         false
 
-      case Line.ParallelToAxisY(x) =>
+      case Line.ParallelToAxisY(_) =>
         if (vertex.x >= lineSegment.start.x - tolerance && vertex.x <= lineSegment.start.x + tolerance && vertex.y >= lineSegment.top && vertex.y <= lineSegment.bottom) true
         else false
 

--- a/indigo/indigo-extras/src/main/scala/indigoextras/geometry/LineSegment.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/geometry/LineSegment.scala
@@ -70,11 +70,11 @@ final case class LineSegment(start: Vertex, end: Vertex) {
 
       case r @ IntersectionResult.IntersectionVertex(_, _) =>
         val pt = r.toVertex
-        containsVertex(pt) && other.containsVertex(pt)
+        contains(pt) && other.contains(pt)
 
     }
 
-  def containsVertex(vertex: Vertex): Boolean =
+  def contains(vertex: Vertex): Boolean =
     LineSegment.lineContainsVertex(this, vertex, 0.5f)
 
   def isFacingVertex(vertex: Vertex): Boolean =

--- a/indigo/indigo-extras/src/main/scala/indigoextras/geometry/LineSegment.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/geometry/LineSegment.scala
@@ -80,6 +80,22 @@ final case class LineSegment(start: Vertex, end: Vertex) {
   def isFacingVertex(vertex: Vertex): Boolean =
     LineSegment.isFacingVertex(this, vertex)
 
+  def closestPointOnLine(to: Vertex): Vertex = {
+    val a   = end.y - start.y
+    val b   = start.x - end.x
+    val c1  = a * start.x + b * start.y
+    val c2  = -b * to.x + a * to.y
+    val det = a * a - -b * b
+
+    if (det != 0.0)
+      Vertex(
+        x = (a * c1 - b * c2) / det,
+        y = (a * c2 - -b * c1) / det
+      )
+    else
+      Vertex.zero
+  }
+
   def ===(other: LineSegment): Boolean =
     implicitly[EqualTo[LineSegment]].equal(this, other)
 
@@ -224,14 +240,6 @@ object LineSegment {
   def isFacingVertex(line: LineSegment, vertex: Vertex): Boolean =
     (line.normal dot Vertex.twoVerticesToVector2(vertex, line.center)) < 0
 
-  /*
-    float sdSegment( in vec2 p, in vec2 a, in vec2 b )
-    {
-        vec2 pa = p-a, ba = b-a;
-        float h = clamp( dot(pa,ba)/dot(ba,ba), 0.0, 1.0 );
-        return length( pa - ba*h );
-    }
-   */
   // Centered at the origin
   def signedDistanceFunction(point: Vertex, start: Vertex, end: Vertex): Double = {
     val pa: Vertex = point - start

--- a/indigo/indigo-extras/src/main/scala/indigoextras/geometry/LineSegment.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/geometry/LineSegment.scala
@@ -17,7 +17,7 @@ final case class LineSegment(start: Vertex, end: Vertex) {
   def bottom: Double = Math.max(start.y, end.y)
 
   def sdf(vertex: Vertex): Double =
-    LineSegment.signedDistanceFunction(vertex, start, end)
+    LineSegment.signedDistanceFunction(this, vertex)
   def distanceToBoundary(vertex: Vertex): Double =
     sdf(vertex)
 
@@ -55,30 +55,43 @@ final case class LineSegment(start: Vertex, end: Vertex) {
     invert
 
   def normal: Vector2 =
-    LineSegment.calculateNormal(start, end)
+    Vector2(
+      x = -(end.y - start.y),
+      y = (end.x - start.x)
+    ).normalise
 
-  def lineProperties: LineProperties =
-    LineSegment.calculateLineComponents(start, end)
+  def toLine: Line =
+    Line.fromLineSegment(this)
 
-  def intersectWith(other: LineSegment): IntersectionResult =
-    LineSegment.intersection(this, other)
+  def intersectsAt(other: LineSegment): Option[Vertex] = {
+    val res = Line.intersection(this.toLine, other.toLine) match {
+      case r @ LineIntersectionResult.NoIntersection =>
+        r
 
-  def intersectWithLine(other: LineSegment): Boolean =
-    LineSegment.intersection(this, other) match {
-      case IntersectionResult.NoIntersection =>
+      case r @ LineIntersectionResult.IntersectionVertex(_, _) =>
+        val pt = r.toVertex
+        if (contains(pt) && other.contains(pt)) r
+        else LineIntersectionResult.NoIntersection
+    }
+
+    res.toOption
+  }
+
+  def intersectsWithLine(other: LineSegment): Boolean =
+    Line.intersection(this.toLine, other.toLine) match {
+      case LineIntersectionResult.NoIntersection =>
         false
 
-      case r @ IntersectionResult.IntersectionVertex(_, _) =>
+      case r @ LineIntersectionResult.IntersectionVertex(_, _) =>
         val pt = r.toVertex
         contains(pt) && other.contains(pt)
-
     }
 
   def contains(vertex: Vertex): Boolean =
-    LineSegment.lineContainsVertex(this, vertex, 0.5f)
+    LineSegment.lineSegmentContainsVertex(this, vertex, 0.5f)
 
   def isFacingVertex(vertex: Vertex): Boolean =
-    LineSegment.isFacingVertex(this, vertex)
+    (normal dot Vertex.twoVerticesToVector2(vertex, center)) < 0
 
   def closestPointOnLine(to: Vertex): Option[Vertex] = {
     val a   = end.y - start.y
@@ -122,161 +135,26 @@ object LineSegment {
   def apply(start: (Double, Double), end: (Double, Double)): LineSegment =
     LineSegment(Vertex.tuple2ToVertex(start), Vertex.tuple2ToVertex(end))
 
-  /*
-  y = mx + b
-
-  We're trying to calculate m and b where
-  m is the slope i.e. number of y units per x unit
-  b is the y-intersect i.e. the point on the y-axis where the line passes through it
-   */
-  def calculateLineComponents(start: Vertex, end: Vertex): LineProperties =
-    (start, end) match {
-      case (Vertex(x1, y1), Vertex(x2, y2)) if x1 === x2 && y1 === y2 =>
-        LineProperties.InvalidLine
-
-      case (Vertex(x1, _), Vertex(x2, _)) if x1 === x2 =>
-        LineProperties.ParallelToAxisY
-
-      case (Vertex(x1, y1), Vertex(x2, y2)) =>
-        val m: Double = (y2 - y1) / (x2 - x1)
-
-        LineProperties.LineComponents(m, y1 - (m * x1))
-    }
-
-  def intersection(l1: LineSegment, l2: LineSegment): IntersectionResult =
-    /*
-    y-intercept = mx + b (i.e. y = mx + b)
-    x-intercept = -b/m   (i.e. x = -b/m where y is moved to 0)
-     */
-    (l1.lineProperties, l2.lineProperties) match {
-      case (LineProperties.LineComponents(m1, _), LineProperties.LineComponents(m2, _)) if m1 === m2 =>
-        // Same slope, so parallel
-        IntersectionResult.NoIntersection
-
-      case (LineProperties.LineComponents(m1, b1), LineProperties.LineComponents(m2, b2)) =>
-        //x = -b/m
-        val x: Double = (b2 - b1) / (m1 - m2)
-
-        //y = mx + b
-        val y: Double = (m1 * x) + b1
-
-        IntersectionResult.IntersectionVertex(x, y)
-
-      case (LineProperties.ParallelToAxisY, LineProperties.LineComponents(m, b)) =>
-        IntersectionResult.IntersectionVertex(
-          x = l1.start.x,
-          y = (m * l1.start.x) + b
-        )
-
-      case (LineProperties.LineComponents(m, b), LineProperties.ParallelToAxisY) =>
-        IntersectionResult.IntersectionVertex(
-          x = l2.start.x,
-          y = (m * l2.start.x) + b
-        )
-
-      case _ =>
-        IntersectionResult.NoIntersection
-    }
-
-  def calculateNormal(start: Vertex, end: Vertex): Vector2 =
-    normaliseVertex(Vector2(-(end.y - start.y), (end.x - start.x)))
-
-  def normaliseVertex(vec2: Vector2): Vector2 = {
-    val x: Double = vec2.x
-    val y: Double = vec2.y
-
-    Vector2(
-      if (x === 0) 0 else (x / Math.abs(x)),
-      if (y === 0) 0 else (y / Math.abs(y))
-    )
-  }
-
-  def lineContainsVertex(lineSegment: LineSegment, point: Vertex): Boolean =
-    lineContainsVertex(lineSegment, point, 0.001d)
-
-  def lineContainsVertex(lineSegment: LineSegment, point: Vertex, tolerance: Double): Boolean =
-    lineSegment.lineProperties match {
-      case LineProperties.InvalidLine =>
+  def lineSegmentContainsVertex(lineSegment: LineSegment, vertex: Vertex, tolerance: Double): Boolean =
+    lineSegment.toLine match {
+      case Line.InvalidLine =>
         false
 
-      case LineProperties.ParallelToAxisY =>
-        if (point.x >= lineSegment.start.x - tolerance && point.x <= lineSegment.start.x + tolerance && point.y >= lineSegment.top && point.y <= lineSegment.bottom) true
+      case Line.ParallelToAxisY(x) =>
+        if (vertex.x >= lineSegment.start.x - tolerance && vertex.x <= lineSegment.start.x + tolerance && vertex.y >= lineSegment.top && vertex.y <= lineSegment.bottom) true
         else false
 
-      case LineProperties.LineComponents(m, b) =>
-        if (point.x >= lineSegment.left && point.x <= lineSegment.right && point.y >= lineSegment.top && point.y <= lineSegment.bottom)
-          slopeCheck(point.x, point.y, m, b, tolerance)
-        else false
-    }
-
-  def lineContainsCoords(lineSegment: LineSegment, coords: (Double, Double), tolerance: Double): Boolean =
-    lineContainsXY(lineSegment, coords._1, coords._2, tolerance)
-
-  def lineContainsXY(lineSegment: LineSegment, x: Double, y: Double, tolerance: Double): Boolean =
-    lineSegment.lineProperties match {
-      case LineProperties.InvalidLine =>
-        false
-
-      case LineProperties.ParallelToAxisY =>
-        if (x === lineSegment.start.x && y >= lineSegment.top && y <= lineSegment.bottom) true
-        else false
-
-      case LineProperties.LineComponents(m, b) =>
-        if (x >= lineSegment.left && x <= lineSegment.right && y >= lineSegment.top && y <= lineSegment.bottom)
-          slopeCheck(x, y, m, b, tolerance)
+      case l @ Line.Components(_, _) =>
+        if (vertex.x >= lineSegment.left && vertex.x <= lineSegment.right && vertex.y >= lineSegment.top && vertex.y <= lineSegment.bottom)
+          l.slopeComparison(vertex, tolerance)
         else false
     }
 
-  def slopeCheck(x: Double, y: Double, m: Double, b: Double, tolerance: Double): Boolean = {
-    // This is a slope comparison.. Any point on the line should have the same slope as the line.
-    val m2: Double =
-      if (x === 0) 0
-      else (b - y) / (0 - x)
-
-    val mDelta: Double =
-      m - m2
-
-    mDelta >= -tolerance && mDelta <= tolerance
-  }
-
-  def isFacingVertex(line: LineSegment, vertex: Vertex): Boolean =
-    (line.normal dot Vertex.twoVerticesToVector2(vertex, line.center)) < 0
-
-  // Centered at the origin
-  def signedDistanceFunction(point: Vertex, start: Vertex, end: Vertex): Double = {
-    val pa: Vertex = point - start
-    val ba: Vertex = end - start
+  def signedDistanceFunction(lineSegment: LineSegment, vertex: Vertex): Double = {
+    val pa: Vertex = vertex - lineSegment.start
+    val ba: Vertex = lineSegment.end - lineSegment.start
     val h: Double  = Math.min(1.0, Math.max(0.0, (pa.dot(ba) / ba.dot(ba))))
     (pa - (ba * h)).length
   }
 
-}
-
-sealed trait LineProperties
-object LineProperties {
-// y = mx + b
-  final case class LineComponents(m: Double, b: Double) extends LineProperties
-  case object ParallelToAxisY                           extends LineProperties
-  case object InvalidLine                               extends LineProperties
-}
-
-sealed trait IntersectionResult {
-  def toOption: Option[Vertex]
-  def toList: List[Vertex]
-}
-object IntersectionResult {
-  final case class IntersectionVertex(x: Double, y: Double) extends IntersectionResult {
-    def toVertex: Vertex =
-      Vertex(x, y)
-
-    def toOption: Option[Vertex] =
-      Some(toVertex)
-
-    def toList: List[Vertex] =
-      List(toVertex)
-  }
-  case object NoIntersection extends IntersectionResult {
-    def toOption: Option[Vertex] = None
-    def toList: List[Vertex]     = Nil
-  }
 }

--- a/indigo/indigo-extras/src/main/scala/indigoextras/geometry/LineSegment.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/geometry/LineSegment.scala
@@ -45,7 +45,7 @@ final case class LineSegment(start: Vertex, end: Vertex) {
   def moveEndTo(x: Double, y: Double): LineSegment =
     moveEndTo(Vertex(x, y))
   def moveEndBy(amount: Vertex): LineSegment =
-    moveEndTo(start + amount)
+    moveEndTo(end + amount)
   def moveEndBy(x: Double, y: Double): LineSegment =
     moveEndBy(Vertex(x, y))
 
@@ -80,7 +80,7 @@ final case class LineSegment(start: Vertex, end: Vertex) {
   def isFacingVertex(vertex: Vertex): Boolean =
     LineSegment.isFacingVertex(this, vertex)
 
-  def closestPointOnLine(to: Vertex): Vertex = {
+  def closestPointOnLine(to: Vertex): Option[Vertex] = {
     val a   = end.y - start.y
     val b   = start.x - end.x
     val c1  = a * start.x + b * start.y
@@ -88,12 +88,14 @@ final case class LineSegment(start: Vertex, end: Vertex) {
     val det = a * a - -b * b
 
     if (det != 0.0)
-      Vertex(
-        x = (a * c1 - b * c2) / det,
-        y = (a * c2 - -b * c1) / det
+      Some(
+        Vertex(
+          x = (a * c1 - b * c2) / det,
+          y = (a * c2 - -b * c1) / det
+        ).clamp(start, end)
       )
     else
-      Vertex.zero
+      None
   }
 
   def ===(other: LineSegment): Boolean =

--- a/indigo/indigo-extras/src/main/scala/indigoextras/geometry/Polygon.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/geometry/Polygon.scala
@@ -41,7 +41,7 @@ sealed trait Polygon {
     }
 
   def lineIntersectCheck(lineSegment: LineSegment): Boolean =
-    lineSegments.exists(_.intersectWithLine(lineSegment))
+    lineSegments.exists(_.intersectsWithLine(lineSegment))
 
   def rectangleIntersectCheck(rectangle: Rectangle): Boolean =
     Polygon.fromRectangle(rectangle).lineSegments.exists(lineIntersectCheck)

--- a/indigo/indigo-extras/src/main/scala/indigoextras/geometry/Vertex.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/geometry/Vertex.scala
@@ -151,7 +151,7 @@ object Vertex {
         val aa = x2.toDouble - x1.toDouble
         val bb = y2.toDouble - y1.toDouble
 
-        Math.sqrt(Math.abs((aa * aa) + (bb * bb)))
+        Math.sqrt(Math.abs(aa * aa + bb * bb))
     }
 
   def dotProduct(vec1: Vertex, vec2: Vertex): Double =

--- a/indigo/indigo-extras/src/main/scala/indigoextras/geometry/Vertex.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/geometry/Vertex.scala
@@ -13,6 +13,28 @@ final case class Vertex(x: Double, y: Double) {
   def withY(newY: Double): Vertex =
     this.copy(y = newY)
 
+  def dot(other: Vertex): Double =
+    Vertex.dotProduct(this, other)
+
+  def abs: Vertex =
+    Vertex(Math.abs(x), Math.abs(y))
+
+  def min(other: Vertex): Vertex =
+    Vertex(Math.min(other.x, x), Math.min(other.y, y))
+  def min(value: Double): Vertex =
+    Vertex(Math.min(value, x), Math.min(value, y))
+
+  def max(other: Vertex): Vertex =
+    Vertex(Math.max(other.x, x), Math.max(other.y, y))
+  def max(value: Double): Vertex =
+    Vertex(Math.max(value, x), Math.max(value, y))
+
+  def clamp(min: Double, max: Double): Vertex =
+    Vertex(Math.min(max, Math.max(min, x)), Math.min(max, Math.max(min, y)))
+
+  def length: Double =
+    distanceTo(Vertex.zero)
+
   def invert: Vertex =
     Vertex(-x, -y)
 
@@ -124,6 +146,9 @@ object Vertex {
 
         Math.sqrt(Math.abs((aa * aa) + (bb * bb)))
     }
+
+  def dotProduct(vec1: Vertex, vec2: Vertex): Double =
+    (vec1.x * vec2.x) + (vec1.y * vec2.y)
 
   def equalEnough(v1: Vertex, v2: Vertex, tolerance: Double): Boolean =
     v1.x >= v2.x - tolerance &&

--- a/indigo/indigo-extras/src/main/scala/indigoextras/geometry/Vertex.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/geometry/Vertex.scala
@@ -14,8 +14,8 @@ final case class Vertex(x: Double, y: Double) {
     this.copy(y = newY)
 
   /**
-   * Dot product. Here for convenience but really this is vector operation.
-   */
+    * Dot product. Here for convenience but really this is vector operation.
+    */
   def dot(other: Vertex): Double =
     Vertex.dotProduct(this, other)
 
@@ -34,6 +34,8 @@ final case class Vertex(x: Double, y: Double) {
 
   def clamp(min: Double, max: Double): Vertex =
     Vertex(Math.min(max, Math.max(min, x)), Math.min(max, Math.max(min, y)))
+  def clamp(min: Vertex, max: Vertex): Vertex =
+    Vertex(Math.min(max.x, Math.max(min.x, x)), Math.min(max.y, Math.max(min.y, y)))
 
   def length: Double =
     distanceTo(Vertex.zero)

--- a/indigo/indigo-extras/src/main/scala/indigoextras/geometry/Vertex.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/geometry/Vertex.scala
@@ -13,6 +13,9 @@ final case class Vertex(x: Double, y: Double) {
   def withY(newY: Double): Vertex =
     this.copy(y = newY)
 
+  /**
+   * Dot product. Here for convenience but really this is vector operation.
+   */
   def dot(other: Vertex): Double =
     Vertex.dotProduct(this, other)
 
@@ -53,6 +56,8 @@ final case class Vertex(x: Double, y: Double) {
 
   def scaleBy(vec: Vertex): Vertex =
     Vertex.multiply(this, vec)
+  def scaleBy(amount: Double): Vertex =
+    scaleBy(Vertex(amount))
 
   def round: Vertex =
     Vertex(Math.round(x).toDouble, Math.round(y).toDouble)

--- a/indigo/indigo-extras/src/test/scala/indigoextras/geometry/BoundingBoxTests.scala
+++ b/indigo/indigo-extras/src/test/scala/indigoextras/geometry/BoundingBoxTests.scala
@@ -158,4 +158,45 @@ class BoundingBoxTests extends munit.FunSuite {
     assertEquals(BoundingBox.expand(b, 50) === BoundingBox(-50, -40, 200, 105), true)
   }
 
+  test("signed distance function") {
+    val bb = BoundingBox(10, 20, 30, 40)
+
+    // TL
+    val tl = Vertex(5, 5)
+    assertEquals(bb.sdf(tl), tl.distanceTo(bb.topLeft))
+
+    // T
+    val t = Vertex(15, 0)
+    assertEquals(bb.sdf(t), t.distanceTo(Vertex(15, 20)))
+
+    // TR
+    val tr = Vertex(45, 5)
+    assertEquals(bb.sdf(tr), tr.distanceTo(bb.topRight))
+
+    // ML
+    val ml = Vertex(2, 25)
+    assertEquals(bb.sdf(ml), ml.distanceTo(Vertex(10, 25)))
+
+    // M
+    val m = Vertex(15, 25)
+    assertEquals(bb.sdf(m), -m.distanceTo(Vertex(10, 25)))
+
+    // MR
+    val mr = Vertex(55, 30)
+    assertEquals(bb.sdf(mr), mr.distanceTo(Vertex(40, 30)))
+
+    // BL
+    val bl = Vertex(5, 70)
+    assertEquals(bb.sdf(bl), bl.distanceTo(bb.bottomLeft))
+
+    // B
+    val b = Vertex(20, 80)
+    assertEquals(bb.sdf(b), b.distanceTo(Vertex(20, 60)))
+
+    // BR
+    val br = Vertex(45, 70)
+    assertEquals(bb.sdf(br), br.distanceTo(bb.bottomRight))
+
+  }
+
 }

--- a/indigo/indigo-extras/src/test/scala/indigoextras/geometry/BoundingBoxTests.scala
+++ b/indigo/indigo-extras/src/test/scala/indigoextras/geometry/BoundingBoxTests.scala
@@ -110,6 +110,11 @@ class BoundingBoxTests extends munit.FunSuite {
     )
   }
 
+  test("intersecting lines.detecting a hit") {
+    assert(BoundingBox(1, 1, 3, 3).lineIntersects(LineSegment((1d, 2d), (4d, 2.5d))))
+    assert(!BoundingBox(5, 5, 4, 4).lineIntersects(LineSegment((0d, 0d), (3d, 3d))))
+  }
+
   test("encompasing rectangles.should return true when A encompases B") {
     val a = BoundingBox(10, 10, 110, 110)
     val b = BoundingBox(20, 20, 10, 10)

--- a/indigo/indigo-extras/src/test/scala/indigoextras/geometry/BoundingCircleTests.scala
+++ b/indigo/indigo-extras/src/test/scala/indigoextras/geometry/BoundingCircleTests.scala
@@ -1,5 +1,164 @@
 package indigoextras.geometry
 
 class BoundingCircleTests extends munit.FunSuite {
-  //
+
+  test("contains") {
+    val c = BoundingCircle(Vertex(20, 20), 10)
+
+    assert(c.contains(Vertex(15, 15)))
+    assert(!c.contains(Vertex.zero))
+  }
+
+  test("expandToInclude") {
+    val c1 = BoundingCircle(Vertex(20, 20), 10)
+    val c2 = BoundingCircle(Vertex(40, 20), 5)
+    val c3 = BoundingCircle(Vertex(20, 20), 25)
+
+    assertEquals(c1.expandToInclude(c2), c3)
+  }
+
+  test("encompasses") {
+    val c1 = BoundingCircle(Vertex(20, 20), 10)
+    val c2 = BoundingCircle(Vertex(40, 20), 5)
+    val c3 = BoundingCircle(Vertex(20, 20), 25)
+
+    assert(c3.encompasses(c1))
+    assert(c3.encompasses(c2))
+    assert(!c1.encompasses(c2))
+  }
+
+  test("overlaps") {
+    val c1 = BoundingCircle(Vertex(20, 20), 10)
+    val c2 = BoundingCircle(Vertex(25, 25), 10)
+    val c3 = BoundingCircle(Vertex(10, 40), 10)
+
+    assert(c1 overlaps c2)
+    assert(!(c1 overlaps c3))
+  }
+
+  test("moveBy | moveTo") {
+    val c = BoundingCircle(Vertex(20, 20), 10)
+
+    assertEquals(c.moveBy(1, 2).position, Vertex(21, 22))
+    assertEquals(c.moveTo(1, 2).position, Vertex(1, 2))
+  }
+
+  test("resize") {
+    val c = BoundingCircle(Vertex(20, 20), 10)
+
+    assertEquals(c.resize(5).radius, 5.0d)
+  }
+
+  test("Constructor - fromTwoVertices") {
+    val c = BoundingCircle.fromTwoVertices(Vertex(5, 10), Vertex(5, -10))
+
+    assertEquals(c.position, Vertex(5, 10))
+    assertEquals(c.radius, 20.0d)
+  }
+
+  test("Constructor - fromVertices") {
+    val actual =
+      BoundingCircle.fromVertices(
+        List(
+          Vertex(10, 10), // tl
+          Vertex(20, 10), // tr
+          Vertex(20, 20), // br
+          Vertex(10, 20)  // bl
+        )
+      )
+
+    val expected =
+      BoundingCircle(Vertex(15, 15), Vertex(15, 15).distanceTo(Vertex(10, 10)))
+
+    assertEquals(actual, expected)
+  }
+
+  test("lineIntersects - miss") {
+    val c = BoundingCircle(Vertex(20, 20), 10)
+    val l = LineSegment(Vertex(0, 0), Vertex(5, 5))
+
+    assert(!c.lineIntersects(l))
+  }
+
+  test("lineIntersects - one point") {
+    val c = BoundingCircle(Vertex(20, 20), 10)
+    val l = LineSegment(Vertex(0, 10), Vertex(50, 10))
+
+    assert(c.lineIntersects(l))
+  }
+
+  test("lineIntersects - two points") {
+    val c = BoundingCircle(Vertex(20, 20), 10)
+    val l = LineSegment(Vertex(0, 15), Vertex(50, 15))
+
+    assert(c.lineIntersects(l))
+  }
+
+  test("lineIntersectsAt - miss") {
+    val c = BoundingCircle(Vertex(20, 20), 10)
+    val l = LineSegment(Vertex(0, 0), Vertex(5, 5))
+
+    assertEquals(c.lineIntersectsAt(l).toOption, None)
+  }
+
+  test("lineIntersectsAt - one point") {
+    val c = BoundingCircle(Vertex(20, 20), 10)
+    val l = LineSegment(Vertex(0, 10), Vertex(50, 10))
+
+    val expected =
+      Some(
+        List(
+          Vertex(20, 10)
+        )
+      )
+
+    assertEquals(c.lineIntersectsAt(l).toOption, expected)
+  }
+
+  test("lineIntersectsAt - two points") {
+    val c = BoundingCircle(Vertex(20, 20), 10)
+    val l = LineSegment(Vertex(0, 15), Vertex(50, 15))
+
+    val expected =
+      Some(
+        List(
+          Vertex(11, 15),
+          Vertex(29, 15)
+        )
+      )
+
+    val actual =
+      c.lineIntersectsAt(l)
+        .toOption
+        .map(_.map(_.round))
+
+    assertEquals(actual, expected)
+  }
+
+  test("signed distance function") {
+    val c = BoundingCircle(Vertex(20, 20), 10)
+
+    // top
+    assertEquals(c.sdf(Vertex(20, 1)), 9.0d)
+
+    // bottom
+    assertEquals(c.sdf(Vertex(20, 55)), 25.0d)
+
+    // left
+    assertEquals(c.sdf(Vertex(-10, 20)), 20.0d)
+
+    // right
+    assertEquals(c.sdf(Vertex(33, 20)), 3.0d)
+
+    // edge
+    assertEquals(c.sdf(Vertex(10, 20)), 0.0d)
+
+    // inside
+    assertEquals(c.sdf(Vertex(12, 20)), -2.0d)
+
+    // Diagonal
+    assertEquals(Math.round(c.sdf(Vertex.zero)).toDouble, 18.0d)
+
+  }
+
 }

--- a/indigo/indigo-extras/src/test/scala/indigoextras/geometry/BoundingCircleTests.scala
+++ b/indigo/indigo-extras/src/test/scala/indigoextras/geometry/BoundingCircleTests.scala
@@ -1,0 +1,5 @@
+package indigoextras.geometry
+
+class BoundingCircleTests extends munit.FunSuite {
+  //
+}

--- a/indigo/indigo-extras/src/test/scala/indigoextras/geometry/LineSegmentTests.scala
+++ b/indigo/indigo-extras/src/test/scala/indigoextras/geometry/LineSegmentTests.scala
@@ -1,8 +1,6 @@
 package indigoextras.geometry
 
 import indigo.shared.datatypes.Vector2
-import indigoextras.geometry.LineIntersectionResult._
-import indigoextras.geometry.Line._
 
 class LineSegmentTests extends munit.FunSuite {
 

--- a/indigo/indigo-extras/src/test/scala/indigoextras/geometry/LineSegmentTests.scala
+++ b/indigo/indigo-extras/src/test/scala/indigoextras/geometry/LineSegmentTests.scala
@@ -1,20 +1,10 @@
 package indigoextras.geometry
 
 import indigo.shared.datatypes.Vector2
-import indigoextras.geometry.IntersectionResult._
-import indigoextras.geometry.LineProperties._
+import indigoextras.geometry.LineIntersectionResult._
+import indigoextras.geometry.Line._
 
 class LineSegmentTests extends munit.FunSuite {
-
-  /*
-  y = mx + b
-
-  We're trying to calculate m and b where
-  m is the slope i.e. number of y units per x unit
-  b is the y-intersect i.e. the point on the y-axis where the line passes through it
-   */
-
-  // Repositioning
 
   test("moving the whole line segment") {
     val actual =
@@ -26,255 +16,88 @@ class LineSegmentTests extends munit.FunSuite {
     assertEquals(actual, expected)
   }
 
-  // Line calculations
-
-  test("calculating line components.should correctly calculate the line components.(0, 0) -> (2, 2)") {
-    val expected: LineComponents = LineComponents(1, 0)
-
-    assertEquals(LineSegment.calculateLineComponents(Vertex(0, 0), Vertex(2, 2)), expected)
-  }
-
-  test("calculating line components.should correctly calculate the line components.(2, 1) -> (3, 4)") {
-    val expected: LineComponents = LineComponents(3, -5)
-
-    assertEquals(LineSegment.calculateLineComponents(Vertex(2, 1), Vertex(3, 4)), expected)
-  }
-
-  test("calculating line components.should correctly calculate the line components.(2, 2) -> (2, -3)") {
-    // Does not work because you can't have m of 0 or b of infinity)
-    // i.e. lines parallel to x or y axis
-    // We're also getting a divide by 0 because ... / x - x = 0
-    val expected = ParallelToAxisY
-
-    assertEquals(LineSegment.calculateLineComponents(Vertex(2, 2), Vertex(2, -3)), expected)
-  }
-
-  test("calculating line components.should correctly identify a line parallel to the y-axis") {
-    //b = Infinity (or -Infinity)
-    assertEquals(LineSegment.calculateLineComponents(Vertex(1, 2), Vertex(1, -3)), ParallelToAxisY)
-  }
-
-  test("line intersections.should not intersect with a parallel lines") {
-    val actual: IntersectionResult = LineSegment.intersection(
-      LineSegment((-3d, 3d), (2d, 3d)),
-      LineSegment((1d, 1d), (-2d, 1d))
-    )
-
-    val expected = NoIntersection
-
-    assertEquals(actual, expected)
-  }
-
-  test("line intersections.should intersect lines at right angles to each other") {
-    val actual: IntersectionResult = LineSegment.intersection(
-      LineSegment((2d, 2d), (2d, -3d)),
-      LineSegment((-1d, -2d), (3d, -2d))
-    )
-
-    val expected: IntersectionVertex = IntersectionVertex(2, -2)
-
-    assertEquals(actual, expected)
-  }
-
-  test("line intersections.should intersect diagonally right angle lines") {
-    val actual: IntersectionResult = LineSegment.intersection(
-      LineSegment((1d, 1d), (5d, 5d)),
-      LineSegment((1d, 5d), (4d, 2d))
-    )
-
-    val expected: IntersectionVertex = IntersectionVertex(3, 3)
-
-    assertEquals(actual, expected)
-  }
-
-  test("line intersections.should intersect diagonally non-right angle lines") {
-    val actual: IntersectionResult = LineSegment.intersection(
-      LineSegment((1d, 5d), (3d, 1d)),
-      LineSegment((1d, 2d), (4d, 5d))
-    )
-
-    val expected: IntersectionVertex = IntersectionVertex(2, 3)
-
-    assertEquals(actual, expected)
-  }
-
-  test("line intersections.should intersect where one line is parallel to the y-axis") {
-    val actual: IntersectionResult = LineSegment.intersection(
-      LineSegment((4d, 1d), (4d, 4d)),
-      LineSegment((2d, 1d), (5d, 4d))
-    )
-
-    val expected: IntersectionVertex = IntersectionVertex(4, 3)
-
-    assertEquals(actual, expected)
-  }
-
-  test("line intersections.should intersect where one line is parallel to the x-axis") {
-    val actual: IntersectionResult = LineSegment.intersection(
-      LineSegment((1d, 2d), (5d, 2d)),
-      LineSegment((2d, 4d), (5d, 1d))
-    )
-
-    val expected: IntersectionVertex = IntersectionVertex(4, 2)
-
-    assertEquals(actual, expected)
-  }
-
-  test("line intersections.should give the same intersection regardless of order") {
-    val actual1: IntersectionResult = LineSegment.intersection(
-      LineSegment((0d, 15d), (50d, 15d)),
-      LineSegment((10d, 10d), (10d, 30d))
-    )
-
-    val actual2: IntersectionResult = LineSegment.intersection(
-      LineSegment((0d, 15d), (50d, 15d)),
-      LineSegment((10d, 10d), (10d, 30d))
-    )
-
-    val expected: IntersectionVertex = IntersectionVertex(10, 15)
-
-    assertEquals(actual1, expected)
-    assertEquals(actual2, expected)
-    assertEquals(actual1, actual2)
-  }
-
-  test("line intersections.should intersect diagonally right angle lines (again)") {
-    val actual: IntersectionResult = LineSegment.intersection(
-      LineSegment((0d, 0d), (5d, 5d)),
-      LineSegment((0d, 5d), (5d, 0d))
-    )
-
-    val expected: IntersectionVertex = IntersectionVertex(2.5f, 2.5f)
-
-    assertEquals(actual, expected)
-  }
-
-  test("line intersections.Intersection use case A") {
-
-    val actual: IntersectionResult = LineSegment.intersection(
-      LineSegment((0.0, 0.0), (5.0, 5.0)),
-      LineSegment((0.0, 3.0), (5.0, 3.0))
-    )
-
-    val expected: IntersectionVertex = IntersectionVertex(3d, 3d)
-
-    assertEquals(actual, expected)
-
-  }
-
-  test("line intersections.Intersection use case B") {
-    val lineA = LineSegment((0.0, 0.0), (0.0, 5.0))
-    val lineB = LineSegment((0.0, 0.5), (5.0, 3.0))
-
-    val actual: IntersectionResult = LineSegment.intersection(
-      lineA,
-      lineB
-    )
-
-    val expected: IntersectionVertex = IntersectionVertex(0.0, 0.5)
-
-    assertEquals(actual, expected)
-
-    assertEquals(lineA.intersectWithLine(lineB), true)
-  }
-
   test("normals.should calculate the normal for a horizontal line (Left -> Right)") {
     val start: Vertex = Vertex(-10, 1)
     val end: Vertex   = Vertex(10, 1)
+    val line          = LineSegment(start, end)
 
-    assertEquals(LineSegment.calculateNormal(start, end) === Vector2(0, 1), true)
+    assertEquals(line.normal === Vector2(0, 1), true)
   }
 
   test("normals.should calculate the normal for a horizontal line (Right -> Left)") {
     val start: Vertex = Vertex(5, 2)
     val end: Vertex   = Vertex(-5, 2)
+    val line          = LineSegment(start, end)
 
-    assertEquals(LineSegment.calculateNormal(start, end) === Vector2(0, -1), true)
+    assertEquals(line.normal === Vector2(0, -1), true)
   }
 
   test("normals.should calculate the normal for a vertical line (Top -> Bottom") {
     val start: Vertex = Vertex(-1, 10)
     val end: Vertex   = Vertex(-1, -10)
+    val line          = LineSegment(start, end)
 
-    assertEquals(LineSegment.calculateNormal(start, end) === Vector2(1, 0), true)
+    assertEquals(line.normal === Vector2(1, 0), true)
   }
 
   test("normals.should calculate the normal for a vertical line (Bottom -> Top") {
     val start: Vertex = Vertex(1, -10)
     val end: Vertex   = Vertex(1, 10)
+    val line          = LineSegment(start, end)
 
-    assertEquals(LineSegment.calculateNormal(start, end) === Vector2(-1, 0), true)
+    assertEquals(line.normal === Vector2(-1, 0), true)
   }
 
   test("normals.should calculate the normal for a diagonal line") {
     val start: Vertex = Vertex(2, 2)
     val end: Vertex   = Vertex(-2, -2)
+    val line          = LineSegment(start, end)
 
-    assertEquals(LineSegment.calculateNormal(start, end) === Vector2(1, -1), true)
+    assertEquals(line.normal === Vector2(1, -1), true)
   }
 
-  test("Normalising a point.should be able to normalise a point.10, 10") {
-    assertEquals(LineSegment.normaliseVertex(Vector2(10, 10)) === Vector2(1, 1), true)
-  }
-
-  test("Normalising a point.should be able to normalise a point.-10, -10") {
-    assertEquals(LineSegment.normaliseVertex(Vector2(-10, -10)) === Vector2(-1, -1), true)
-  }
-
-  test("Normalising a point.should be able to normalise a point.10, 0") {
-    assertEquals(LineSegment.normaliseVertex(Vector2(10, 0)) === Vector2(1, 0), true)
-  }
-
-  test("Normalising a point.should be able to normalise a point.0, 10") {
-    assertEquals(LineSegment.normaliseVertex(Vector2(0, 10)) === Vector2(0, 1), true)
-  }
-
-  test("Normalising a point.should be able to normalise a point.-50, 1000") {
-    assertEquals(LineSegment.normaliseVertex(Vector2(-50, 1000)) === Vector2(-1, 1), true)
-  }
-
-  test("Vertexs & Lines.Facing a point.facing") {
+  test("Vertexs & Lines.Facing a vertex.facing") {
     val line: LineSegment = LineSegment((1d, 5d), (9d, 5d))
-    val point: Vertex     = Vertex(5, 20)
+    val vertex: Vertex    = Vertex(5, 20)
 
-    assertEquals(line.isFacingVertex(point), true)
+    assertEquals(line.isFacingVertex(vertex), true)
   }
 
-  test("Vertexs & Lines.Facing a point.not facing") {
+  test("Vertexs & Lines.Facing a vertex.not facing") {
     val line: LineSegment = LineSegment((1d, 5d), (9d, 5d))
-    val point: Vertex     = Vertex(5, 2)
+    val vertex: Vertex    = Vertex(5, 2)
 
-    assertEquals(line.isFacingVertex(point), false)
+    assertEquals(line.isFacingVertex(vertex), false)
   }
 
-  //TODO: Can do a property based check here. Forall points on a line
-  // (i.e. start point * slope m < end point)
-  test("Vertex on a line.should be able to check if a point is on a line.horizontal") {
+  //TODO: Can do a property based check here. Forall vertices on a line
+  // (i.e. start vertex * slope m < end vertex)
+  test("Vertex on a line.should be able to check if a vertex is on a line.horizontal") {
     val line: LineSegment = LineSegment((10d, 10d), (20d, 10d))
-    val point: Vertex     = Vertex(15, 10)
+    val vertex: Vertex    = Vertex(15, 10)
 
-    assertEquals(LineSegment.lineContainsVertex(line, point), true)
+    assert(line.contains(vertex))
   }
 
-  test("Vertex on a line.should be able to check if a point is on a line.vertical") {
+  test("Vertex on a line.should be able to check if a vertex is on a line.vertical") {
     val line: LineSegment = LineSegment((10d, 10d), (10d, 20d))
-    val point: Vertex     = Vertex(10, 15)
+    val vertex: Vertex    = Vertex(10, 15)
 
-    assertEquals(LineSegment.lineContainsVertex(line, point), true)
+    assert(line.contains(vertex))
   }
 
-  test("Vertex on a line.should be able to check if a point is on a line.diagonal") {
+  test("Vertex on a line.should be able to check if a vertex is on a line.diagonal") {
     val line: LineSegment = LineSegment((10d, 10d), (20d, 20d))
-    val point: Vertex     = Vertex(15, 15)
+    val vertex: Vertex    = Vertex(15, 15)
 
-    assertEquals(LineSegment.lineContainsVertex(line, point), true)
+    assert(line.contains(vertex))
   }
 
-  test("Vertex on a line.should be able to check if a point is NOT on a line") {
+  test("Vertex on a line.should be able to check if a vertex is NOT on a line") {
     val line: LineSegment = LineSegment((10d, 10d), (20d, 20d))
-    val point: Vertex     = Vertex(1, 5)
+    val vertex: Vertex    = Vertex(1, 5)
 
-    assertEquals(LineSegment.lineContainsVertex(line, point), false)
+    assert(!line.contains(vertex))
   }
 
   test("moveTo | moveBy | moveStartTo | moveStartBy | moveEndTo | moveEndBy") {
@@ -296,7 +119,7 @@ class LineSegmentTests extends munit.FunSuite {
     assertEquals(LineSegment((10d, 10d), (20d, 20d)).flip, LineSegment((20d, 20d), (10d, 10d)))
   }
 
-  test("Finding the closet point on the line to a vertex") {
+  test("Finding the closet vertex on the line to a vertex") {
     val line: LineSegment = LineSegment((10d, 10d), (20d, 20d))
 
     // before line
@@ -325,6 +148,25 @@ class LineSegmentTests extends munit.FunSuite {
 
     // end
     assertEquals(line.sdf(Vertex(25, 25)), Math.sqrt(5 * 5 + 5 * 5))
+  }
+
+
+  test("line intersections.Intersection use case A") {
+
+    val lineA = LineSegment((0.0, 0.0), (5.0, 5.0))
+    val lineB = LineSegment((0.0, 3.0), (5.0, 3.0))
+
+    assert(lineA.intersectsWithLine(lineB))
+    assertEquals(lineA.intersectsAt(lineB), Some(Vertex(3d, 3d)))
+
+  }
+
+  test("line intersections.Intersection use case B") {
+    val lineA = LineSegment((0.0, 0.0), (0.0, 5.0))
+    val lineB = LineSegment((0.0, 0.5), (5.0, 3.0))
+
+    assert(lineA.intersectsWithLine(lineB))
+    assertEquals(lineA.intersectsAt(lineB), Some(Vertex(0.0, 0.5)))
   }
 
 }

--- a/indigo/indigo-extras/src/test/scala/indigoextras/geometry/LineSegmentTests.scala
+++ b/indigo/indigo-extras/src/test/scala/indigoextras/geometry/LineSegmentTests.scala
@@ -277,4 +277,54 @@ class LineSegmentTests extends munit.FunSuite {
     assertEquals(LineSegment.lineContainsVertex(line, point), false)
   }
 
+  test("moveTo | moveBy | moveStartTo | moveStartBy | moveEndTo | moveEndBy") {
+
+    val line: LineSegment = LineSegment((10d, 10d), (20d, 20d))
+
+    assertEquals(line.moveTo(1, 2), LineSegment((1d, 2d), (11d, 12d)))
+    assertEquals(line.moveBy(1, 2), LineSegment((11d, 12d), (21d, 22d)))
+
+    assertEquals(line.moveStartTo(1, 2), LineSegment((1d, 2d), (20d, 20d)))
+    assertEquals(line.moveStartBy(1, 2), LineSegment((11d, 12d), (20d, 20d)))
+
+    assertEquals(line.moveEndTo(1, 2), LineSegment((10d, 10d), (1d, 2d)))
+    assertEquals(line.moveEndBy(1, 2), LineSegment((10d, 10d), (21d, 22d)))
+  }
+
+  test("invert | flip") {
+    assertEquals(LineSegment((10d, 10d), (20d, 20d)).invert, LineSegment((20d, 20d), (10d, 10d)))
+    assertEquals(LineSegment((10d, 10d), (20d, 20d)).flip, LineSegment((20d, 20d), (10d, 10d)))
+  }
+
+  test("Finding the closet point on the line to a vertex") {
+    val line: LineSegment = LineSegment((10d, 10d), (20d, 20d))
+
+    // before line
+    assertEquals(line.closestPointOnLine(Vertex(1, 1)), Some(line.start))
+    assertEquals(line.closestPointOnLine(Vertex(10, 10)), Some(line.start))
+
+    // some where in the middle
+    assertEquals(line.closestPointOnLine(Vertex(15, 10)), Some(Vertex(12.5, 12.5)))
+    assertEquals(line.closestPointOnLine(Vertex(15, 15)), Some(Vertex(15, 15)))
+    assertEquals(line.closestPointOnLine(Vertex(15, 20)), Some(Vertex(17.5, 17.5)))
+
+    // past line
+    assertEquals(line.closestPointOnLine(Vertex(20, 20)), Some(line.end))
+    assertEquals(line.closestPointOnLine(Vertex(27, 21)), Some(line.end))
+  }
+
+  test("signed distance function") {
+    val line: LineSegment = LineSegment((10d, 10d), (20d, 20d))
+
+    // start
+    assertEquals(line.sdf(Vertex(0, 10)), 10.0d)
+
+    assertEquals(line.sdf(Vertex(15, 10)), Vertex(15, 10).distanceTo(Vertex(12.5, 12.5)))
+    assertEquals(line.sdf(Vertex(15, 15)), 0.0d)
+    assertEquals(line.sdf(Vertex(15, 20)), Vertex(15, 20).distanceTo(Vertex(17.5, 17.5)))
+
+    // end
+    assertEquals(line.sdf(Vertex(25, 25)), Math.sqrt(5 * 5 + 5 * 5))
+  }
+
 }

--- a/indigo/indigo-extras/src/test/scala/indigoextras/geometry/LineTests.scala
+++ b/indigo/indigo-extras/src/test/scala/indigoextras/geometry/LineTests.scala
@@ -1,6 +1,5 @@
 package indigoextras.geometry
 
-import indigo.shared.datatypes.Vector2
 import indigoextras.geometry.LineIntersectionResult._
 import indigoextras.geometry.LineSegment
 

--- a/indigo/indigo-extras/src/test/scala/indigoextras/geometry/LineTests.scala
+++ b/indigo/indigo-extras/src/test/scala/indigoextras/geometry/LineTests.scala
@@ -1,0 +1,167 @@
+package indigoextras.geometry
+
+import indigo.shared.datatypes.Vector2
+import indigoextras.geometry.LineIntersectionResult._
+import indigoextras.geometry.LineSegment
+
+class LineTests extends munit.FunSuite {
+
+  /*
+  y = mx + b
+
+  We're trying to calculate m and b where
+  m is the slope i.e. number of y units per x unit
+  b is the y-intersect i.e. the point on the y-axis where the line passes through it
+   */
+
+  // Line calculations
+
+  test("calculating line components.should correctly calculate the line components.(0, 0) -> (2, 2)") {
+    val expected: Line.Components = Line.Components(1, 0)
+
+    assertEquals(Line.fromLineSegment(LineSegment(Vertex(0, 0), Vertex(2, 2))), expected)
+  }
+
+  test("calculating line components.should correctly calculate the line components.(2, 1) -> (3, 4)") {
+    val expected: Line.Components = Line.Components(3, -5)
+
+    assertEquals(Line.fromLineSegment(LineSegment(Vertex(2, 1), Vertex(3, 4))), expected)
+  }
+
+  test("calculating line components.should correctly calculate the line components.(2, 2) -> (2, -3)") {
+    // Does not work because you can't have m of 0 or b of infinity)
+    // i.e. lines parallel to x or y axis
+    // We're also getting a divide by 0 because ... / x - x = 0
+    val expected: Line = Line.ParallelToAxisY(2)
+
+    assertEquals(Line.fromLineSegment(LineSegment(Vertex(2, 2), Vertex(2, -3))), expected)
+  }
+
+  test("calculating line components.should correctly identify a line parallel to the y-axis") {
+    //b = Infinity (or -Infinity)
+    assertEquals(Line.fromLineSegment(LineSegment(Vertex(1, 2), Vertex(1, -3))), Line.ParallelToAxisY(1))
+  }
+
+  test("line intersections.should not intersect with a parallel lines") {
+    val actual: LineIntersectionResult = Line.intersection(
+      LineSegment((-3d, 3d), (2d, 3d)).toLine,
+      LineSegment((1d, 1d), (-2d, 1d)).toLine
+    )
+
+    val expected = NoIntersection
+
+    assertEquals(actual, expected)
+  }
+
+  test("line intersections.should intersect lines at right angles to each other") {
+    val actual: LineIntersectionResult = Line.intersection(
+      LineSegment((2d, 2d), (2d, -3d)).toLine,
+      LineSegment((-1d, -2d), (3d, -2d)).toLine
+    )
+
+    val expected: IntersectionVertex = IntersectionVertex(2, -2)
+
+    assertEquals(actual, expected)
+  }
+
+  test("line intersections.should intersect diagonally right angle lines") {
+    val actual: LineIntersectionResult = Line.intersection(
+      LineSegment((1d, 1d), (5d, 5d)).toLine,
+      LineSegment((1d, 5d), (4d, 2d)).toLine
+    )
+
+    val expected: IntersectionVertex = IntersectionVertex(3, 3)
+
+    assertEquals(actual, expected)
+  }
+
+  test("line intersections.should intersect diagonally non-right angle lines") {
+    val actual: LineIntersectionResult = Line.intersection(
+      LineSegment((1d, 5d), (3d, 1d)).toLine,
+      LineSegment((1d, 2d), (4d, 5d)).toLine
+    )
+
+    val expected: IntersectionVertex = IntersectionVertex(2, 3)
+
+    assertEquals(actual, expected)
+  }
+
+  test("line intersections.should intersect where one line is parallel to the y-axis") {
+    val actual: LineIntersectionResult = Line.intersection(
+      LineSegment((4d, 1d), (4d, 4d)).toLine,
+      LineSegment((2d, 1d), (5d, 4d)).toLine
+    )
+
+    val expected: IntersectionVertex = IntersectionVertex(4, 3)
+
+    assertEquals(actual, expected)
+  }
+
+  test("line intersections.should intersect where one line is parallel to the x-axis") {
+    val actual: LineIntersectionResult = Line.intersection(
+      LineSegment((1d, 2d), (5d, 2d)).toLine,
+      LineSegment((2d, 4d), (5d, 1d)).toLine
+    )
+
+    val expected: IntersectionVertex = IntersectionVertex(4, 2)
+
+    assertEquals(actual, expected)
+  }
+
+  test("line intersections.should give the same intersection regardless of order") {
+    val actual1: LineIntersectionResult = Line.intersection(
+      LineSegment((0d, 15d), (50d, 15d)).toLine,
+      LineSegment((10d, 10d), (10d, 30d)).toLine
+    )
+
+    val actual2: LineIntersectionResult = Line.intersection(
+      LineSegment((0d, 15d), (50d, 15d)).toLine,
+      LineSegment((10d, 10d), (10d, 30d)).toLine
+    )
+
+    val expected: IntersectionVertex = IntersectionVertex(10, 15)
+
+    assertEquals(actual1, expected)
+    assertEquals(actual2, expected)
+    assertEquals(actual1, actual2)
+  }
+
+  test("line intersections.should intersect diagonally right angle lines (again)") {
+    val actual: LineIntersectionResult = Line.intersection(
+      LineSegment((0d, 0d), (5d, 5d)).toLine,
+      LineSegment((0d, 5d), (5d, 0d)).toLine
+    )
+
+    val expected: IntersectionVertex = IntersectionVertex(2.5f, 2.5f)
+
+    assertEquals(actual, expected)
+  }
+
+  test("line intersections.Intersection use case A") {
+
+    val actual: LineIntersectionResult = Line.intersection(
+      LineSegment((0.0, 0.0), (5.0, 5.0)).toLine,
+      LineSegment((0.0, 3.0), (5.0, 3.0)).toLine
+    )
+
+    val expected: IntersectionVertex = IntersectionVertex(3d, 3d)
+
+    assertEquals(actual, expected)
+
+  }
+
+  test("line intersections.Intersection use case B") {
+    val lineA = LineSegment((0.0, 0.0), (0.0, 5.0)).toLine
+    val lineB = LineSegment((0.0, 0.5), (5.0, 3.0)).toLine
+
+    val actual: LineIntersectionResult = Line.intersection(
+      lineA,
+      lineB
+    )
+
+    val expected: IntersectionVertex = IntersectionVertex(0.0, 0.5)
+
+    assertEquals(actual, expected)
+  }
+
+}

--- a/indigo/indigo-extras/src/test/scala/indigoextras/geometry/VertexTests.scala
+++ b/indigo/indigo-extras/src/test/scala/indigoextras/geometry/VertexTests.scala
@@ -1,6 +1,11 @@
 package indigoextras.geometry
 
+import indigo.shared.datatypes.Vector2
+
 class VertexTests extends munit.FunSuite {
+
+  def nearEnoughEqual(d1: Double, d2: Double, tolerance: Double): Boolean =
+    d1 >= d2 - tolerance && d1 <= d2 + tolerance
 
   test("Distance.horizontal distance") {
     assertEquals(Vertex.zero.distanceTo(Vertex(10, 0)), 10d)
@@ -27,7 +32,84 @@ class VertexTests extends munit.FunSuite {
     assertEquals(nearEnoughEqual(Vertex(0.0, 0.0).distanceTo(Vertex(100.0, 100.0)), c, 0.025d), true)
   }
 
-  def nearEnoughEqual(d1: Double, d2: Double, tolerance: Double): Boolean =
-    d1 >= d2 - tolerance && d1 <= d2 + tolerance
+  test("dot product") {
+    assert(clue(Vertex(1, 0).dot(Vertex(1, 0))) == 1)
+    assert(clue(Vertex(1, 0).dot(Vertex(0, -1))) == 0)
+    assert(clue(Vertex(-1, 0).dot(Vertex(1, 0))) == -1)
+    assert(clue(Vertex(1, 0).dot(Vertex(-1, 0))) == -1)
+  }
+
+  test("abs") {
+    assertEquals(Vertex(1, 1).abs, Vertex(1, 1))
+    assertEquals(Vertex(-1, 1).abs, Vertex(1, 1))
+    assertEquals(Vertex(1, -1).abs, Vertex(1, 1))
+    assertEquals(Vertex(-1, -1).abs, Vertex(1, 1))
+  }
+
+  test("min") {
+    assertEquals(Vertex(10, 10).min(1), Vertex(1, 1))
+    assertEquals(Vertex(10, 10).min(100), Vertex(10, 10))
+    assertEquals(Vertex(10, 10).min(Vertex(50, 5)), Vertex(10, 5))
+  }
+
+  test("max") {
+    assertEquals(Vertex(10, 10).max(1), Vertex(10, 10))
+    assertEquals(Vertex(10, 10).max(100), Vertex(100, 100))
+    assertEquals(Vertex(10, 10).max(Vertex(50, 5)), Vertex(50, 10))
+  }
+
+  test("clamp") {
+    assertEquals(Vertex(0.1, 0.1).clamp(0, 1), Vertex(0.1, 0.1))
+    assertEquals(Vertex(-0.1, 1.1).clamp(0, 1), Vertex(0.0, 1.0))
+    assertEquals(Vertex(1, 4).clamp(2, 3), Vertex(2, 3))
+  }
+
+  test("length") {
+    assertEquals(Vertex(10, 0).length, 10.0)
+    assertEquals(Vertex(0, 10).length, 10.0)
+    assert(nearEnoughEqual(Vertex(10, 10).length, 14.14d, 0.01))
+  }
+
+  test("invert") {
+    assertEquals(Vertex(1, 1).invert, Vertex(-1, -1))
+    assertEquals(Vertex(-1, 1).invert, Vertex(1, -1))
+    assertEquals(Vertex(1, -1).invert, Vertex(-1, 1))
+    assertEquals(Vertex(-1, -1).invert, Vertex(1, 1))
+  }
+
+  test("translate | moveBy | moveTo") {
+    assertEquals(Vertex(1, 1).translate(Vertex(10, 10)), Vertex(11, 11))
+    assertEquals(Vertex(1, 1).moveBy(Vertex(10, 10)), Vertex(11, 11))
+    assertEquals(Vertex(1, 1).moveTo(Vertex(10, 10)), Vertex(10, 10))
+  }
+
+  test("scaleBy") {
+    assertEquals(Vertex(2, 2).scaleBy(Vertex(10, 2)), Vertex(20, 4))
+  }
+
+  test("round") {
+    assertEquals(Vertex(2.2, 2.6).round, Vertex(2, 3))
+  }
+
+  test("twoVerticesToVector2") {
+    assertEquals(Vertex.twoVerticesToVector2(Vertex(2, 2), Vertex(1, 5)), Vector2(-1, 3))
+  }
+
+  /*
+  also applies to vector...
+  dot
+  abs
+  min
+  max
+  clamp
+  length
+  invert
+  translate
+  moveTo
+  moveBy
+  scaleBy
+  round
+  twoVerticesToVector2
+   */
 
 }

--- a/indigo/indigo-extras/src/test/scala/indigoextras/geometry/VertexTests.scala
+++ b/indigo/indigo-extras/src/test/scala/indigoextras/geometry/VertexTests.scala
@@ -95,21 +95,4 @@ class VertexTests extends munit.FunSuite {
     assertEquals(Vertex.twoVerticesToVector2(Vertex(2, 2), Vertex(1, 5)), Vector2(-1, 3))
   }
 
-  /*
-  also applies to vector...
-  dot
-  abs
-  min
-  max
-  clamp
-  length
-  invert
-  translate
-  moveTo
-  moveBy
-  scaleBy
-  round
-  twoVerticesToVector2
-   */
-
 }

--- a/indigo/indigo-extras/src/test/scala/indigoextras/geometry/VertexTests.scala
+++ b/indigo/indigo-extras/src/test/scala/indigoextras/geometry/VertexTests.scala
@@ -58,10 +58,19 @@ class VertexTests extends munit.FunSuite {
     assertEquals(Vertex(10, 10).max(Vertex(50, 5)), Vertex(50, 10))
   }
 
-  test("clamp") {
+  test("clamp (double)") {
     assertEquals(Vertex(0.1, 0.1).clamp(0, 1), Vertex(0.1, 0.1))
     assertEquals(Vertex(-0.1, 1.1).clamp(0, 1), Vertex(0.0, 1.0))
     assertEquals(Vertex(1, 4).clamp(2, 3), Vertex(2, 3))
+  }
+
+  test("clamp (vertex)") {
+    assertEquals(Vertex(0.1, 0.1).clamp(Vertex(0, 0), Vertex(1, 1)), Vertex(0.1, 0.1))
+    assertEquals(Vertex(-0.1, 1.1).clamp(Vertex(0, 0), Vertex(1, 1)), Vertex(0.0, 1.0))
+
+    assertEquals(Vertex(1, 4).clamp(Vertex(10, 20), Vertex(30, 40)), Vertex(10, 20))
+    assertEquals(Vertex(12, 33).clamp(Vertex(10, 20), Vertex(30, 40)), Vertex(12, 33))
+    assertEquals(Vertex(50, 100).clamp(Vertex(10, 20), Vertex(30, 40)), Vertex(30, 40))
   }
 
   test("length") {

--- a/indigo/indigo-platforms/src/main/scala/indigo/platform/Platform.scala
+++ b/indigo/indigo-platforms/src/main/scala/indigo/platform/Platform.scala
@@ -85,7 +85,7 @@ class Platform(
           .map { p =>
             p._1 -> new TextureRefAndOffset(
               atlasName = p._2.id.id,
-              atlasSize = textureAtlas.atlases.get(p._2.id).map(_.size.value).map(Vector2.apply).getOrElse(Vector2.one),
+              atlasSize = textureAtlas.atlases.get(p._2.id).map(_.size.value).map(i => Vector2(i.toDouble)).getOrElse(Vector2.one),
               offset = p._2.offset
             )
           }

--- a/indigo/shared/src/main/scala/indigo/shared/datatypes/Vector2.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/datatypes/Vector2.scala
@@ -11,6 +11,25 @@ final case class Vector2(x: Double, y: Double) {
   def withY(newY: Double): Vector2 =
     this.copy(y = newY)
 
+  def abs: Vector2 =
+    Vector2(Math.abs(x), Math.abs(y))
+
+  def min(other: Vector2): Vector2 =
+    Vector2(Math.min(other.x, x), Math.min(other.y, y))
+  def min(value: Double): Vector2 =
+    Vector2(Math.min(value, x), Math.min(value, y))
+
+  def max(other: Vector2): Vector2 =
+    Vector2(Math.max(other.x, x), Math.max(other.y, y))
+  def max(value: Double): Vector2 =
+    Vector2(Math.max(value, x), Math.max(value, y))
+
+  def clamp(min: Double, max: Double): Vector2 =
+    Vector2(Math.min(max, Math.max(min, x)), Math.min(max, Math.max(min, y)))
+
+  def length: Double =
+    distanceTo(Vector2.zero)
+
   def invert: Vector2 =
     Vector2(-x, -y)
 

--- a/indigo/shared/src/main/scala/indigo/shared/datatypes/Vector2.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/datatypes/Vector2.scala
@@ -36,8 +36,20 @@ final case class Vector2(x: Double, y: Double) {
   def translate(vec: Vector2): Vector2 =
     Vector2.add(this, vec)
 
-  def scale(vec: Vector2): Vector2 =
+  def moveTo(newPosition: Vector2): Vector2 =
+    newPosition
+  def moveTo(x: Double, y: Double): Vector2 =
+    moveTo(Vector2(x, y))
+
+  def moveBy(amount: Vector2): Vector2 =
+    Vector2.add(this, amount)
+  def moveBy(x: Double, y: Double): Vector2 =
+    moveBy(Vector2(x, y))
+
+  def scaleBy(vec: Vector2): Vector2 =
     Vector2.multiply(this, vec)
+  def scaleBy(amount: Double): Vector2 =
+    scaleBy(Vector2(amount))
 
   def round: Vector2 =
     Vector2(Math.round(x).toDouble, Math.round(y).toDouble)
@@ -95,8 +107,8 @@ object Vector2 {
     }
   }
 
-  def apply(i: Int): Vector2 =
-    Vector2(i.toDouble, i.toDouble)
+  def apply(d: Double): Vector2 =
+    Vector2(d, d)
 
   val zero: Vector2     = Vector2(0d, 0d)
   val one: Vector2      = Vector2(1d, 1d)

--- a/indigo/shared/src/main/scala/indigo/shared/datatypes/Vector3.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/datatypes/Vector3.scala
@@ -14,6 +14,25 @@ final case class Vector3(x: Double, y: Double, z: Double) {
   def withZ(newZ: Double): Vector3 =
     this.copy(z = newZ)
 
+  def abs: Vector3 =
+    Vector3(Math.abs(x), Math.abs(y), Math.abs(z))
+
+  def min(other: Vector3): Vector3 =
+    Vector3(Math.min(other.x, x), Math.min(other.y, y), Math.min(other.z, z))
+  def min(value: Double): Vector3 =
+    Vector3(Math.min(value, x), Math.min(value, y), Math.min(value, z))
+
+  def max(other: Vector3): Vector3 =
+    Vector3(Math.max(other.x, x), Math.max(other.y, y), Math.max(other.z, z))
+  def max(value: Double): Vector3 =
+    Vector3(Math.max(value, x), Math.max(value, y), Math.max(value, z))
+
+  def clamp(min: Double, max: Double): Vector3 =
+    Vector3(Math.min(max, Math.max(min, x)), Math.min(max, Math.max(min, y)), Math.min(max, Math.max(min, z)))
+
+  def length: Double =
+    distanceTo(Vector3.zero)
+
   def translate(vec: Vector3): Vector3 =
     Vector3.add(this, vec)
 
@@ -51,6 +70,9 @@ final case class Vector3(x: Double, y: Double, z: Double) {
   def toVector2: Vector2 =
     Vector2(x, y)
 
+  def distanceTo(other: Vector3): Double =
+    Vector3.distance(this, other)
+
   def ===(other: Vector3): Boolean =
     implicitly[EqualTo[Vector3]].equal(this, other)
 }
@@ -85,6 +107,9 @@ object Vector3 {
 
   def dotProduct(vec1: Vector3, vec2: Vector3): Double =
     (vec1.x * vec2.x) + (vec1.y * vec2.y) + (vec1.z * vec2.z)
+
+  def distance(v1: Vector3, v2: Vector3): Double =
+    Math.sqrt(Math.abs(Math.pow(v2.x - v1.x, 2) + Math.pow(v2.y - v1.y, 2) + Math.pow(v2.z - v1.z, 2)))
 
   def applyMatrix4(vector3: Vector3, matrix4: Matrix4): Vector3 = {
     val m  = matrix4.transpose

--- a/indigo/shared/src/main/scala/indigo/shared/datatypes/Vector4.scala
+++ b/indigo/shared/src/main/scala/indigo/shared/datatypes/Vector4.scala
@@ -17,6 +17,25 @@ final case class Vector4(x: Double, y: Double, z: Double, w: Double) {
   def withW(newW: Double): Vector4 =
     this.copy(w = newW)
 
+  def abs: Vector4 =
+    Vector4(Math.abs(x), Math.abs(y), Math.abs(z), Math.abs(w))
+
+  def min(other: Vector4): Vector4 =
+    Vector4(Math.min(other.x, x), Math.min(other.y, y), Math.min(other.z, z), Math.min(other.w, w))
+  def min(value: Double): Vector4 =
+    Vector4(Math.min(value, x), Math.min(value, y), Math.min(value, z), Math.min(value, w))
+
+  def max(other: Vector4): Vector4 =
+    Vector4(Math.max(other.x, x), Math.max(other.y, y), Math.max(other.z, z), Math.max(other.w, w))
+  def max(value: Double): Vector4 =
+    Vector4(Math.max(value, x), Math.max(value, y), Math.max(value, z), Math.max(value, w))
+
+  def clamp(min: Double, max: Double): Vector4 =
+    Vector4(Math.min(max, Math.max(min, x)), Math.min(max, Math.max(min, y)), Math.min(max, Math.max(min, z)), Math.min(max, Math.max(min, w)))
+
+  def length: Double =
+    distanceTo(Vector4.zero)
+
   def translate(vec: Vector4): Vector4 =
     Vector4.add(this, vec)
 
@@ -57,6 +76,9 @@ final case class Vector4(x: Double, y: Double, z: Double, w: Double) {
 
   def toVector3: Vector3 =
     Vector3(x, y, x)
+
+  def distanceTo(other: Vector4): Double =
+    Vector4.distance(this, other)
 
   override def toString: String =
     s"Vector4(x = ${x.toString()}, y = ${y.toString()}, z = ${z.toString()}, w = ${z.toString()})"
@@ -101,6 +123,9 @@ object Vector4 {
 
   def dotProduct(vec1: Vector4, vec2: Vector4): Double =
     (vec1.x * vec2.x) + (vec1.y * vec2.y) + (vec1.z * vec2.z) + (vec1.w * vec2.w)
+
+  def distance(v1: Vector4, v2: Vector4): Double =
+    Math.sqrt(Math.abs(Math.pow(v2.x - v1.x, 2) + Math.pow(v2.y - v1.y, 2) + Math.pow(v2.z - v1.z, 2) + Math.pow(v2.w - v1.w, 2)))
 
   def applyMatrix4(vector4: Vector4, matrix4: Matrix4): Vector4 = {
     val m  = matrix4.transpose

--- a/indigo/shared/src/test/scala/indigo/shared/display/SpriteSheetFrameTests.scala
+++ b/indigo/shared/src/test/scala/indigo/shared/display/SpriteSheetFrameTests.scala
@@ -16,17 +16,17 @@ class SpriteSheetFrameTests extends munit.FunSuite {
     val offset = SpriteSheetFrame.calculateFrameOffset(atlasSize, frameCrop, textureOffset)
 
     val textureCoordinate1   = Vector2(0, 0)
-    val resultingMultiplier1 = textureCoordinate1.scale(offset.scale).translate(offset.translate)
+    val resultingMultiplier1 = textureCoordinate1.scaleBy(offset.scale).translate(offset.translate)
 
     assertEquals(Vector2.multiply(atlasSize, resultingMultiplier1) === Vector2(74, 10), true)
 
     val textureCoordinate2   = Vector2(0.5, 0.5)
-    val resultingMultiplier2 = textureCoordinate2.scale(offset.scale).translate(offset.translate)
+    val resultingMultiplier2 = textureCoordinate2.scaleBy(offset.scale).translate(offset.translate)
 
     assertEquals(Vector2.multiply(atlasSize, resultingMultiplier2) === Vector2(106, 42), true)
 
     val textureCoordinate3   = Vector2(1, 1)
-    val resultingMultiplier3 = textureCoordinate3.scale(offset.scale).translate(offset.translate)
+    val resultingMultiplier3 = textureCoordinate3.scaleBy(offset.scale).translate(offset.translate)
 
     assertEquals(Vector2.multiply(atlasSize, resultingMultiplier3) === Vector2(138, 74.0), true)
 
@@ -41,17 +41,17 @@ class SpriteSheetFrameTests extends munit.FunSuite {
     val offset = SpriteSheetFrame.calculateFrameOffset(atlasSize, frameCrop, textureOffset)
 
     val textureCoordinate1   = Vector2(0, 0)
-    val resultingMultiplier1 = textureCoordinate1.scale(offset.scale).translate(offset.translate)
+    val resultingMultiplier1 = textureCoordinate1.scaleBy(offset.scale).translate(offset.translate)
 
     assertEquals(Vector2.multiply(atlasSize, resultingMultiplier1) === Vector2(64, 0), true)
 
     val textureCoordinate2   = Vector2(0.5, 0.5)
-    val resultingMultiplier2 = textureCoordinate2.scale(offset.scale).translate(offset.translate)
+    val resultingMultiplier2 = textureCoordinate2.scaleBy(offset.scale).translate(offset.translate)
 
     assertEquals(Vector2.multiply(atlasSize, resultingMultiplier2) === Vector2(96, 32), true)
 
     val textureCoordinate3   = Vector2(1, 1)
-    val resultingMultiplier3 = textureCoordinate3.scale(offset.scale).translate(offset.translate)
+    val resultingMultiplier3 = textureCoordinate3.scaleBy(offset.scale).translate(offset.translate)
 
     assertEquals(Vector2.multiply(atlasSize, resultingMultiplier3) === Vector2(128.0, 64.0), true)
 

--- a/indigo/shared/src/test/scala/indigo/shared/display/Vector2Tests.scala
+++ b/indigo/shared/src/test/scala/indigo/shared/display/Vector2Tests.scala
@@ -27,7 +27,7 @@ class Vector2Tests extends munit.FunSuite {
 
     val result =
       Vector2(1, 1)
-        .scale(scaleFactor)
+        .scaleBy(scaleFactor)
         .translate(multiplier)
 
     assertEquals(areDoubleVectorsEqual(Vector2(0.66, 1), result), true)
@@ -36,7 +36,7 @@ class Vector2Tests extends munit.FunSuite {
 
   test("Basic vector operation.should be able to scale and translate") {
 
-    val res = Vector2(10, 10).scale(Vector2(2, 2)).translate(Vector2(5, 5))
+    val res = Vector2(10, 10).scaleBy(Vector2(2, 2)).translate(Vector2(5, 5))
 
     assertEquals(res.x, 25.0)
     assertEquals(res.y, 25.0)
@@ -64,6 +64,65 @@ class Vector2Tests extends munit.FunSuite {
     assertEquals(Vector2.fromPoints(Point(10, 2), Point(2, 2)) === Vector2(-8, 0), true)
   }
 
+  test("dot product") {
+    assert(clue(Vector2(1, 0).dot(Vector2(1, 0))) == 1)
+    assert(clue(Vector2(1, 0).dot(Vector2(0, -1))) == 0)
+    assert(clue(Vector2(-1, 0).dot(Vector2(1, 0))) == -1)
+    assert(clue(Vector2(1, 0).dot(Vector2(-1, 0))) == -1)
+  }
+
+  test("abs") {
+    assertEquals(Vector2(1, 1).abs, Vector2(1, 1))
+    assertEquals(Vector2(-1, 1).abs, Vector2(1, 1))
+    assertEquals(Vector2(1, -1).abs, Vector2(1, 1))
+    assertEquals(Vector2(-1, -1).abs, Vector2(1, 1))
+  }
+
+  test("min") {
+    assertEquals(Vector2(10, 10).min(1), Vector2(1, 1))
+    assertEquals(Vector2(10, 10).min(100), Vector2(10, 10))
+    assertEquals(Vector2(10, 10).min(Vector2(50, 5)), Vector2(10, 5))
+  }
+
+  test("max") {
+    assertEquals(Vector2(10, 10).max(1), Vector2(10, 10))
+    assertEquals(Vector2(10, 10).max(100), Vector2(100, 100))
+    assertEquals(Vector2(10, 10).max(Vector2(50, 5)), Vector2(50, 10))
+  }
+
+  test("clamp") {
+    assertEquals(Vector2(0.1, 0.1).clamp(0, 1), Vector2(0.1, 0.1))
+    assertEquals(Vector2(-0.1, 1.1).clamp(0, 1), Vector2(0.0, 1.0))
+    assertEquals(Vector2(1, 4).clamp(2, 3), Vector2(2, 3))
+  }
+
+  test("length") {
+    assertEquals(Vector2(10, 0).length, 10.0)
+    assertEquals(Vector2(0, 10).length, 10.0)
+    assert(nearEnoughEqual(Vector2(10, 10).length, 14.14d, 0.01))
+  }
+
+  test("invert") {
+    assertEquals(Vector2(1, 1).invert, Vector2(-1, -1))
+    assertEquals(Vector2(-1, 1).invert, Vector2(1, -1))
+    assertEquals(Vector2(1, -1).invert, Vector2(-1, 1))
+    assertEquals(Vector2(-1, -1).invert, Vector2(1, 1))
+  }
+
+  test("translate | moveBy | moveTo") {
+    assertEquals(Vector2(1, 1).translate(Vector2(10, 10)), Vector2(11, 11))
+    assertEquals(Vector2(1, 1).moveBy(Vector2(10, 10)), Vector2(11, 11))
+    assertEquals(Vector2(1, 1).moveTo(Vector2(10, 10)), Vector2(10, 10))
+  }
+
+  test("scaleBy") {
+    assertEquals(Vector2(2, 2).scaleBy(Vector2(10, 2)), Vector2(20, 4))
+  }
+
+  test("round") {
+    assertEquals(Vector2(2.2, 2.6).round, Vector2(2, 3))
+  }
+
   def areDoubleVectorsEqual(expected: Vector2, actual: Vector2): Boolean =
     areDoublesEqual(expected.x, actual.x) && areDoublesEqual(expected.y, actual.y)
 
@@ -72,5 +131,8 @@ class Vector2Tests extends munit.FunSuite {
 
   def to2dp(d: Double): Double =
     Math.round(d * 100).toDouble / 100
+
+  def nearEnoughEqual(d1: Double, d2: Double, tolerance: Double): Boolean =
+    d1 >= d2 - tolerance && d1 <= d2 + tolerance
 
 }

--- a/indigo/shared/src/test/scala/indigo/shared/display/Vector2Tests.scala
+++ b/indigo/shared/src/test/scala/indigo/shared/display/Vector2Tests.scala
@@ -123,6 +123,14 @@ class Vector2Tests extends munit.FunSuite {
     assertEquals(Vector2(2.2, 2.6).round, Vector2(2, 3))
   }
 
+  test("normalise") {
+    assert(clue(Vector2(10, 10).normalise) === clue(Vector2(1, 1)))
+    assert(clue(Vector2(-10, -10).normalise) === clue(Vector2(-1, -1)))
+    assert(clue(Vector2(10, 0).normalise) === clue(Vector2(1, 0)))
+    assert(clue(Vector2(0, 10).normalise) === clue(Vector2(0, 1)))
+    assert(clue(Vector2(-50, 1000).normalise) === clue(Vector2(-1, 1)))
+  }
+
   def areDoubleVectorsEqual(expected: Vector2, actual: Vector2): Boolean =
     areDoublesEqual(expected.x, actual.x) && areDoublesEqual(expected.y, actual.y)
 


### PR DESCRIPTION
The relatively simple task of added a `BoundingCircle` to complement `BoundingBox` resulted in a fairly fundamental review and clean up of most of the geometry classes.

As well as making what was there more consistent and usable, other interesting things have been added like the ability to find the closest point on a line and SDF functions for LineSegment, BoundingBox and BoundingCircle.

The testing has also been improved a lot, and I've split the notion of Lines, which are infinite, out of LineSegments which are finite.

Another point of interest is that you can now perform operations on Vector2 (and 3 and 4 and Vertex) in terms of vectors as you would in a shader.

Fair to say this one got away from me a bit, but the results are pretty cool.