### PR TITLE
Log error on negatively sized rectangles

### DIFF
--- a/indigo/indigo/src/main/scala/indigo/shared/datatypes/Rectangle.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/datatypes/Rectangle.scala
@@ -3,6 +3,12 @@ package indigo.shared.datatypes
 import scala.annotation.tailrec
 
 final case class Rectangle(position: Point, size: Point) {
+  if (size.x < 0 || size.y < 0)
+    IndigoLogger.error(
+      s"Rectangle size (${size.x}, ${size.y}) is not permitted",
+      "negatively sized rectangles may cause computation errors"
+    )
+  
   lazy val x: Int       = position.x
   lazy val y: Int       = position.y
   lazy val width: Int   = size.x


### PR DESCRIPTION
rel https://github.com/PurpleKingdomGames/indigo/pull/138

in case rectangle overlap for negative sizes isn't fixed right away, an error message for the user to help them debug

negative sizes probably affects more than just overlap, but if that's not the case we could move this snippet into the overlap method