### PR TITLE
Fixing #141 negative box size issues

### DIFF
--- a/indigo/indigo-extras/src/main/scala/indigoextras/geometry/BoundingBox.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/geometry/BoundingBox.scala
@@ -52,6 +52,9 @@ final case class BoundingBox(position: Vertex, size: Vertex) derives CanEqual {
   def distanceToBoundary(vertex: Vertex): Double =
     sdf(vertex)
 
+  def expand(amount: Double): BoundingBox =
+    BoundingBox.expand(this, amount)
+
   def expandToInclude(other: BoundingBox): BoundingBox =
     BoundingBox.expandToInclude(this, other)
 
@@ -154,10 +157,10 @@ object BoundingBox {
 
   def expand(boundingBox: BoundingBox, amount: Double): BoundingBox =
     BoundingBox(
-      x = boundingBox.x - amount,
-      y = boundingBox.y - amount,
-      width = boundingBox.width + (amount * 2),
-      height = boundingBox.height + (amount * 2)
+      x = if boundingBox.width >= 0 then boundingBox.x - amount else boundingBox.x + amount,
+      y = if boundingBox.height >= 0 then boundingBox.y - amount else boundingBox.y + amount,
+      width = if boundingBox.width >= 0 then boundingBox.width + (amount * 2) else boundingBox.width - (amount * 2),
+      height = if boundingBox.height >= 0 then boundingBox.height + (amount * 2) else boundingBox.height - (amount * 2)
     )
 
   def expandToInclude(a: BoundingBox, b: BoundingBox): BoundingBox = {

--- a/indigo/indigo-extras/src/main/scala/indigoextras/trees/QuadTree.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/trees/QuadTree.scala
@@ -94,7 +94,8 @@ object QuadTree {
   def apply[T](elements: List[(T, Vertex)]): QuadTree[T] =
     QuadEmpty(BoundingBox.fromVertexCloud(elements.map(_._2))).insertElements(elements)
 
-  final case class QuadBranch[T](bounds: BoundingBox, a: QuadTree[T], b: QuadTree[T], c: QuadTree[T], d: QuadTree[T]) extends QuadTree[T] {
+  final case class QuadBranch[T](bounds: BoundingBox, a: QuadTree[T], b: QuadTree[T], c: QuadTree[T], d: QuadTree[T])
+      extends QuadTree[T] {
     def isEmpty: Boolean =
       a.isEmpty && b.isEmpty && c.isEmpty && d.isEmpty
   }
@@ -111,29 +112,34 @@ object QuadTree {
       fromBoundsAndQuads(bounds, subdivide(bounds))
 
     def subdivide(quadBounds: BoundingBox): (BoundingBox, BoundingBox, BoundingBox, BoundingBox) =
+      val newWidth  = quadBounds.width / 2
+      val newHeight = quadBounds.height / 2
       (
-        BoundingBox(quadBounds.x, quadBounds.y, quadBounds.width / 2, quadBounds.height / 2),
+        BoundingBox(quadBounds.x, quadBounds.y, newWidth, newHeight),
         BoundingBox(
-          quadBounds.x + (quadBounds.width / 2),
+          quadBounds.x + newWidth,
           quadBounds.y,
-          quadBounds.width - (quadBounds.width / 2),
-          quadBounds.height / 2
+          newWidth,
+          newHeight
         ),
         BoundingBox(
           quadBounds.x,
-          quadBounds.y + (quadBounds.height / 2),
-          quadBounds.width / 2,
-          quadBounds.height - (quadBounds.height / 2)
+          quadBounds.y + newHeight,
+          newWidth,
+          newHeight
         ),
         BoundingBox(
-          quadBounds.x + (quadBounds.width / 2),
-          quadBounds.y + (quadBounds.height / 2),
-          quadBounds.width - (quadBounds.width / 2),
-          quadBounds.height - (quadBounds.height / 2)
+          quadBounds.x + newWidth,
+          quadBounds.y + newHeight,
+          newWidth,
+          newHeight
         )
       )
 
-    def fromBoundsAndQuads[T](bounds: BoundingBox, quads: (BoundingBox, BoundingBox, BoundingBox, BoundingBox)): QuadBranch[T] =
+    def fromBoundsAndQuads[T](
+        bounds: BoundingBox,
+        quads: (BoundingBox, BoundingBox, BoundingBox, BoundingBox)
+    ): QuadBranch[T] =
       QuadBranch(
         bounds,
         QuadEmpty(quads._1),

--- a/indigo/indigo-extras/src/test/scala/indigoextras/geometry/BoundingBoxTests.scala
+++ b/indigo/indigo-extras/src/test/scala/indigoextras/geometry/BoundingBoxTests.scala
@@ -70,6 +70,19 @@ class BoundingBoxTests extends munit.FunSuite {
     assertEquals(BoundingBox.expandToInclude(a, b) == BoundingBox(10, 10, 190, 190), true)
   }
 
+  test("expand a bounding box with negative size") {
+    val a = BoundingBox(10, 10, -20, -20)
+
+    assertEquals(a.expand(10), BoundingBox(20, 20, -40, -40))
+  }
+
+  test("expand a bounding box to include another bounding box with negative size") {
+    val a = BoundingBox(50, 50, -20, -20)
+    val b = BoundingBox(100, 100, 100, 100)
+
+    assertEquals(BoundingBox.expandToInclude(a, b) == BoundingBox(30, 30, 170, 170), true)
+  }
+
   test("intersecting vertices.should be able to detect if the point is inside the BoundingBox") {
     assertEquals(BoundingBox(0, 0, 10, 10).contains(Vertex(5, 5)), true)
   }
@@ -122,21 +135,28 @@ class BoundingBoxTests extends munit.FunSuite {
     assert(!BoundingBox(5, 5, 4, 4).lineIntersects(LineSegment((0d, 0d), (3d, 3d))))
   }
 
-  test("encompasing rectangles.should return true when A encompases B") {
+  test("encompasing bounding box.should return true when A encompases B") {
     val a = BoundingBox(10, 10, 110, 110)
     val b = BoundingBox(20, 20, 10, 10)
 
     assertEquals(BoundingBox.encompassing(a, b), true)
   }
 
-  test("encompasing rectangles.should return false when A does not encompass B") {
+  test("encompasing bounding box.should return false when A does not encompass B") {
     val a = BoundingBox(20, 20, 10, 10)
     val b = BoundingBox(10, 10, 110, 110)
 
     assertEquals(BoundingBox.encompassing(a, b), false)
   }
 
-  test("encompasing rectangles.should return false when A and B merely intersect") {
+  test("encompasing bounding box.should return true when A encompases B and B has a negative size") {
+    val a = Rectangle(10, 10, 110, 110)
+    val b = Rectangle(30, 30, -10, -10)
+
+    assertEquals(Rectangle.encompassing(a, b), true)
+  }
+
+  test("encompasing bounding box.should return false when A and B merely intersect") {
     val a = BoundingBox(10, 10, 20, 200)
     val b = BoundingBox(15, 15, 100, 10)
 

--- a/indigo/indigo-extras/src/test/scala/indigoextras/geometry/BoundingBoxTests.scala
+++ b/indigo/indigo-extras/src/test/scala/indigoextras/geometry/BoundingBoxTests.scala
@@ -157,6 +157,20 @@ class BoundingBoxTests extends munit.FunSuite {
     assertEquals(BoundingBox.overlapping(a, b), false)
   }
 
+  test("overlapping rectangles.should return true when A overlaps B and A has a negative size.") {
+    val a = BoundingBox(105, 105, -20, -20)
+    val b = BoundingBox(10, 10, 90, 90)
+
+    assertEquals(BoundingBox.overlapping(a, b), true)
+  }
+
+  test("overlapping rectangles.should return false when A and B do not overlap and A has a negative size.") {
+    val a = BoundingBox(125, 125, -10, -10)
+    val b = BoundingBox(10, 10, 90, 90)
+
+    assertEquals(BoundingBox.overlapping(a, b), false)
+  }
+
   test("Expand should be able to expand in size by a given amount") {
     val a = BoundingBox(10, 10, 20, 20)
     val b = BoundingBox(0, 10, 100, 5)
@@ -204,6 +218,24 @@ class BoundingBoxTests extends munit.FunSuite {
     val br = Vertex(45, 70)
     assertEquals(bb.sdf(br), br.distanceTo(bb.bottomRight))
 
+  }
+
+  test("should be able to find edges (positive)") {
+     val a = BoundingBox(10, 20, 30, 40)
+
+     assert(a.left == 10)
+     assert(a.right == 40)
+     assert(a.top == 20)
+     assert(a.bottom == 60)
+  }
+
+  test("should be able to find edges (negative)") {
+     val a = BoundingBox(10, 20, -30, -40)
+
+     assert(a.left == -20)
+     assert(a.right == 10)
+     assert(a.top == -20)
+     assert(a.bottom == 20)
   }
 
 }

--- a/indigo/indigo-extras/src/test/scala/indigoextras/trees/QuadTreeSpecification.scala
+++ b/indigo/indigo-extras/src/test/scala/indigoextras/trees/QuadTreeSpecification.scala
@@ -13,17 +13,9 @@ object QuadTreeSpecification extends Properties("QuadTree") {
 
     val divisions = QuadTree.QuadBranch.subdivide(original)
 
-    val z =
-      BoundingBox(
-        Double.PositiveInfinity,
-        Double.PositiveInfinity,
-        Double.NegativeInfinity,
-        Double.NegativeInfinity
-      )
-
     val recombined: BoundingBox =
       List(divisions._1, divisions._2, divisions._3, divisions._4)
-        .foldLeft(z)((acc, next) => acc.expandToInclude(next))
+        .reduce(_.expandToInclude(_))
 
     (recombined ~== original) :| s"Recombined: ${recombined.toString()} - Original: ${original.toString()} - Divisions: $divisions"
   }

--- a/indigo/indigo-extras/src/test/scala/indigoextras/trees/QuadTreeTests.scala
+++ b/indigo/indigo-extras/src/test/scala/indigoextras/trees/QuadTreeTests.scala
@@ -350,17 +350,9 @@ class QuadTreeTests extends munit.FunSuite {
     assert(q3 ~== BoundingBox(0, 100, 50, 100))
     assert(q4 ~== BoundingBox(50, 100, 50, 100))
 
-    val z =
-      BoundingBox(
-        Double.PositiveInfinity,
-        Double.PositiveInfinity,
-        Double.NegativeInfinity,
-        Double.NegativeInfinity
-      )
-
     val recombined: BoundingBox =
       List(q1, q2, q3, q4)
-        .foldLeft(z)((acc, next) => acc.expandToInclude(next))
+        .reduce(_.expandToInclude(_))
 
     assert(recombined ~== original)
   }
@@ -376,17 +368,10 @@ class QuadTreeTests extends munit.FunSuite {
 
     val (q1, q2, q3, q4) = QuadTree.QuadBranch.subdivide(original)
 
-    val z =
-      BoundingBox(
-        Double.PositiveInfinity,
-        Double.PositiveInfinity,
-        Double.NegativeInfinity,
-        Double.NegativeInfinity
-      )
-
     val recombined: BoundingBox =
       List(q1, q2, q3, q4)
-        .foldLeft(z)((acc, next) => acc.expandToInclude(next))
+        .reduce(_.expandToInclude(_))
+        // .foldLeft(z)((acc, next) => acc.expandToInclude(next))
 
     assert(clue(recombined) ~== clue(original))
   }

--- a/indigo/indigo/src/main/scala/indigo/shared/datatypes/Point.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/datatypes/Point.scala
@@ -13,6 +13,22 @@ final case class Point(x: Int, y: Int) derives CanEqual {
   def withX(newX: Int): Point = this.copy(x = newX)
   def withY(newY: Int): Point = this.copy(y = newY)
 
+  def abs: Point =
+    Point(Math.abs(x), Math.abs(y))
+
+  def min(other: Point): Point =
+    Point(Math.min(other.x, x), Math.min(other.y, y))
+  def min(value: Int): Point =
+    Point(Math.min(value, x), Math.min(value, y))
+
+  def max(other: Point): Point =
+    Point(Math.max(other.x, x), Math.max(other.y, y))
+  def max(value: Int): Point =
+    Point(Math.max(value, x), Math.max(value, y))
+
+  def clamp(min: Int, max: Int): Point =
+    Point(Math.min(max, Math.max(min, x)), Math.min(max, Math.max(min, y)))
+
   def invert: Point =
     Point(-x, -y)
 

--- a/indigo/indigo/src/main/scala/indigo/shared/datatypes/Rectangle.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/datatypes/Rectangle.scala
@@ -105,10 +105,10 @@ object Rectangle {
 
   def expand(rectangle: Rectangle, amount: Int): Rectangle =
     Rectangle(
-      x = rectangle.x - amount,
-      y = rectangle.y - amount,
-      width = rectangle.width + (amount * 2),
-      height = rectangle.height + (amount * 2)
+      x = if rectangle.width >= 0 then rectangle.x - amount else rectangle.x + amount,
+      y = if rectangle.height >= 0 then rectangle.y - amount else rectangle.y + amount,
+      width = if rectangle.width >= 0 then rectangle.width + (amount * 2) else rectangle.width - (amount * 2),
+      height = if rectangle.height >= 0 then rectangle.height + (amount * 2) else rectangle.height - (amount * 2)
     )
 
   def expandToInclude(a: Rectangle, b: Rectangle): Rectangle = {

--- a/indigo/indigo/src/main/scala/indigo/shared/datatypes/Rectangle.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/datatypes/Rectangle.scala
@@ -9,10 +9,10 @@ final case class Rectangle(position: Point, size: Point) derives CanEqual {
   lazy val height: Int  = size.y
   lazy val hash: String = s"${x.toString()}${y.toString()}${width.toString()}${height.toString()}"
 
-  lazy val left: Int   = x
-  lazy val right: Int  = x + width
-  lazy val top: Int    = y
-  lazy val bottom: Int = y + height
+  lazy val left: Int   = if width >= 0 then x else x + width
+  lazy val right: Int  = if width >= 0 then x + width else x
+  lazy val top: Int    = if height >= 0 then y else y + height
+  lazy val bottom: Int = if height >= 0 then y + height else y
 
   lazy val horizontalCenter: Int = x + (width / 2)
   lazy val verticalCenter: Int   = y + (height / 2)
@@ -22,7 +22,7 @@ final case class Rectangle(position: Point, size: Point) derives CanEqual {
   lazy val bottomRight: Point = Point(right, bottom)
   lazy val bottomLeft: Point  = Point(left, bottom)
   lazy val center: Point      = Point(horizontalCenter, verticalCenter)
-  lazy val halfSize: Point    = size / 2
+  lazy val halfSize: Point    = (size / 2).abs
 
   lazy val corners: List[Point] =
     List(topLeft, topRight, bottomRight, bottomLeft)
@@ -127,8 +127,7 @@ object Rectangle {
     b.x >= a.x && b.y >= a.y && (b.width + (b.x - a.x)) <= a.width && (b.height + (b.y - a.y)) <= a.height
 
   def overlapping(a: Rectangle, b: Rectangle): Boolean =
-    Math.abs(a.center.x - b.center.x) < a.halfSize.x + b.halfSize.x && Math.abs(
-      a.center.y - b.center.y
-    ) < a.halfSize.y + b.halfSize.y
+    Math.abs(a.center.x - b.center.x) < a.halfSize.x + b.halfSize.x &&
+      Math.abs(a.center.y - b.center.y) < a.halfSize.y + b.halfSize.y
 
 }

--- a/indigo/indigo/src/test/scala/indigo/shared/datatypes/RectangleTests.scala
+++ b/indigo/indigo/src/test/scala/indigo/shared/datatypes/RectangleTests.scala
@@ -47,6 +47,19 @@ class RectangleTests extends munit.FunSuite {
     assertEquals(Rectangle.expandToInclude(a, b) == Rectangle(10, 10, 190, 190), true)
   }
 
+  test("expand a rectangle with negative size") {
+    val a = Rectangle(10, 10, -20, -20)
+
+    assertEquals(a.expand(10), Rectangle(20, 20, -40, -40))
+  }
+
+  test("expand a rectangle to include another rectangle with negative size") {
+    val a = Rectangle(50, 50, -20, -20)
+    val b = Rectangle(100, 100, 100, 100)
+
+    assertEquals(Rectangle.expandToInclude(a, b) == Rectangle(30, 30, 170, 170), true)
+  }
+
   test("intersecting points.should be able to detect if the point is inside the Rectangle") {
     assertEquals(Rectangle(0, 0, 10, 10).isPointWithin(Point(5, 5)), true)
   }
@@ -58,6 +71,13 @@ class RectangleTests extends munit.FunSuite {
   test("encompasing rectangles.should return true when A encompases B") {
     val a = Rectangle(10, 10, 110, 110)
     val b = Rectangle(20, 20, 10, 10)
+
+    assertEquals(Rectangle.encompassing(a, b), true)
+  }
+
+  test("encompasing rectangles.should return true when A encompases B and B has a negative size") {
+    val a = Rectangle(10, 10, 110, 110)
+    val b = Rectangle(30, 30, -10, -10)
 
     assertEquals(Rectangle.encompassing(a, b), true)
   }

--- a/indigo/indigo/src/test/scala/indigo/shared/datatypes/RectangleTests.scala
+++ b/indigo/indigo/src/test/scala/indigo/shared/datatypes/RectangleTests.scala
@@ -90,11 +90,43 @@ class RectangleTests extends munit.FunSuite {
     assertEquals(Rectangle.overlapping(a, b), false)
   }
 
+  test("overlapping rectangles.should return true when A overlaps B and A has a negative size.") {
+    val a = Rectangle(105, 105, -20, -20)
+    val b = Rectangle(10, 10, 90, 90)
+
+    assertEquals(Rectangle.overlapping(a, b), true)
+  }
+
+  test("overlapping rectangles.should return false when A and B do not overlap and A has a negative size.") {
+    val a = Rectangle(125, 125, -10, -10)
+    val b = Rectangle(10, 10, 90, 90)
+
+    assertEquals(Rectangle.overlapping(a, b), false)
+  }
+
   test("Expand should be able to expand in size by a given amount") {
     val a = Rectangle(10, 10, 20, 20)
     val b = Rectangle(0, 10, 100, 5)
 
     assertEquals(Rectangle.expand(a, 10) == Rectangle(0, 0, 40, 40), true)
     assertEquals(Rectangle.expand(b, 50) == Rectangle(-50, -40, 200, 105), true)
+  }
+
+  test("should be able to find edges (positive)") {
+     val a = Rectangle(10, 20, 30, 40)
+
+     assert(a.left == 10)
+     assert(a.right == 40)
+     assert(a.top == 20)
+     assert(a.bottom == 60)
+  }
+
+  test("should be able to find edges (negative)") {
+     val a = Rectangle(10, 20, -30, -40)
+
+     assert(a.left == -20)
+     assert(a.right == 10)
+     assert(a.top == -20)
+     assert(a.bottom == 20)
   }
 }


### PR DESCRIPTION
This PR is a fix for issue #141 which references and replaces PR's #138 and #139.

As @kag0 rightly identified, Indigo had never been written with negatively sized rectangles or bounding boxes in mind (oversight), and was giving some terribly wrong answers when that was the case!