### PR TITLE
Fix #143: Uniform Buffer offsets > max allowed

### DIFF
--- a/indigo/indigo/src/main/scala/indigo/platform/renderer/webgl2/RendererWebGL2Constants.scala
+++ b/indigo/indigo/src/main/scala/indigo/platform/renderer/webgl2/RendererWebGL2Constants.scala
@@ -2,11 +2,17 @@ package indigo.platform.renderer.webgl2
 
 object RendererWebGL2Constants {
 
-  val mergeObjectBlockPointer: Int = 0
-  val projectionBlockPointer: Int  = 1
-  val frameDataBlockPointer: Int   = 2
-  val lightDataBlockPointer: Int   = 3
-  val blendDataBlockOffsetPointer: Int   = 32
-  val customDataBlockOffsetPointer: Int  = 64
+  // The minimum value of gl.MAX_UNIFORM_BUFFER_BINDINGS we test
+  // for during WebGL 2.0 detection is 24. However, 24 should be
+  // treated as the MAX number. So these pointers must not exceed
+  // that. In practice this means we're allowing 8 offsets / UBOS
+  // for blend and custom shaders each. The first 8 are reserved
+  // for internal use.
+  val mergeObjectBlockPointer: Int      = 0
+  val projectionBlockPointer: Int       = 1
+  val frameDataBlockPointer: Int        = 2
+  val lightDataBlockPointer: Int        = 3
+  val blendDataBlockOffsetPointer: Int  = 8
+  val customDataBlockOffsetPointer: Int = 16
 
 }


### PR DESCRIPTION
We're still testing to see if this completely fixes https://github.com/PurpleKingdomGames/indigo/issues/143, but it was definitely an issue.

Essentially the max number of buffer bindings on the Windows machines we have access to is 24, but 24 is the _minimum_ number that the WebGL 2.0 detection process in Indigo looks for. So I was foolishly (oversight) checking for 24 to be available, and then instantly setting two pointers outside that range to 32 and 64 for the blend and custom UBO data bindings respectively.

This was not a problem on Mac or Linux, which is why it went undetected, but was immediately a problem when we tried it on Windows, even a Windows VM. At least, on the machines we have for testing.

The solution is simply to reduce Indigo's requirements by lowering the pointer offsets.

In theory this reduces the amount of data you could send per unique shader + data combo drastically from 32 down to 8 UBOs.

In practice however, 8 UBO structs is still A LOT of data. If you're using more than that you've probably got bigger problems - so I think it's probably fine. (...and if it isn't... tough! It's the max limit!)