### PR TITLE
Stop build artifacts from polluting git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ elm-stuff
 metals.sbt
 .bsp/
 .ammonite
+.coursier


### PR DESCRIPTION
I followed the build instructions and git was reporting 4K+ changes, all build artifacts. I added this and they all went away.