### PR TITLE
Built-in primitives have `Material` type param

### DIFF
--- a/indigo/indigo-extras/src/main/scala/indigoextras/ui/Button.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/ui/Button.scala
@@ -54,13 +54,13 @@ final case class Button(
 
   private def applyPositionAndDepth(sceneNode: SceneNode, pt: Point, d: Depth): SceneNode =
     sceneNode match {
-      case n: Shape   => n.withPosition(pt).withDepth(d)
-      case n: Graphic => n.withPosition(pt).withDepth(d)
-      case n: Sprite  => n.withPosition(pt).withDepth(d)
-      case n: Text    => n.withPosition(pt).withDepth(d)
-      case n: TextBox => n.withPosition(pt).withDepth(d)
-      case n: Group   => n.withPosition(pt).withDepth(d)
-      case n          => n
+      case n: Shape      => n.withPosition(pt).withDepth(d)
+      case n: Graphic[_] => n.withPosition(pt).withDepth(d)
+      case n: Sprite[_]  => n.withPosition(pt).withDepth(d)
+      case n: Text[_]    => n.withPosition(pt).withDepth(d)
+      case n: TextBox    => n.withPosition(pt).withDepth(d)
+      case n: Group      => n.withPosition(pt).withDepth(d)
+      case n             => n
     }
 
   def draw: SceneNode =

--- a/indigo/indigo-extras/src/main/scala/indigoextras/ui/InputField.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/ui/InputField.scala
@@ -324,10 +324,10 @@ object InputField {
 
 }
 
-final case class InputFieldAssets(text: Text, cursor: Graphic) derives CanEqual {
-  def withText(newText: Text): InputFieldAssets =
+final case class InputFieldAssets(text: Text[_], cursor: Graphic[_]) derives CanEqual {
+  def withText(newText: Text[_]): InputFieldAssets =
     this.copy(text = newText)
-  def withCursor(newCursor: Graphic): InputFieldAssets =
+  def withCursor(newCursor: Graphic[_]): InputFieldAssets =
     this.copy(cursor = newCursor)
 }
 

--- a/indigo/indigo-extras/src/main/scala/indigoextras/ui/RadioButtonGroup.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/ui/RadioButtonGroup.scala
@@ -357,13 +357,13 @@ final case class RadioButtonGroup(
 
   private def applyPositionAndDepth(sceneNode: SceneNode, pt: Point, d: Depth): SceneNode =
     sceneNode match {
-      case n: Shape   => n.withPosition(pt).withDepth(d)
-      case n: Graphic => n.withPosition(pt).withDepth(d)
-      case n: Sprite  => n.withPosition(pt).withDepth(d)
-      case n: Text    => n.withPosition(pt).withDepth(d)
-      case n: TextBox => n.withPosition(pt).withDepth(d)
-      case n: Group   => n.withPosition(pt).withDepth(d)
-      case n          => n
+      case n: Shape      => n.withPosition(pt).withDepth(d)
+      case n: Graphic[_] => n.withPosition(pt).withDepth(d)
+      case n: Sprite[_]  => n.withPosition(pt).withDepth(d)
+      case n: Text[_]    => n.withPosition(pt).withDepth(d)
+      case n: TextBox    => n.withPosition(pt).withDepth(d)
+      case n: Group      => n.withPosition(pt).withDepth(d)
+      case n             => n
     }
 
   /** Returns graphics to present the current state of the radio button.

--- a/indigo/indigo-extras/src/test/scala/indigoextras/subsystems/AutomataTests.scala
+++ b/indigo/indigo-extras/src/test/scala/indigoextras/subsystems/AutomataTests.scala
@@ -79,7 +79,7 @@ class AutomataTests extends munit.FunSuite {
     assertEquals(makePosition(seed).at(Seconds(1)), Point(0, -30))
 
     // Test the automaton
-    def drawAt(time: Seconds): Graphic = {
+    def drawAt(time: Seconds): Graphic[_] = {
       val ctx = context(1, time, time)
 
       val nextState =
@@ -94,7 +94,7 @@ class AutomataTests extends munit.FunSuite {
         .find(l => l.key.contains(layerKey))
         .get
         .nodes
-        .collect { case g: Graphic => g }
+        .collect { case g: Graphic[_] => g }
         .head
     }
 
@@ -205,7 +205,7 @@ class AutomataTests extends munit.FunSuite {
         makePosition(seed).map { position =>
           AutomatonUpdate(
             sceneGraphNode match {
-              case g: Graphic =>
+              case g: Graphic[_] =>
                 List(g.moveTo(position))
 
               case _ =>

--- a/indigo/indigo-extras/src/test/scala/indigoextras/ui/InputFieldTests.scala
+++ b/indigo/indigo-extras/src/test/scala/indigoextras/ui/InputFieldTests.scala
@@ -162,7 +162,7 @@ class InputFieldTests extends munit.FunSuite {
   def extractCursorPosition(field: InputField): Point =
     field
       .draw(GameTime.zero, boundaryLocator)
-      .collect { case g: Graphic => g }
+      .collect { case g: Graphic[_] => g }
       .head
       .position
 

--- a/indigo/indigo/src/main/scala/indigo/package.scala
+++ b/indigo/indigo/src/main/scala/indigo/package.scala
@@ -421,13 +421,13 @@ val AnimationAction: indigo.shared.animation.AnimationAction.type = indigo.share
 type Shape = shared.scenegraph.Shape
 val Shape: shared.scenegraph.Shape.type = shared.scenegraph.Shape
 
-type Sprite = shared.scenegraph.Sprite
+type Sprite[M <: Material] = shared.scenegraph.Sprite[M]
 val Sprite: shared.scenegraph.Sprite.type = shared.scenegraph.Sprite
 
-type Text = shared.scenegraph.Text
+type Text[M <: Material] = shared.scenegraph.Text[M]
 val Text: shared.scenegraph.Text.type = shared.scenegraph.Text
 
-type Graphic = shared.scenegraph.Graphic
+type Graphic[M <: Material] = shared.scenegraph.Graphic[M]
 val Graphic: shared.scenegraph.Graphic.type = shared.scenegraph.Graphic
 
 type Group = shared.scenegraph.Group

--- a/indigo/indigo/src/main/scala/indigo/package.scala
+++ b/indigo/indigo/src/main/scala/indigo/package.scala
@@ -221,9 +221,6 @@ val FontInfo: shared.datatypes.FontInfo.type = shared.datatypes.FontInfo
 type FontKey = shared.datatypes.FontKey
 val FontKey: shared.datatypes.FontKey.type = shared.datatypes.FontKey
 
-type FontSpriteSheet = shared.datatypes.FontSpriteSheet
-val FontSpriteSheet: shared.datatypes.FontSpriteSheet.type = shared.datatypes.FontSpriteSheet
-
 type TextAlignment = shared.datatypes.TextAlignment
 val TextAlignment: shared.datatypes.TextAlignment.type = shared.datatypes.TextAlignment
 

--- a/indigo/indigo/src/main/scala/indigo/shared/BoundaryLocator.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/BoundaryLocator.scala
@@ -58,7 +58,7 @@ final class BoundaryLocator(
       case s: Shape =>
         Option(shapeBounds(s)).map(rect => BoundaryLocator.findBounds(s, rect.position, rect.size, s.ref))
 
-      case g: Graphic =>
+      case g: Graphic[_] =>
         Option(g.bounds)
 
       case t: TextBox =>
@@ -76,10 +76,10 @@ final class BoundaryLocator(
       case _: CloneBatch =>
         None
 
-      case s: Sprite =>
+      case s: Sprite[_] =>
         spriteBounds(s).map(rect => BoundaryLocator.findBounds(s, rect.position, rect.size, s.ref))
 
-      case t: Text =>
+      case t: Text[_] =>
         Option(textBounds(t)).map { rect =>
 
           val offset: Int =
@@ -112,7 +112,7 @@ final class BoundaryLocator(
           .getOrElse(Rectangle.zero)
     }
 
-  def spriteBounds(sprite: Sprite): Option[Rectangle] =
+  def spriteBounds(sprite: Sprite[_]): Option[Rectangle] =
     QuickCache(s"""sprite-${sprite.bindingKey.toString}-${sprite.animationKey.toString}""") {
       animationsRegister.fetchAnimationInLastState(sprite.bindingKey, sprite.animationKey) match {
         case Some(animation) =>
@@ -152,7 +152,7 @@ final class BoundaryLocator(
         }
     }
 
-  def textBounds(text: Text): Rectangle =
+  def textBounds(text: Text[_]): Rectangle =
     val unaligned =
       textAsLinesWithBounds(text.text, text.fontKey)
         .map(_.lineBounds)

--- a/indigo/indigo/src/main/scala/indigo/shared/datatypes/FontInfo.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/datatypes/FontInfo.scala
@@ -61,8 +61,6 @@ object FontKey:
 
   extension (f: FontKey) def toString: String = f
 
-final case class FontSpriteSheet(material: Material, size: Size) derives CanEqual
-
 final case class FontChar(character: String, bounds: Rectangle) derives CanEqual
 object FontChar:
   def apply(character: String, x: Int, y: Int, width: Int, height: Int): FontChar =

--- a/indigo/indigo/src/main/scala/indigo/shared/formats/Aseprite.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/formats/Aseprite.scala
@@ -37,7 +37,7 @@ final case class AsepriteSize(w: Int, h: Int) derives CanEqual
 
 final case class AsepriteFrameTag(name: String, from: Int, to: Int, direction: String) derives CanEqual
 
-final case class SpriteAndAnimations(sprite: Sprite, animations: Animation) derives CanEqual
+final case class SpriteAndAnimations(sprite: Sprite[Material.Bitmap], animations: Animation) derives CanEqual
 object Aseprite {
 
   def toSpriteAndAnimations(aseprite: Aseprite, dice: Dice, assetName: AssetName): Option[SpriteAndAnimations] =

--- a/indigo/indigo/src/main/scala/indigo/shared/formats/TiledMap.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/formats/TiledMap.scala
@@ -125,8 +125,8 @@ object TiledMap {
 
       val layers: List[Group] =
         tiledMap.layers.map { layer =>
-          val tilesInUse: Map[Int, Graphic] =
-            layer.data.toSet.foldLeft(Map.empty[Int, Graphic]) { (tiles, i) =>
+          val tilesInUse: Map[Int, Graphic[Material.Bitmap]] =
+            layer.data.toSet.foldLeft(Map.empty[Int, Graphic[Material.Bitmap]]) { (tiles, i) =>
               tiles ++ Map(
                 i ->
                   Graphic(Rectangle(Point.zero, tileSize), 1, Material.Bitmap(assetName))

--- a/indigo/indigo/src/main/scala/indigo/shared/platform/DisplayObjectConversions.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/platform/DisplayObjectConversions.scala
@@ -198,7 +198,7 @@ final class DisplayObjectConversions(
   ): List[DisplayEntity] =
     sceneNode match {
 
-      case x: Graphic =>
+      case x: Graphic[_] =>
         List(graphicToDisplayObject(x, assetMapping))
 
       case s: Shape =>
@@ -242,7 +242,7 @@ final class DisplayObjectConversions(
         sceneNodeToDisplayObject(t.node, gameTime, assetMapping, cloneBlankDisplayObjects)
           .map(_.applyTransform(t.transform))
 
-      case x: Sprite =>
+      case x: Sprite[_] =>
         animationsRegister.fetchAnimationForSprite(gameTime, x.bindingKey, x.animationKey, x.animationActions) match {
           case None =>
             IndigoLogger.errorOnce(s"Cannot render Sprite, missing Animations with key: ${x.animationKey.toString()}")
@@ -252,7 +252,7 @@ final class DisplayObjectConversions(
             List(spriteToDisplayObject(boundaryLocator, x, assetMapping, anim))
         }
 
-      case x: Text =>
+      case x: Text[_] =>
         val alignmentOffsetX: Rectangle => Int = lineBounds =>
           x.alignment match {
             case TextAlignment.Left => 0
@@ -421,7 +421,7 @@ final class DisplayObjectConversions(
       height = leaf.size.height
     )
 
-  def graphicToDisplayObject(leaf: Graphic, assetMapping: AssetMapping): DisplayObject = {
+  def graphicToDisplayObject(leaf: Graphic[_], assetMapping: AssetMapping): DisplayObject = {
     val shaderData     = leaf.material.toShaderData
     val shaderDataHash = shaderData.hashCode().toString
     val materialName   = shaderData.channel0.get
@@ -473,7 +473,7 @@ final class DisplayObjectConversions(
 
   def spriteToDisplayObject(
       boundaryLocator: BoundaryLocator,
-      leaf: Sprite,
+      leaf: Sprite[_],
       assetMapping: AssetMapping,
       anim: AnimationRef
   ): DisplayObject = {
@@ -529,7 +529,7 @@ final class DisplayObjectConversions(
   }
 
   def textLineToDisplayObjects(
-      leaf: Text,
+      leaf: Text[_],
       assetMapping: AssetMapping,
       fontInfo: FontInfo
   ): (TextLine, Int, Int) => List[DisplayObject] =

--- a/indigo/indigo/src/main/scala/indigo/shared/platform/SceneProcessor.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/platform/SceneProcessor.scala
@@ -57,10 +57,10 @@ final class SceneProcessor(
           case s: Shape =>
             acc + (blank.id -> displayObjectConverterClone.shapeToDisplayObject(s))
 
-          case g: Graphic =>
+          case g: Graphic[_] =>
             acc + (blank.id -> displayObjectConverterClone.graphicToDisplayObject(g, assetMapping))
 
-          case s: Sprite =>
+          case s: Sprite[_] =>
             animationsRegister.fetchAnimationForSprite(
               gameTime,
               s.bindingKey,

--- a/indigo/indigo/src/main/scala/indigo/shared/scenegraph/Graphic.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/scenegraph/Graphic.scala
@@ -23,8 +23,8 @@ import indigo.shared.BoundaryLocator
   * @param crop
   *   @param material
   */
-final case class Graphic(
-    material: Material,
+final case class Graphic[M <: Material](
+    material: M,
     crop: Rectangle,
     position: Point,
     rotation: Radians,
@@ -34,7 +34,7 @@ final case class Graphic(
     flip: Flip
 ) extends RenderNode
     with Cloneable
-    with SpatialModifiers[Graphic] derives CanEqual {
+    with SpatialModifiers[Graphic[M]] derives CanEqual {
 
   def bounds: Rectangle =
     BoundaryLocator.findBounds(this, position, crop.size, ref)
@@ -45,62 +45,62 @@ final case class Graphic(
   lazy val x: Int = position.x
   lazy val y: Int = position.y
 
-  def withMaterial(newMaterial: Material): Graphic =
+  def withMaterial[MB <: Material](newMaterial: MB): Graphic[MB] =
     this.copy(material = newMaterial)
 
-  def modifyMaterial(alter: Material => Material): Graphic =
+  def modifyMaterial[MB <: Material](alter: M => MB): Graphic[MB] =
     this.copy(material = alter(material))
 
-  def moveTo(pt: Point): Graphic =
+  def moveTo(pt: Point): Graphic[M] =
     this.copy(position = pt)
-  def moveTo(x: Int, y: Int): Graphic =
+  def moveTo(x: Int, y: Int): Graphic[M] =
     moveTo(Point(x, y))
-  def withPosition(newPosition: Point): Graphic =
+  def withPosition(newPosition: Point): Graphic[M] =
     moveTo(newPosition)
 
-  def moveBy(pt: Point): Graphic =
+  def moveBy(pt: Point): Graphic[M] =
     this.copy(position = position + pt)
-  def moveBy(x: Int, y: Int): Graphic =
+  def moveBy(x: Int, y: Int): Graphic[M] =
     moveBy(Point(x, y))
 
-  def rotateTo(angle: Radians): Graphic =
+  def rotateTo(angle: Radians): Graphic[M] =
     this.copy(rotation = angle)
-  def rotateBy(angle: Radians): Graphic =
+  def rotateBy(angle: Radians): Graphic[M] =
     rotateTo(rotation + angle)
-  def withRotation(newRotation: Radians): Graphic =
+  def withRotation(newRotation: Radians): Graphic[M] =
     rotateTo(newRotation)
 
-  def scaleBy(amount: Vector2): Graphic =
+  def scaleBy(amount: Vector2): Graphic[M] =
     this.copy(scale = scale * amount)
-  def scaleBy(x: Double, y: Double): Graphic =
+  def scaleBy(x: Double, y: Double): Graphic[M] =
     scaleBy(Vector2(x, y))
-  def withScale(newScale: Vector2): Graphic =
+  def withScale(newScale: Vector2): Graphic[M] =
     this.copy(scale = newScale)
 
-  def transformTo(newPosition: Point, newRotation: Radians, newScale: Vector2): Graphic =
+  def transformTo(newPosition: Point, newRotation: Radians, newScale: Vector2): Graphic[M] =
     this.copy(position = newPosition, rotation = newRotation, scale = newScale)
 
-  def transformBy(positionDiff: Point, rotationDiff: Radians, scaleDiff: Vector2): Graphic =
+  def transformBy(positionDiff: Point, rotationDiff: Radians, scaleDiff: Vector2): Graphic[M] =
     transformTo(position + positionDiff, rotation + rotationDiff, scale * scaleDiff)
 
-  def withDepth(newDepth: Depth): Graphic =
+  def withDepth(newDepth: Depth): Graphic[M] =
     this.copy(depth = newDepth)
 
-  def flipHorizontal(isFlipped: Boolean): Graphic =
+  def flipHorizontal(isFlipped: Boolean): Graphic[M] =
     this.copy(flip = flip.withHorizontalFlip(isFlipped))
-  def flipVertical(isFlipped: Boolean): Graphic =
+  def flipVertical(isFlipped: Boolean): Graphic[M] =
     this.copy(flip = flip.withVerticalFlip(isFlipped))
-  def withFlip(newFlip: Flip): Graphic =
+  def withFlip(newFlip: Flip): Graphic[M] =
     this.copy(flip = newFlip)
 
-  def withRef(newRef: Point): Graphic =
+  def withRef(newRef: Point): Graphic[M] =
     this.copy(ref = newRef)
-  def withRef(x: Int, y: Int): Graphic =
+  def withRef(x: Int, y: Int): Graphic[M] =
     withRef(Point(x, y))
 
-  def withCrop(newCrop: Rectangle): Graphic =
+  def withCrop(newCrop: Rectangle): Graphic[M] =
     this.copy(crop = newCrop)
-  def withCrop(x: Int, y: Int, width: Int, height: Int): Graphic =
+  def withCrop(x: Int, y: Int, width: Int, height: Int): Graphic[M] =
     withCrop(Rectangle(x, y, width, height))
 
   def toShaderData: ShaderData =
@@ -110,7 +110,7 @@ final case class Graphic(
 
 object Graphic {
 
-  def apply(x: Int, y: Int, width: Int, height: Int, depth: Int, material: Material): Graphic =
+  def apply[M <: Material](x: Int, y: Int, width: Int, height: Int, depth: Int, material: M): Graphic[M] =
     Graphic(
       position = Point(x, y),
       rotation = Radians.zero,
@@ -122,7 +122,7 @@ object Graphic {
       material = material
     )
 
-  def apply(bounds: Rectangle, depth: Int, material: Material): Graphic =
+  def apply[M <: Material](bounds: Rectangle, depth: Int, material: M): Graphic[M] =
     Graphic(
       position = bounds.position,
       rotation = Radians.zero,
@@ -134,7 +134,7 @@ object Graphic {
       material = material
     )
 
-  def apply(width: Int, height: Int, material: Material): Graphic =
+  def apply[M <: Material](width: Int, height: Int, material: M): Graphic[M] =
     Graphic(
       position = Point.zero,
       rotation = Radians.zero,

--- a/indigo/indigo/src/main/scala/indigo/shared/scenegraph/Sprite.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/scenegraph/Sprite.scala
@@ -12,9 +12,9 @@ import indigo.shared.datatypes._
 
 /** Sprites are used to represented key-frame animated screen elements.
   */
-final case class Sprite(
+final case class Sprite[M <: Material](
     bindingKey: BindingKey,
-    material: Material,
+    material: M,
     animationKey: AnimationKey,
     animationActions: List[AnimationAction],
     eventHandler: ((Rectangle, GlobalEvent)) => List[GlobalEvent],
@@ -27,7 +27,7 @@ final case class Sprite(
 ) extends DependentNode
     with EventHandler
     with Cloneable
-    with SpatialModifiers[Sprite] derives CanEqual {
+    with SpatialModifiers[Sprite[M]] derives CanEqual {
 
   lazy val x: Int = position.x
   lazy val y: Int = position.y
@@ -35,94 +35,94 @@ final case class Sprite(
   def calculatedBounds(locator: BoundaryLocator): Option[Rectangle] =
     locator.spriteBounds(this).map(rect => BoundaryLocator.findBounds(this, rect.position, rect.size, ref))
 
-  def withDepth(newDepth: Depth): Sprite =
+  def withDepth(newDepth: Depth): Sprite[M]=
     this.copy(depth = newDepth)
 
-  def withMaterial(newMaterial: Material): Sprite =
+  def withMaterial[MB <: Material](newMaterial: MB): Sprite[MB]=
     this.copy(material = newMaterial)
 
-  def modifyMaterial(alter: Material => Material): Sprite =
+  def modifyMaterial[MB <: Material](alter: M => MB): Sprite[MB]=
     this.copy(material = alter(material))
 
-  def moveTo(pt: Point): Sprite =
+  def moveTo(pt: Point): Sprite[M]=
     this.copy(position = pt)
-  def moveTo(x: Int, y: Int): Sprite =
+  def moveTo(x: Int, y: Int): Sprite[M]=
     moveTo(Point(x, y))
-  def withPosition(newPosition: Point): Sprite =
+  def withPosition(newPosition: Point): Sprite[M]=
     moveTo(newPosition)
 
-  def moveBy(pt: Point): Sprite =
+  def moveBy(pt: Point): Sprite[M]=
     this.copy(position = position + pt)
-  def moveBy(x: Int, y: Int): Sprite =
+  def moveBy(x: Int, y: Int): Sprite[M]=
     moveBy(Point(x, y))
 
-  def rotateTo(angle: Radians): Sprite =
+  def rotateTo(angle: Radians): Sprite[M]=
     this.copy(rotation = angle)
-  def rotateBy(angle: Radians): Sprite =
+  def rotateBy(angle: Radians): Sprite[M]=
     rotateTo(rotation + angle)
-  def withRotation(newRotation: Radians): Sprite =
+  def withRotation(newRotation: Radians): Sprite[M]=
     rotateTo(newRotation)
 
-  def scaleBy(amount: Vector2): Sprite =
+  def scaleBy(amount: Vector2): Sprite[M]=
     this.copy(scale = scale * amount)
-  def scaleBy(x: Double, y: Double): Sprite =
+  def scaleBy(x: Double, y: Double): Sprite[M]=
     scaleBy(Vector2(x, y))
-  def withScale(newScale: Vector2): Sprite =
+  def withScale(newScale: Vector2): Sprite[M]=
     this.copy(scale = newScale)
 
-  def transformTo(newPosition: Point, newRotation: Radians, newScale: Vector2): Sprite =
+  def transformTo(newPosition: Point, newRotation: Radians, newScale: Vector2): Sprite[M]=
     this.copy(position = newPosition, rotation = newRotation, scale = newScale)
 
-  def transformBy(positionDiff: Point, rotationDiff: Radians, scaleDiff: Vector2): Sprite =
+  def transformBy(positionDiff: Point, rotationDiff: Radians, scaleDiff: Vector2): Sprite[M]=
     transformTo(position + positionDiff, rotation + rotationDiff, scale * scaleDiff)
 
-  def withBindingKey(newBindingKey: BindingKey): Sprite =
+  def withBindingKey(newBindingKey: BindingKey): Sprite[M]=
     this.copy(bindingKey = newBindingKey)
 
-  def flipHorizontal(isFlipped: Boolean): Sprite =
+  def flipHorizontal(isFlipped: Boolean): Sprite[M]=
     this.copy(flip = flip.withHorizontalFlip(isFlipped))
-  def flipVertical(isFlipped: Boolean): Sprite =
+  def flipVertical(isFlipped: Boolean): Sprite[M]=
     this.copy(flip = flip.withVerticalFlip(isFlipped))
-  def withFlip(newFlip: Flip): Sprite =
+  def withFlip(newFlip: Flip): Sprite[M]=
     this.copy(flip = newFlip)
 
-  def withRef(newRef: Point): Sprite =
+  def withRef(newRef: Point): Sprite[M]=
     this.copy(ref = newRef)
-  def withRef(x: Int, y: Int): Sprite =
+  def withRef(x: Int, y: Int): Sprite[M]=
     withRef(Point(x, y))
 
-  def withAnimationKey(newAnimationKey: AnimationKey): Sprite =
+  def withAnimationKey(newAnimationKey: AnimationKey): Sprite[M]=
     this.copy(animationKey = newAnimationKey)
 
-  def play(): Sprite =
+  def play(): Sprite[M]=
     this.copy(animationActions = animationActions ++ List(Play))
 
-  def changeCycle(label: CycleLabel): Sprite =
+  def changeCycle(label: CycleLabel): Sprite[M]=
     this.copy(animationActions = animationActions ++ List(ChangeCycle(label)))
 
-  def jumpToFirstFrame(): Sprite =
+  def jumpToFirstFrame(): Sprite[M]=
     this.copy(animationActions = animationActions ++ List(JumpToFirstFrame))
 
-  def jumpToLastFrame(): Sprite =
+  def jumpToLastFrame(): Sprite[M]=
     this.copy(animationActions = animationActions ++ List(JumpToLastFrame))
 
-  def jumpToFrame(number: Int): Sprite =
+  def jumpToFrame(number: Int): Sprite[M]=
     this.copy(animationActions = animationActions ++ List(JumpToFrame(number)))
 
-  def onEvent(e: ((Rectangle, GlobalEvent)) => List[GlobalEvent]): Sprite =
+  def onEvent(e: ((Rectangle, GlobalEvent)) => List[GlobalEvent]): Sprite[M]=
     this.copy(eventHandler = e)
 
 }
 
 object Sprite {
-  def apply(
+  def apply[M <: Material](
       bindingKey: BindingKey,
       x: Int,
       y: Int,
       depth: Int,
       animationKey: AnimationKey,
-      material: Material
-  ): Sprite =
+      material: M
+  ): Sprite[M]=
     Sprite(
       position = Point(x, y),
       rotation = Radians.zero,
@@ -137,7 +137,7 @@ object Sprite {
       material = material
     )
 
-  def apply(
+  def apply[M <: Material](
       bindingKey: BindingKey,
       position: Point,
       depth: Depth,
@@ -146,8 +146,8 @@ object Sprite {
       animationKey: AnimationKey,
       ref: Point,
       eventHandler: ((Rectangle, GlobalEvent)) => List[GlobalEvent],
-      material: Material
-  ): Sprite =
+      material: M
+  ): Sprite[M]=
     Sprite(
       position = position,
       rotation = rotation,
@@ -162,7 +162,7 @@ object Sprite {
       material = material
     )
 
-  def apply(bindingKey: BindingKey, animationKey: AnimationKey, material: Material): Sprite =
+  def apply[M <: Material](bindingKey: BindingKey, animationKey: AnimationKey, material: M): Sprite[M]=
     Sprite(
       position = Point.zero,
       rotation = Radians.zero,

--- a/indigo/indigo/src/main/scala/indigo/shared/scenegraph/Text.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/scenegraph/Text.scala
@@ -8,11 +8,11 @@ import indigo.shared.BoundaryLocator
 
 /** Used to draw text onto the screen.
   */
-final case class Text(
+final case class Text[M <: Material](
     text: String,
     alignment: TextAlignment,
     fontKey: FontKey,
-    material: Material,
+    material: M,
     eventHandler: ((Rectangle, GlobalEvent)) => List[GlobalEvent],
     position: Point,
     rotation: Radians,
@@ -22,7 +22,7 @@ final case class Text(
     flip: Flip
 ) extends DependentNode
     with EventHandler
-    with SpatialModifiers[Text] derives CanEqual {
+    with SpatialModifiers[Text[M]] derives CanEqual {
 
   def calculatedBounds(locator: BoundaryLocator): Option[Rectangle] =
     Option(locator.textBounds(this)).map { rect =>
@@ -39,83 +39,83 @@ final case class Text(
   lazy val x: Int = position.x
   lazy val y: Int = position.y
 
-  def withMaterial(newMaterial: Material): Text =
+  def withMaterial[MB <: Material](newMaterial: MB): Text[MB] =
     this.copy(material = newMaterial)
 
-  def modifyMaterial(alter: Material => Material): Text =
+  def modifyMaterial[MB <: Material](alter: M => MB): Text[MB] =
     this.copy(material = alter(material))
 
-  def moveTo(pt: Point): Text =
+  def moveTo(pt: Point): Text[M] =
     this.copy(position = pt)
-  def moveTo(x: Int, y: Int): Text =
+  def moveTo(x: Int, y: Int): Text[M] =
     moveTo(Point(x, y))
-  def withPosition(newPosition: Point): Text =
+  def withPosition(newPosition: Point): Text[M] =
     moveTo(newPosition)
 
-  def moveBy(pt: Point): Text =
+  def moveBy(pt: Point): Text[M] =
     this.copy(position = position + pt)
-  def moveBy(x: Int, y: Int): Text =
+  def moveBy(x: Int, y: Int): Text[M] =
     moveBy(Point(x, y))
 
-  def rotateTo(angle: Radians): Text =
+  def rotateTo(angle: Radians): Text[M] =
     this.copy(rotation = angle)
-  def rotateBy(angle: Radians): Text =
+  def rotateBy(angle: Radians): Text[M] =
     rotateTo(rotation + angle)
-  def withRotation(newRotation: Radians): Text =
+  def withRotation(newRotation: Radians): Text[M] =
     rotateTo(newRotation)
 
-  def scaleBy(amount: Vector2): Text =
+  def scaleBy(amount: Vector2): Text[M] =
     this.copy(scale = scale * amount)
-  def scaleBy(x: Double, y: Double): Text =
+  def scaleBy(x: Double, y: Double): Text[M] =
     scaleBy(Vector2(x, y))
-  def withScale(newScale: Vector2): Text =
+  def withScale(newScale: Vector2): Text[M] =
     this.copy(scale = newScale)
 
-  def transformTo(newPosition: Point, newRotation: Radians, newScale: Vector2): Text =
+  def transformTo(newPosition: Point, newRotation: Radians, newScale: Vector2): Text[M] =
     this.copy(position = newPosition, rotation = newRotation, scale = newScale)
 
-  def transformBy(positionDiff: Point, rotationDiff: Radians, scaleDiff: Vector2): Text =
+  def transformBy(positionDiff: Point, rotationDiff: Radians, scaleDiff: Vector2): Text[M] =
     transformTo(position + positionDiff, rotation + rotationDiff, scale * scaleDiff)
 
-  def withDepth(newDepth: Depth): Text =
+  def withDepth(newDepth: Depth): Text[M] =
     this.copy(depth = newDepth)
 
-  def withRef(newRef: Point): Text =
+  def withRef(newRef: Point): Text[M] =
     this.copy(ref = newRef)
-  def withRef(x: Int, y: Int): Text =
+  def withRef(x: Int, y: Int): Text[M] =
     withRef(Point(x, y))
 
-  def flipHorizontal(isFlipped: Boolean): Text =
+  def flipHorizontal(isFlipped: Boolean): Text[M] =
     this.copy(flip = flip.withHorizontalFlip(isFlipped))
-  def flipVertical(isFlipped: Boolean): Text =
+  def flipVertical(isFlipped: Boolean): Text[M] =
     this.copy(flip = flip.withVerticalFlip(isFlipped))
-  def withFlip(newFlip: Flip): Text =
+  def withFlip(newFlip: Flip): Text[M] =
     this.copy(flip = newFlip)
 
-  def withAlignment(newAlignment: TextAlignment): Text =
+  def withAlignment(newAlignment: TextAlignment): Text[M] =
     this.copy(alignment = newAlignment)
 
-  def alignLeft: Text =
+  def alignLeft: Text[M] =
     this.copy(alignment = TextAlignment.Left)
-  def alignCenter: Text =
+  def alignCenter: Text[M] =
     this.copy(alignment = TextAlignment.Center)
-  def alignRight: Text =
+  def alignRight: Text[M] =
     this.copy(alignment = TextAlignment.Right)
 
-  def withText(newText: String): Text =
+  def withText(newText: String): Text[M] =
     this.copy(text = newText)
 
-  def withFontKey(newFontKey: FontKey): Text =
+  def withFontKey(newFontKey: FontKey): Text[M] =
     this.copy(fontKey = newFontKey)
 
-  def onEvent(e: ((Rectangle, GlobalEvent)) => List[GlobalEvent]): Text =
+  def onEvent(e: ((Rectangle, GlobalEvent)) => List[GlobalEvent]): Text[M] =
     this.copy(eventHandler = e)
 
 }
 
 object Text {
 
-  def apply(text: String, x: Int, y: Int, depth: Int, fontKey: FontKey, material: Material): Text =
+  def apply[M <: Material](text: String, x: Int, y: Int, depth: Int, fontKey: FontKey, material: M): Text[M] =
     Text(
       position = Point(x, y),
       rotation = Radians.zero,
@@ -130,7 +130,7 @@ object Text {
       material = material
     )
 
-  def apply(text: String, fontKey: FontKey, material: Material): Text =
+  def apply[M <: Material](text: String, fontKey: FontKey, material: M): Text[M] =
     Text(
       position = Point.zero,
       rotation = Radians.zero,

--- a/indigo/indigo/src/test/scala/indigo/shared/BoundaryLocatorTests.scala
+++ b/indigo/indigo/src/test/scala/indigo/shared/BoundaryLocatorTests.scala
@@ -72,7 +72,7 @@ class BoundaryLocatorTests extends munit.FunSuite {
 
     val fontInfo = FontInfo(fontKey, 256, 256, FontChar("?", 0, 0, 16, 16)).addChars(chars)
 
-    val text: Text =
+    val text: Text[_] =
       Text("<test>", 50, 50, 1, fontKey, material)
   }
 

--- a/indigo/indigo/src/test/scala/indigo/shared/formats/AsepriteTests.scala
+++ b/indigo/indigo/src/test/scala/indigo/shared/formats/AsepriteTests.scala
@@ -159,7 +159,7 @@ object AsepriteSampleData {
       )
     )
 
-  val sprite: Sprite =
+  val sprite: Sprite[_] =
     Sprite(
       bindingKey = BindingKey("0000000000000000"),
       position = Point.zero,

--- a/indigo/indigo/src/test/scala/indigo/shared/formats/TiledMapTests.scala
+++ b/indigo/indigo/src/test/scala/indigo/shared/formats/TiledMapTests.scala
@@ -80,8 +80,8 @@ class TiledMapTests extends munit.FunSuite {
     actual.children.head match {
       case g: Group =>
         // Only 3 tiles have contents.
-        val graphics: List[Graphic] =
-          g.children.collect { case graphic: Graphic => graphic }
+        val graphics: List[Graphic[_]] =
+          g.children.collect { case graphic: Graphic[_] => graphic }
 
         assertEquals(graphics.length, 3)
         assertEquals(graphics(0).position, Point(32, 64))

--- a/indigo/indigo/src/test/scala/indigo/shared/platform/DisplayObjectConversionsTests.scala
+++ b/indigo/indigo/src/test/scala/indigo/shared/platform/DisplayObjectConversionsTests.scala
@@ -32,7 +32,7 @@ import indigo.shared.QuickCache
 @SuppressWarnings(Array("scalafix:DisableSyntax.throw"))
 class DisplayObjectConversionsTests extends munit.FunSuite {
 
-  val graphic: Graphic =
+  val graphic: Graphic[_] =
     Graphic(Rectangle(10, 20, 200, 100), 2, Material.Bitmap(AssetName("texture")))
 
   val animationRegister          = new AnimationsRegister

--- a/indigo/indigo/src/test/scala/indigo/shared/subsystems/SubSystemTests.scala
+++ b/indigo/indigo/src/test/scala/indigo/shared/subsystems/SubSystemTests.scala
@@ -10,7 +10,7 @@ class SubSystemTests extends munit.FunSuite {
   val subSystem = PointsTrackerExample(0)
 
   test("A SubSystem (PointsTracker example).should render the initial state correctly") {
-    val expected = subSystem.present(context(6), 1230).unsafeGet.layers.head.nodes.head.asInstanceOf[Text].text
+    val expected = subSystem.present(context(6), 1230).unsafeGet.layers.head.nodes.head.asInstanceOf[Text[_]].text
 
     assert(expected == "1230")
   }
@@ -27,7 +27,7 @@ class SubSystemTests extends munit.FunSuite {
         .head
         .nodes
         .head
-        .asInstanceOf[Text]
+        .asInstanceOf[Text[_]]
         .text
     }
 
@@ -46,7 +46,7 @@ class SubSystemTests extends munit.FunSuite {
         .head
         .nodes
         .head
-        .asInstanceOf[Text]
+        .asInstanceOf[Text[_]]
         .text
     }
 

--- a/indigo/indigo/src/test/scala/indigo/shared/subsystems/SubSystemsRegisterTests.scala
+++ b/indigo/indigo/src/test/scala/indigo/shared/subsystems/SubSystemsRegisterTests.scala
@@ -54,7 +54,7 @@ class SubSystemsRegisterTests extends munit.FunSuite {
         .present(context(6))
         .unsafeGet
         .layers.flatMap(_.nodes)
-        .map(_.asInstanceOf[Text].text)
+        .map(_.asInstanceOf[Text[_]].text)
 
     assert(rendered.contains("20"))
     assert(rendered.contains("60"))

--- a/indigo/perf/src/main/scala/com/example/perf/PerfGame.scala
+++ b/indigo/perf/src/main/scala/com/example/perf/PerfGame.scala
@@ -105,4 +105,4 @@ object PerfGame extends IndigoDemo[Unit, Dude, DudeModel, Unit] {
 
 }
 
-final case class Dude(aseprite: Aseprite, sprite: Sprite)
+final case class Dude(aseprite: Aseprite, sprite: Sprite[_])

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/SandboxGame.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/SandboxGame.scala
@@ -202,7 +202,7 @@ object SandboxGame extends IndigoGame[SandboxBootData, SandboxStartupData, Sandb
     Outcome(SceneUpdateFragment(Layer(BindingKey("fps counter")).withDepth(Depth(200))))
 }
 
-final case class Dude(aseprite: Aseprite, sprite: Sprite)
+final case class Dude(aseprite: Aseprite, sprite: Sprite[Material.ImageEffects])
 final case class SandboxBootData(message: String, gameViewport: GameViewport)
 final case class SandboxStartupData(dude: Dude, viewportCenter: Point)
 final case class SandboxViewModel(offset: Point, single: InputField, multi: InputField, useLightingLayer: Boolean)

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/SandboxView.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/SandboxView.scala
@@ -65,21 +65,14 @@ object SandboxView {
       currentState.dude.dude.sprite
         .moveBy(8, 10)
         .moveBy(viewModel.offset)
-        .modifyMaterial {
-          case m: Material.ImageEffects =>
-            m.withAlpha(1)
-              .withTint(RGBA.Green.withAmount(0.25))
-              .withSaturation(1.0)
-
-          case m =>
-            m
-        },
+        .modifyMaterial(
+          _.withAlpha(1)
+            .withTint(RGBA.Green.withAmount(0.25))
+            .withSaturation(1.0)
+        ),
       currentState.dude.dude.sprite
         .moveBy(8, -10)
-        .modifyMaterial {
-          case m: Material.ImageEffects => m.withAlpha(0.5).withTint(RGBA.Red.withAmount(0.75))
-          case m                        => m
-        },
+        .modifyMaterial(_.withAlpha(0.5).withTint(RGBA.Red.withAmount(0.75))),
       Clone(dudeCloneId, Depth(1), CloneTransformData.startAt(Point(16, 64)))
         .withHorizontalFlip(true)
     )

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/BoundsScene.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/BoundsScene.scala
@@ -49,12 +49,12 @@ object BoundsScene extends Scene[SandboxStartupData, SandboxGameModel, SandboxVi
 
     val speed = 0.25
 
-    val graphic: Graphic =
+    val graphic: Graphic[Material.Bitmap] =
       Graphic(Rectangle(0, 0, 40, 40), 1, BoundsAssets.junctionBoxMaterialOff)
         .moveTo(context.startUpData.viewportCenter)
         .rotateTo(Radians.fromSeconds(context.running * speed))
 
-    val text: Text =
+    val text: Text[Material.ImageEffects] =
       Text("boom!\nfish", Fonts.fontKey, SandboxAssets.fontMaterial).alignRight
         .moveTo(150, 100)
         .rotateTo(Radians.fromSeconds(context.running * speed).negative)
@@ -89,7 +89,7 @@ object BoundsScene extends Scene[SandboxStartupData, SandboxGameModel, SandboxVi
         .moveTo(180, 150)
         .rotateTo(Radians.fromSeconds(context.running * speed).invert)
 
-    val sprite: Sprite =
+    val sprite: Sprite[Material.ImageEffects] =
       context.startUpData.dude.sprite
         .scaleBy(2, 2)
         .moveTo(50, 120)

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/LegacyEffectsScene.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/LegacyEffectsScene.scala
@@ -31,17 +31,28 @@ object LegacyEffectsScene extends Scene[SandboxStartupData, SandboxGameModel, Sa
   def subSystems: Set[SubSystem] =
     Set()
 
-  def updateModel(context: FrameContext[SandboxStartupData], model: SandboxGameModel): GlobalEvent => Outcome[SandboxGameModel] =
+  def updateModel(
+      context: FrameContext[SandboxStartupData],
+      model: SandboxGameModel
+  ): GlobalEvent => Outcome[SandboxGameModel] =
     _ => Outcome(model)
 
-  def updateViewModel(context: FrameContext[SandboxStartupData], model: SandboxGameModel, viewModel: SandboxViewModel): GlobalEvent => Outcome[SandboxViewModel] =
+  def updateViewModel(
+      context: FrameContext[SandboxStartupData],
+      model: SandboxGameModel,
+      viewModel: SandboxViewModel
+  ): GlobalEvent => Outcome[SandboxViewModel] =
     _ => Outcome(viewModel)
 
-  val graphic: Graphic =
+  val graphic: Graphic[LegacyEffects] =
     Graphic(Rectangle(0, 0, 40, 40), 1, SandboxAssets.junctionBoxEffectsMaterial)
       .withRef(20, 20)
 
-  def present(context: FrameContext[SandboxStartupData], model: SandboxGameModel, viewModel: SandboxViewModel): Outcome[SceneUpdateFragment] = {
+  def present(
+      context: FrameContext[SandboxStartupData],
+      model: SandboxGameModel,
+      viewModel: SandboxViewModel
+  ): Outcome[SceneUpdateFragment] = {
     val viewCenter: Point = context.startUpData.viewportCenter + Point(0, -25)
 
     Outcome(
@@ -49,73 +60,47 @@ object LegacyEffectsScene extends Scene[SandboxStartupData, SandboxGameModel, Sa
         graphic // tint - identical to ImageEffects material
           .moveTo(viewCenter)
           .moveBy(0, -40)
-          .modifyMaterial {
-            case m: LegacyEffects => m.withTint(RGBA.Red)
-            case m                => m
-          },
+          .modifyMaterial(_.withTint(RGBA.Red)),
         graphic // alpha - identical to ImageEffects material
           .moveTo(viewCenter)
           .moveBy(-60, -40)
-          .modifyMaterial {
-            case m: LegacyEffects => m.withAlpha(0.5)
-            case m                => m
-          },
+          .modifyMaterial(_.withAlpha(0.5)),
         graphic // saturation - identical to ImageEffects material
           .moveTo(viewCenter)
           .moveBy(-30, -40)
-          .modifyMaterial {
-            case m: LegacyEffects => m.withSaturation(0.0)
-            case m                => m
-          },
+          .modifyMaterial(_.withSaturation(0.0)),
         graphic //color overlay - identical to ImageEffects material
           .moveTo(viewCenter)
           .moveBy(30, -40)
-          .modifyMaterial {
-            case m: LegacyEffects => m.withOverlay(Fill.Color(RGBA.Magenta.withAmount(0.75)))
-            case m                => m
-          },
+          .modifyMaterial(_.withOverlay(Fill.Color(RGBA.Magenta.withAmount(0.75)))),
         graphic // linear gradient overlay - identical to ImageEffects material
           .moveTo(viewCenter)
           .moveBy(60, -40)
-          .modifyMaterial {
-            case m: LegacyEffects => m.withOverlay(Fill.LinearGradient(Point.zero, RGBA.Magenta, Point(40), RGBA.Cyan.withAmount(0.5)))
-            case m                => m
-          },
+          .modifyMaterial(
+            _.withOverlay(Fill.LinearGradient(Point.zero, RGBA.Magenta, Point(40), RGBA.Cyan.withAmount(0.5)))
+          ),
         graphic // radial gradient overlay - identical to ImageEffects material
           .moveTo(viewCenter)
           .moveBy(-60, 10)
-          .modifyMaterial {
-            case m: LegacyEffects => m.withOverlay(Fill.RadialGradient(Point(20), 10, RGBA.Magenta.withAmount(0.5), RGBA.Cyan.withAmount(0.25)))
-            case m                => m
-          },
+          .modifyMaterial(
+            _.withOverlay(Fill.RadialGradient(Point(20), 10, RGBA.Magenta.withAmount(0.5), RGBA.Cyan.withAmount(0.25)))
+          ),
         graphic // inner glow
           .moveTo(viewCenter)
           .moveBy(0, 10)
-          .modifyMaterial {
-            case m: LegacyEffects => m.withGlow(Glow(RGBA.Green, 2.0, 0.0))
-            case m                => m
-          },
+          .modifyMaterial(_.withGlow(Glow(RGBA.Green, 2.0, 0.0))),
         graphic // outer glow
           .moveTo(viewCenter)
           .moveBy(-30, 10)
-          .modifyMaterial {
-            case m: LegacyEffects => m.withGlow(Glow(RGBA.Blue, 0.0, 2.0))
-            case m                => m
-          },
+          .modifyMaterial(_.withGlow(Glow(RGBA.Blue, 0.0, 2.0))),
         graphic // inner border
           .moveTo(viewCenter)
           .moveBy(30, 60)
-          .modifyMaterial {
-            case m: LegacyEffects => m.withBorder(Border(RGBA(1.0, 0.5, 0.0, 1.0), Thickness.Thick, Thickness.None))
-            case m                => m
-          },
+          .modifyMaterial(_.withBorder(Border(RGBA(1.0, 0.5, 0.0, 1.0), Thickness.Thick, Thickness.None))),
         graphic // outer border
           .moveTo(viewCenter)
           .moveBy(60, 60)
-          .modifyMaterial {
-            case m: LegacyEffects => m.withBorder(Border(RGBA.Yellow, Thickness.None, Thickness.Thick))
-            case m                => m
-          },
+          .modifyMaterial(_.withBorder(Border(RGBA.Yellow, Thickness.None, Thickness.Thick))),
         graphic // rotate & scale - standard transform
           .moveTo(viewCenter)
           .moveBy(30, 10)

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/LightsScene.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/LightsScene.scala
@@ -33,11 +33,11 @@ object LightsScene extends Scene[SandboxStartupData, SandboxGameModel, SandboxVi
   def updateViewModel(context: FrameContext[SandboxStartupData], model: SandboxGameModel, viewModel: SandboxViewModel): GlobalEvent => Outcome[SandboxViewModel] =
     _ => Outcome(viewModel)
 
-  val graphic: Graphic =
+  val graphic: Graphic[Material.Bitmap] =
     Graphic(Rectangle(0, 0, 40, 40), 1, LightingAssets.junctionBoxMaterialOn)
       .withRef(20, 20)
 
-  val grid: List[Graphic] = {
+  val grid: List[Graphic[Material.Bitmap]] = {
     val rows    = 4
     val columns = 6
     val offset  = Point(0)

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/RefractionScene.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/RefractionScene.scala
@@ -7,6 +7,7 @@ import com.example.sandbox.SandboxGameModel
 import com.example.sandbox.SandboxViewModel
 import com.example.sandbox.SandboxAssets
 import indigoextras.effectmaterials.Refraction
+import indigoextras.effectmaterials.RefractionEntity
 
 object RefractionScene extends Scene[SandboxStartupData, SandboxGameModel, SandboxViewModel] {
 
@@ -34,23 +35,23 @@ object RefractionScene extends Scene[SandboxStartupData, SandboxGameModel, Sandb
   def updateViewModel(context: FrameContext[SandboxStartupData], model: SandboxGameModel, viewModel: SandboxViewModel): GlobalEvent => Outcome[SandboxViewModel] =
     _ => Outcome(viewModel)
 
-  val graphic: Graphic =
+  val graphic: Graphic[Material.Bitmap] =
     Graphic(Rectangle(0, 0, 64, 64), 1, SandboxAssets.junctionBoxMaterial)
       .withRef(20, 20)
 
-  val imageLight: Graphic =
+  val imageLight: Graphic[Material.Bitmap] =
     Graphic(Rectangle(0, 0, 320, 240), 1, SandboxAssets.imageLightMaterial)
       .moveBy(-14, -60)
 
-  val distortion: Graphic =
+  val distortion: Graphic[RefractionEntity] =
     Graphic(Rectangle(0, 0, 240, 240), 1, SandboxAssets.normalMapMaterial)
       .scaleBy(0.5, 0.5)
       .withRef(120, 120)
 
-  val background: Graphic =
+  val background: Graphic[Material.Bitmap] =
     Graphic(Rectangle(0, 0, 790, 380), 1, SandboxAssets.foliageMaterial)
 
-  def sliding: Signal[Graphic] =
+  def sliding: Signal[Graphic[RefractionEntity]] =
     Signal.SmoothPulse.map { d =>
       distortion.moveTo(Point(70, 70 + (50 * d).toInt))
     }


### PR DESCRIPTION
This means that this:

```scala
      graphic
          .modifyMaterial {
            case m: LegacyEffects => m.withOverlay(Fill.Color(RGBA.Magenta.withAmount(0.75)))
            case m                => m
          }
```

...can now be this:

```scala
      graphic
          .modifyMaterial(_.withOverlay(Fill.Color(RGBA.Magenta.withAmount(0.75))))
```

At the cost of having to do this:

```scala
val foo: Graphic[_]
```

or this..

```scala
final case class (myGraphic: Graphic[Material.Bitmap])
```

...everywhere.

Worth it?

Applies to `Text`, `Graphic`, and `Sprite`. `TextBox`s and `Shape`s don't work with materials.