### PR TITLE
Add a Camera to the scene

### DIFF
--- a/indigo/indigo/src/main/scala/indigo/package.scala
+++ b/indigo/indigo/src/main/scala/indigo/package.scala
@@ -366,6 +366,12 @@ val HttpResponse: shared.networking.HttpReceiveEvent.HttpResponse.type = shared.
 type SceneUpdateFragment = shared.scenegraph.SceneUpdateFragment
 val SceneUpdateFragment: shared.scenegraph.SceneUpdateFragment.type = shared.scenegraph.SceneUpdateFragment
 
+type Camera = shared.scenegraph.Camera
+val Camera: shared.scenegraph.Camera.type = shared.scenegraph.Camera
+
+type Zoom = shared.scenegraph.Zoom
+val Zoom: shared.scenegraph.Zoom.type = shared.scenegraph.Zoom
+
 type Layer = shared.scenegraph.Layer
 val Layer: shared.scenegraph.Layer.type = shared.scenegraph.Layer
 

--- a/indigo/indigo/src/main/scala/indigo/platform/renderer/shared/CameraHelper.scala
+++ b/indigo/indigo/src/main/scala/indigo/platform/renderer/shared/CameraHelper.scala
@@ -1,0 +1,44 @@
+package indigo.platform.renderer.shared
+
+import indigo.shared.datatypes.mutable.CheapMatrix4
+
+object CameraHelper:
+
+  def calculateCameraMatrix(
+      screenWidth: Double,
+      screenHeight: Double,
+      magnification: Double,
+      cameraX: Double,
+      cameraY: Double,
+      cameraZoom: Double,
+      flipY: Boolean
+  ): CheapMatrix4 =
+    val newWidth  = screenWidth / magnification
+    val newHeight = screenHeight / magnification
+
+    val bounds: (Double, Double, Double, Double) =
+      zoom(cameraX, cameraY, newWidth, newHeight, cameraZoom)
+
+    val mat =
+      CheapMatrix4
+        .orthographic(
+          bounds._1,
+          bounds._2,
+          bounds._3,
+          bounds._4
+        )
+     
+    if flipY then mat.scale(1.0, -1.0, 1.0) else mat
+
+  def zoom(x: Double, y: Double, width: Double, height: Double, zoom: Double): (Double, Double, Double, Double) =
+    val newWidth: Double  = width / zoom
+    val newHeight: Double = height / zoom
+    val amountH: Double   = (width - (width / zoom)) / 2
+    val amountV: Double   = (height - (height / zoom)) / 2
+
+    (
+      x + amountH,
+      y + amountV,
+      newWidth,
+      newHeight
+    )

--- a/indigo/indigo/src/main/scala/indigo/platform/renderer/webgl1/RendererWebGL1.scala
+++ b/indigo/indigo/src/main/scala/indigo/platform/renderer/webgl1/RendererWebGL1.scala
@@ -5,6 +5,7 @@ import indigo.platform.renderer.shared.WebGLHelper
 import indigo.platform.renderer.shared.LoadedTextureAsset
 import indigo.platform.renderer.shared.TextureLookupResult
 import indigo.platform.renderer.shared.ContextAndCanvas
+import indigo.platform.renderer.shared.CameraHelper
 import indigo.platform.events.GlobalEventStream
 
 import indigo.shared.platform.RendererConfig
@@ -97,13 +98,49 @@ final class RendererWebGL1(
 
     sceneData.layers.foreach { layer =>
       val projection =
-        layer.magnification match {
-          case None =>
+        (layer.magnification, sceneData.camera) match {
+          case (None, None) =>
             gameProjection
 
-          case Some(m) =>
-            CheapMatrix4
-              .orthographic(cNc.canvas.width.toDouble / m.toDouble, cNc.canvas.height.toDouble / m.toDouble)
+          case (Some(m), None) =>
+            CameraHelper
+              .calculateCameraMatrix(
+                cNc.canvas.width.toDouble,
+                cNc.canvas.height.toDouble,
+                m.toDouble,
+                0,
+                0,
+                1,
+                false
+              )
+              .mat
+              .toJSArray
+
+          case (None, Some(c)) =>
+            CameraHelper
+              .calculateCameraMatrix(
+                cNc.canvas.width.toDouble,
+                cNc.canvas.height.toDouble,
+                cNc.magnification.toDouble,
+                c.position.x.toDouble,
+                c.position.y.toDouble,
+                c.zoom.toDouble,
+                false
+              )
+              .mat
+              .toJSArray
+
+          case (Some(m), Some(c)) =>
+            CameraHelper
+              .calculateCameraMatrix(
+                cNc.canvas.width.toDouble,
+                cNc.canvas.height.toDouble,
+                m.toDouble,
+                c.position.x.toDouble,
+                c.position.y.toDouble,
+                c.zoom.toDouble,
+                false
+              )
               .mat
               .toJSArray
         }

--- a/indigo/indigo/src/main/scala/indigo/platform/renderer/webgl2/RendererWebGL2.scala
+++ b/indigo/indigo/src/main/scala/indigo/platform/renderer/webgl2/RendererWebGL2.scala
@@ -19,6 +19,7 @@ import indigo.shared.platform.ProcessedSceneData
 import indigo.platform.renderer.shared.LoadedTextureAsset
 import indigo.platform.renderer.shared.TextureLookupResult
 import indigo.platform.renderer.shared.ContextAndCanvas
+import indigo.platform.renderer.shared.CameraHelper
 import indigo.platform.renderer.shared.WebGLHelper
 import indigo.platform.renderer.shared.FrameBufferFunctions
 import indigo.platform.renderer.shared.FrameBufferComponents
@@ -247,16 +248,60 @@ final class RendererWebGL2(
         customShaders
       )
 
+      def makeCacheName(m: Int, w: Int, h: Int, cx: Int, cy: Int, cz: Double): String =
+        s"${m.toString}_${w.toString()}x${h.toString()}-${cx.toString},${cy.toString}_${cz.toString}"
+
       val projection =
-        layer.magnification match {
-          case None =>
+        (layer.magnification, sceneData.camera) match {
+          case (None, None) =>
             defaultLayerProjectionMatrix
 
-          case Some(m) =>
-            QuickCache(s"${m.toString}_${lastWidth.toString()}x${lastHeight.toString()}") {
-              CheapMatrix4
-                .orthographic(lastWidth.toDouble / m.toDouble, lastHeight.toDouble / m.toDouble)
-                .scale(1.0, -1.0, 1.0)
+          case (Some(m), None) =>
+            QuickCache(makeCacheName(m, lastWidth, lastHeight, 0, 0, 1.0d)) {
+              CameraHelper
+                .calculateCameraMatrix(
+                  lastWidth.toDouble,
+                  lastHeight.toDouble,
+                  m.toDouble,
+                  0,
+                  0,
+                  1,
+                  true
+                )
+                .mat
+                .map(_.toFloat)
+            }
+
+          case (None, Some(c)) =>
+            QuickCache(
+              makeCacheName(cNc.magnification, lastWidth, lastHeight, c.position.x, c.position.y, c.zoom.toDouble)
+            ) {
+              CameraHelper
+                .calculateCameraMatrix(
+                  lastWidth.toDouble,
+                  lastHeight.toDouble,
+                  cNc.magnification.toDouble,
+                  c.position.x.toDouble,
+                  c.position.y.toDouble,
+                  c.zoom.toDouble,
+                  true
+                )
+                .mat
+                .map(_.toFloat)
+            }
+
+          case (Some(m), Some(c)) =>
+            QuickCache(makeCacheName(m, lastWidth, lastHeight, c.position.x, c.position.y, c.zoom.toDouble)) {
+              CameraHelper
+                .calculateCameraMatrix(
+                  lastWidth.toDouble,
+                  lastHeight.toDouble,
+                  m.toDouble,
+                  c.position.x.toDouble,
+                  c.position.y.toDouble,
+                  c.zoom.toDouble,
+                  true
+                )
                 .mat
                 .map(_.toFloat)
             }

--- a/indigo/indigo/src/main/scala/indigo/platform/renderer/webgl2/RendererWebGL2.scala
+++ b/indigo/indigo/src/main/scala/indigo/platform/renderer/webgl2/RendererWebGL2.scala
@@ -273,38 +273,32 @@ final class RendererWebGL2(
             }
 
           case (None, Some(c)) =>
-            QuickCache(
-              makeCacheName(cNc.magnification, lastWidth, lastHeight, c.position.x, c.position.y, c.zoom.toDouble)
-            ) {
-              CameraHelper
-                .calculateCameraMatrix(
-                  lastWidth.toDouble,
-                  lastHeight.toDouble,
-                  cNc.magnification.toDouble,
-                  c.position.x.toDouble,
-                  c.position.y.toDouble,
-                  c.zoom.toDouble,
-                  true
-                )
-                .mat
-                .map(_.toFloat)
-            }
+            CameraHelper
+              .calculateCameraMatrix(
+                lastWidth.toDouble,
+                lastHeight.toDouble,
+                cNc.magnification.toDouble,
+                c.position.x.toDouble,
+                c.position.y.toDouble,
+                c.zoom.toDouble,
+                true
+              )
+              .mat
+              .map(_.toFloat)
 
           case (Some(m), Some(c)) =>
-            QuickCache(makeCacheName(m, lastWidth, lastHeight, c.position.x, c.position.y, c.zoom.toDouble)) {
-              CameraHelper
-                .calculateCameraMatrix(
-                  lastWidth.toDouble,
-                  lastHeight.toDouble,
-                  m.toDouble,
-                  c.position.x.toDouble,
-                  c.position.y.toDouble,
-                  c.zoom.toDouble,
-                  true
-                )
-                .mat
-                .map(_.toFloat)
-            }
+            CameraHelper
+              .calculateCameraMatrix(
+                lastWidth.toDouble,
+                lastHeight.toDouble,
+                m.toDouble,
+                c.position.x.toDouble,
+                c.position.y.toDouble,
+                c.zoom.toDouble,
+                true
+              )
+              .mat
+              .map(_.toFloat)
         }
 
       // Clear the blend mode

--- a/indigo/indigo/src/main/scala/indigo/shared/datatypes/mutable/CheapMatrix4.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/datatypes/mutable/CheapMatrix4.scala
@@ -143,6 +143,9 @@ object CheapMatrix4 {
   def orthographic(width: Double, height: Double): CheapMatrix4 =
     orthographic(0, width, height, 0, -10000, 10000)
 
+  def orthographic(x: Double, y: Double, width: Double, height: Double): CheapMatrix4 =
+    orthographic(x, x + width, y + height, y, -10000, 10000)
+
   def translate(tx: Double, ty: Double, tz: Double): Array[Double] =
     Array(
       1,

--- a/indigo/indigo/src/main/scala/indigo/shared/platform/ProcessedSceneData.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/platform/ProcessedSceneData.scala
@@ -5,10 +5,12 @@ import indigo.shared.display.DisplayLayer
 import indigo.shared.shader.ShaderId
 import indigo.shared.display.DisplayObjectUniformData
 import indigo.shared.scenegraph.CloneId
+import indigo.shared.scenegraph.Camera
 
 final class ProcessedSceneData(
     val layers: List[DisplayLayer],
     val cloneBlankDisplayObjects: Map[CloneId, DisplayObject],
     val shaderId: ShaderId,
-    val shaderUniformData: List[DisplayObjectUniformData]
+    val shaderUniformData: List[DisplayObjectUniformData],
+    val camera: Option[Camera]
 )

--- a/indigo/indigo/src/main/scala/indigo/shared/platform/SceneProcessor.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/platform/SceneProcessor.scala
@@ -113,7 +113,8 @@ final class SceneProcessor(
       displayLayers,
       cloneBlankDisplayObjects,
       sceneBlend.shaderId,
-      SceneProcessor.mergeShaderToUniformData(sceneBlend)
+      SceneProcessor.mergeShaderToUniformData(sceneBlend),
+      scene.camera
     )
   }
 
@@ -257,7 +258,9 @@ object SceneProcessor {
         )
     }
 
-  def mergeShaderToUniformData(shaderData: BlendShaderData)(using QuickCache[Array[Float]]): List[DisplayObjectUniformData] =
+  def mergeShaderToUniformData(
+      shaderData: BlendShaderData
+  )(using QuickCache[Array[Float]]): List[DisplayObjectUniformData] =
     shaderData.uniformBlocks.map { ub =>
       DisplayObjectUniformData(
         uniformHash = ub.uniformHash,

--- a/indigo/indigo/src/main/scala/indigo/shared/scenegraph/Camera.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/scenegraph/Camera.scala
@@ -1,0 +1,43 @@
+package indigo.shared.scenegraph
+
+import indigo.shared.datatypes.Point
+
+final case class Camera(position: Point, zoom: Zoom):
+
+  def withX(newX: Int): Camera =
+    this.copy(position = position.withX(newX))
+  def withY(newY: Int): Camera =
+    this.copy(position = position.withY(newY))
+
+  def moveTo(newPosition: Point): Camera =
+    this.copy(position = newPosition)
+  def moveTo(x: Int, y: Int): Camera =
+    moveTo(Point(x, y))
+
+  def moveBy(amount: Point): Camera =
+    this.copy(position = position + amount)
+  def moveBy(x: Int, y: Int): Camera =
+    moveBy(Point(x, y))
+
+  def withZoom(newZoom: Zoom): Camera =
+    this.copy(zoom = newZoom)
+
+object Camera:
+  def default: Camera =
+    Camera(Point.zero, Zoom.x1)
+
+  given CanEqual[Camera, Camera]                 = CanEqual.derived
+  given CanEqual[Option[Camera], Option[Camera]] = CanEqual.derived
+
+opaque type Zoom = Double
+object Zoom:
+  def apply(amount: Double): Zoom = amount
+
+  val x025: Zoom = Zoom(0.25)
+  val x05: Zoom  = Zoom(0.5)
+  val x1: Zoom   = Zoom(1.0)
+  val x2: Zoom   = Zoom(2.0)
+  val x3: Zoom   = Zoom(3.0)
+  val x4: Zoom   = Zoom(4.0)
+
+  extension (z: Zoom) def toDouble: Double = z

--- a/indigo/indigo/src/test/scala/indigo/platform/renderer/shared/CameraHelperTests.scala
+++ b/indigo/indigo/src/test/scala/indigo/platform/renderer/shared/CameraHelperTests.scala
@@ -1,0 +1,71 @@
+package indigo.platform.renderer.shared
+
+class CameraHelperTests extends munit.FunSuite {
+  
+  test("zoom 0.25") {
+
+    val actual =
+      CameraHelper.zoom(0.0d, 0.0d, 100.0d, 50.0d, 0.25d)
+
+    val expected =
+      (-150.0d, -75.0d, 400.0d, 200.0d)
+
+    assertEquals(actual, expected)
+  }
+  
+  test("zoom 0.5") {
+
+    val actual =
+      CameraHelper.zoom(0.0d, 0.0d, 100.0d, 50.0d, 0.5d)
+
+    val expected =
+      (-50.0d, -25.0d, 200.0d, 100.0d)
+
+    assertEquals(actual, expected)
+  }
+  
+  test("zoom x1") {
+
+    val actual =
+      CameraHelper.zoom(0.0d, 0.0d, 100.0d, 50.0d, 1.0d)
+
+    val expected =
+      (0.0d, 0.0d, 100.0d, 50.0d)
+
+    assertEquals(actual, expected)
+  }
+  
+  test("zoom x2") {
+
+    val actual =
+      CameraHelper.zoom(0.0d, 0.0d, 100.0d, 50.0d, 2.0d)
+
+    val expected =
+      (25.0d, 12.5d, 50.0d, 25.0d)
+
+    assertEquals(actual, expected)
+  }
+  
+  test("zoom x4") {
+
+    val actual =
+      CameraHelper.zoom(0.0d, 0.0d, 100.0d, 50.0d, 4.0d)
+
+    val expected =
+      (37.5d, 18.75, 25.0d, 12.5d)
+
+    assertEquals(actual, expected)
+  }
+  
+  test("zoom x2 - off center") {
+
+    val actual =
+      CameraHelper.zoom(10.0d, 10.0d, 100.0d, 50.0d, 2.0d)
+
+    val expected =
+      (35.0d, 22.5d, 50.0d, 25.0d)
+
+    assertEquals(actual, expected)
+  }
+
+}

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/SandboxGame.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/SandboxGame.scala
@@ -13,6 +13,7 @@ import scala.scalajs.js.annotation._
 import com.example.sandbox.scenes.OriginalScene
 import com.example.sandbox.scenes.Shaders
 import com.example.sandbox.scenes.ShapesScene
+import com.example.sandbox.scenes.CameraScene
 import com.example.sandbox.scenes.LightsScene
 import com.example.sandbox.scenes.RefractionScene
 import com.example.sandbox.scenes.LegacyEffectsScene
@@ -30,7 +31,7 @@ object SandboxGame extends IndigoGame[SandboxBootData, SandboxStartupData, Sandb
   private val viewportHeight: Int     = 128 * magnificationLevel
 
   def initialScene(bootData: SandboxBootData): Option[SceneName] =
-    Some(BoundsScene.name)
+    Some(CameraScene.name)
 
   def scenes(bootData: SandboxBootData): NonEmptyList[Scene[SandboxStartupData, SandboxGameModel, SandboxViewModel]] =
     NonEmptyList(
@@ -40,7 +41,8 @@ object SandboxGame extends IndigoGame[SandboxBootData, SandboxStartupData, Sandb
       RefractionScene,
       LegacyEffectsScene,
       TextBoxScene,
-      BoundsScene
+      BoundsScene,
+      CameraScene
     )
 
   val eventFilters: EventFilters = EventFilters.Permissive

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/CameraScene.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/CameraScene.scala
@@ -1,0 +1,74 @@
+package com.example.sandbox.scenes
+
+import indigo._
+import indigo.scenes._
+import com.example.sandbox.SandboxStartupData
+import com.example.sandbox.SandboxGameModel
+import com.example.sandbox.SandboxViewModel
+import com.example.sandbox.SandboxAssets
+
+object CameraScene extends Scene[SandboxStartupData, SandboxGameModel, SandboxViewModel] {
+
+  type SceneModel     = SandboxGameModel
+  type SceneViewModel = SandboxViewModel
+
+  def eventFilters: EventFilters =
+    EventFilters.Restricted
+
+  def modelLens: indigo.scenes.Lens[SandboxGameModel, SandboxGameModel] =
+    Lens.keepOriginal
+
+  def viewModelLens: Lens[SandboxViewModel, SandboxViewModel] =
+    Lens.keepOriginal
+
+  def name: SceneName =
+    SceneName("camera")
+
+  def subSystems: Set[SubSystem] =
+    Set()
+
+  def updateModel(
+      context: FrameContext[SandboxStartupData],
+      model: SandboxGameModel
+  ): GlobalEvent => Outcome[SandboxGameModel] =
+    _ => Outcome(model)
+
+  def updateViewModel(
+      context: FrameContext[SandboxStartupData],
+      model: SandboxGameModel,
+      viewModel: SandboxViewModel
+  ): GlobalEvent => Outcome[SandboxViewModel] =
+    _ => Outcome(viewModel)
+
+  def zoom: Signal[Zoom] =
+    Signal.SmoothPulse.map { d =>
+      Zoom(d * 2.0d)
+    }
+
+  def orbit: Signal[Point] =
+    Signal.Orbit(Point.zero, 100.0d).map(_.toPoint)
+
+  def present(
+      context: FrameContext[SandboxStartupData],
+      model: SandboxGameModel,
+      viewModel: SandboxViewModel
+  ): Outcome[SceneUpdateFragment] = {
+    val viewCenter: Point = context.startUpData.viewportCenter
+
+    Outcome(
+      SceneUpdateFragment(
+        Layer(
+          Graphic(
+            Rectangle(Point.zero, (context.startUpData.viewportCenter * 4).toSize),
+            1,
+            SandboxAssets.foliageMaterial
+          )
+        ).withMagnification(1)
+      ).modifyCamera(
+        _.moveTo(orbit.at(context.running * 0.3))
+          .withZoom(zoom.at(context.running * 0.35))
+      )
+    )
+  }
+
+}


### PR DESCRIPTION
Fixes #124 

Allows you to optionally add a camera to the `SceneUpdateFragment`.

Camera have position (default is 0,0, which means top-left!) and zoom (default is 1).