### PR TITLE
Add `#` prefix in RGBA.fromHexString

### DIFF
--- a/indigo/indigo/src/main/scala/indigo/shared/datatypes/RGBA.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/datatypes/RGBA.scala
@@ -82,7 +82,6 @@ object RGBA:
     }
 
   def fromHexString(hex: String): RGBA =
-    val hex = if hex.startsWith("#") then hex.substring(1).trim else hex.trim
     hex match {
       case h if h.startsWith("0x") && h.length == 10 =>
         fromColorInts(
@@ -97,6 +96,21 @@ object RGBA:
           Integer.parseInt(hex.substring(2, 4), 16),
           Integer.parseInt(hex.substring(4, 6), 16),
           Integer.parseInt(hex.substring(6, 8), 16)
+        )
+
+      case h if h.startsWith("#") &&  h.length == 9 =>
+        fromColorInts(
+          Integer.parseInt(hex.substring(1, 3), 16),
+          Integer.parseInt(hex.substring(3, 5), 16),
+          Integer.parseInt(hex.substring(5, 7), 16)
+        )
+
+      case h if h.startsWith("#") && h.length == 7 =>
+        fromColorInts(
+          Integer.parseInt(hex.substring(1, 3), 16),
+          Integer.parseInt(hex.substring(3, 5), 16),
+          Integer.parseInt(hex.substring(5, 7), 16),
+          Integer.parseInt(hex.substring(7, 9), 16),
         )
 
       case h if h.length == 8 =>

--- a/indigo/indigo/src/main/scala/indigo/shared/datatypes/RGBA.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/datatypes/RGBA.scala
@@ -82,7 +82,8 @@ object RGBA:
     }
 
   def fromHexString(hex: String): RGBA =
-    hex.trim match {
+    val hex = if hex.startsWith("#") then hex.substring(1).trim else hex.trim
+    hex match {
       case h if h.startsWith("0x") && h.length == 10 =>
         fromColorInts(
           Integer.parseInt(hex.substring(2, 4), 16),

--- a/indigo/indigo/src/main/scala/indigo/shared/datatypes/RGBA.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/datatypes/RGBA.scala
@@ -103,14 +103,14 @@ object RGBA:
           Integer.parseInt(hex.substring(1, 3), 16),
           Integer.parseInt(hex.substring(3, 5), 16),
           Integer.parseInt(hex.substring(5, 7), 16)
+          Integer.parseInt(hex.substring(7, 9), 16)
         )
 
       case h if h.startsWith("#") && h.length == 7 =>
         fromColorInts(
           Integer.parseInt(hex.substring(1, 3), 16),
           Integer.parseInt(hex.substring(3, 5), 16),
-          Integer.parseInt(hex.substring(5, 7), 16),
-          Integer.parseInt(hex.substring(7, 9), 16),
+          Integer.parseInt(hex.substring(5, 7), 16)
         )
 
       case h if h.length == 8 =>

--- a/indigo/indigo/src/test/scala/indigo/shared/datatypes/RGBATests.scala
+++ b/indigo/indigo/src/test/scala/indigo/shared/datatypes/RGBATests.scala
@@ -24,13 +24,17 @@ class RGBATests extends munit.FunSuite {
   test("Creating RGBA instances.should convert from Hexadecimal") {
     assertEquals(RGBA.fromHexString("0xFF0000FF"), RGBA.Red)
     assertEquals(RGBA.fromHexString("FF0000FF"), RGBA.Red)
+    assertEquals(RGBA.fromHexString("#FF0000FF"), RGBA.Red)
     assertEquals(RGBA.fromHexString("00FF00FF"), RGBA.Green)
     assertEquals(RGBA.fromHexString("0000FFFF"), RGBA.Blue)
 
     assertEquals(RGBA.fromHexString("0xFF0000"), RGBA.Red)
     assertEquals(RGBA.fromHexString("FF0000"), RGBA.Red)
+    assertEquals(RGBA.fromHexString("#FF0000"), RGBA.Red)
     assertEquals(RGBA.fromHexString("00FF00"), RGBA.Green)
+    assertEquals(RGBA.fromHexString("#00FF00"), RGBA.Green)
     assertEquals(RGBA.fromHexString("0000FF"), RGBA.Blue)
+    assertEquals(RGBA.fromHexString("#0000FF"), RGBA.Blue)
 
     val transparent = RGBA.fromHexString("0xFF000080")
     assertEquals((transparent.a > 0.48 && transparent.a < 0.52), true)

--- a/indigo/indigo/src/test/scala/indigo/shared/datatypes/RGBTests.scala
+++ b/indigo/indigo/src/test/scala/indigo/shared/datatypes/RGBTests.scala
@@ -12,9 +12,12 @@ class RGBTests extends munit.FunSuite {
 
   test("Creating RGB instances.should convert from Hexadecimal") {
     assertEquals(RGB.fromHexString("0xFF0000"), RGB.Red)
+    assertEquals(RGB.fromHexString("#FF0000"), RGB.Red)
     assertEquals(RGB.fromHexString("FF0000"), RGB.Red)
     assertEquals(RGB.fromHexString("00FF00"), RGB.Green)
+    assertEquals(RGB.fromHexString("#00FF00"), RGB.Green)
     assertEquals(RGB.fromHexString("0000FF"), RGB.Blue)
+    assertEquals(RGB.fromHexString("#0000FF"), RGB.Blue)
 
     assertEquals(RGB.fromHexString("0xFF0000FF"), RGB.Red)
   }


### PR DESCRIPTION
I just shadowed `hex`, not sure if this is the most idiomatic Scala.

`RGB.fromHexString` just calls the method of `RGBA` so this should also make it work without changing anything else.