### PR TITLE
Remove unreachable branch when traversing keyboard events

### DIFF
--- a/indigo/indigo/src/main/scala/indigo/shared/input/Keyboard.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/input/Keyboard.scala
@@ -41,9 +41,6 @@ object Keyboard {
 
         case KeyboardEvent.KeyUp(k) :: tl =>
           rec(tl, keysDownAcc.filterNot(p => p === k))
-
-        case _ :: tl =>
-          rec(tl, keysDownAcc)
       }
 
     rec(keyboardEvents, previousKeysDown.reverse)


### PR DESCRIPTION
Improved pattern matching exhaustivity in 3.0.1 is already paying off :smiley: Keyboard event is a sealed trait with two different events, this branch is unreachable.