### PR TITLE
Revisiting shader primitives

### DIFF
--- a/indigo/indigo/src/main/scala/indigo/package.scala
+++ b/indigo/indigo/src/main/scala/indigo/package.scala
@@ -68,6 +68,27 @@ val UniformBlock: shared.shader.UniformBlock.type = shared.shader.UniformBlock
 type ShaderPrimitive = shared.shader.ShaderPrimitive
 val ShaderPrimitive: shared.shader.ShaderPrimitive.type = shared.shader.ShaderPrimitive
 
+type float = shared.shader.ShaderPrimitive.float
+val float: shared.shader.ShaderPrimitive.float.type = shared.shader.ShaderPrimitive.float
+
+type vec2 = shared.shader.ShaderPrimitive.vec2
+val vec2: shared.shader.ShaderPrimitive.vec2.type = shared.shader.ShaderPrimitive.vec2
+
+type vec3 = shared.shader.ShaderPrimitive.vec3
+val vec3: shared.shader.ShaderPrimitive.vec3.type = shared.shader.ShaderPrimitive.vec3
+
+type vec4 = shared.shader.ShaderPrimitive.vec4
+val vec4: shared.shader.ShaderPrimitive.vec4.type = shared.shader.ShaderPrimitive.vec4
+
+type mat4 = shared.shader.ShaderPrimitive.mat4
+val mat4: shared.shader.ShaderPrimitive.mat4.type = shared.shader.ShaderPrimitive.mat4
+
+type array[T] = shared.shader.ShaderPrimitive.array[T]
+val array: shared.shader.ShaderPrimitive.array.type = shared.shader.ShaderPrimitive.array
+
+type rawArray = shared.shader.ShaderPrimitive.rawArray
+val rawArray: shared.shader.ShaderPrimitive.rawArray.type = shared.shader.ShaderPrimitive.rawArray
+
 val StandardShaders: shared.shader.StandardShaders.type = shared.shader.StandardShaders
 
 type Outcome[T] = shared.Outcome[T]

--- a/indigo/indigo/src/main/scala/indigo/shared/shader/ShaderPrimitive.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/shader/ShaderPrimitive.scala
@@ -6,6 +6,12 @@ import indigo.shared.datatypes.RGB
 import indigo.shared.datatypes.RGBA
 import indigo.shared.datatypes.mutable.CheapMatrix4
 import indigo.shared.datatypes.Matrix4
+import indigo.shared.datatypes.Point
+import indigo.shared.datatypes.Rectangle
+import indigo.shared.datatypes.Size
+import indigo.shared.datatypes.Vector2
+import indigo.shared.datatypes.Vector3
+import indigo.shared.datatypes.Vector4
 
 sealed trait ShaderPrimitive derives CanEqual:
   def length: Int
@@ -64,6 +70,10 @@ object ShaderPrimitive:
     def apply(x: Double, y: Double): vec2 =
       vec2(x.toFloat, y.toFloat)
 
+    def fromPoint(pt: Point): vec2 = vec2(pt.x.toFloat, pt.y.toFloat)
+    def fromSize(s: Size): vec2 = vec2(s.width.toFloat, s.height.toFloat)
+    def fromVector2(v: Vector2): vec2 = vec2(v.x, v.y)
+
     given IsShaderValue[vec2] =
       IsShaderValue.create[vec2](length, _.toArray)
 
@@ -83,8 +93,8 @@ object ShaderPrimitive:
     def apply(x: Double, y: Double, z: Double): vec3 =
       vec3(x.toFloat, y.toFloat, z.toFloat)
 
-    def fromRGB(rgb: RGB): vec3 =
-      vec3(rgb.r, rgb.g, rgb.b)
+    def fromRGB(rgb: RGB): vec3 = vec3(rgb.r, rgb.g, rgb.b)
+    def fromVector3(v: Vector3): vec3 = vec3(v.x, v.y, v.z)
 
     given IsShaderValue[vec3] =
       IsShaderValue.create[vec3](length, _.toArray)
@@ -105,11 +115,10 @@ object ShaderPrimitive:
     def apply(x: Double, y: Double, z: Double, w: Double): vec4 =
       vec4(x.toFloat, y.toFloat, z.toFloat, w.toFloat)
 
-    def fromRGB(rgb: RGB): vec4 =
-      vec4(rgb.r, rgb.g, rgb.b, 1.0)
-
-    def fromRGBA(rgba: RGBA): vec4 =
-      vec4(rgba.r, rgba.g, rgba.b, rgba.a)
+    def fromRGB(rgb: RGB): vec4 = vec4(rgb.r, rgb.g, rgb.b, 1.0)
+    def fromRGBA(rgba: RGBA): vec4 = vec4(rgba.r, rgba.g, rgba.b, rgba.a)
+    def fromVector4(v: Vector4): vec4 = vec4(v.x, v.y, v.z, v.w)
+    def fromRectangle(r: Rectangle): vec4 = vec4(r.x.toFloat, r.y.toFloat, r.width.toFloat, r.height.toFloat)
 
     given IsShaderValue[vec4] =
       IsShaderValue.create[vec4](length, _.toArray)

--- a/indigo/indigo/src/test/scala/indigo/shared/shader/ShaderPrimitiveTests.scala
+++ b/indigo/indigo/src/test/scala/indigo/shared/shader/ShaderPrimitiveTests.scala
@@ -1,0 +1,121 @@
+package indigo.shared.shader
+
+import indigo.shared.datatypes.RGB
+import indigo.shared.datatypes.RGBA
+import indigo.shared.datatypes.Matrix4
+
+class ShaderPrimitiveTests extends munit.FunSuite {
+
+  import ShaderPrimitive._
+
+  test("can make an array of 'float'") {
+
+    val actual =
+      array(4, List(float(1), float(2), float(3), float(4))).toArray
+
+    val expected =
+      Array[Float](1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 4, 0, 0, 0)
+
+    assertEquals(actual.toList, expected.toList)
+
+  }
+
+  test("can make an array of 'Float'") {
+
+    val actual =
+      array(4, List(1.0f, 2.0f, 3.0f, 4.0f)).toArray
+
+    val expected =
+      Array[Float](1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 4, 0, 0, 0)
+
+    assertEquals(actual.toList, expected.toList)
+
+  }
+
+  test("can make an array of 'vec2'") {
+
+    val actual =
+      array(4, List(vec2(1), vec2(2), vec2(3), vec2(4))).toArray
+
+    val expected =
+      Array[Float](1, 1, 0, 0, 2, 2, 0, 0, 3, 3, 0, 0, 4, 4, 0, 0)
+
+    assertEquals(actual.toList, expected.toList)
+
+  }
+
+  test("can make an array of 'vec3'") {
+
+    val actual =
+      array(4, List(vec3(1), vec3(2), vec3(3), vec3(4))).toArray
+
+    val expected =
+      Array[Float](1, 1, 1, 0, 2, 2, 2, 0, 3, 3, 3, 0, 4, 4, 4, 0)
+
+    assertEquals(actual.toList, expected.toList)
+
+  }
+
+  test("can make an array of 'vec4'") {
+
+    val actual =
+      array(4, List(vec4(1), vec4(2), vec4(3), vec4(4))).toArray
+
+    val expected =
+      Array[Float](1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4)
+
+    assertEquals(actual.toList, expected.toList)
+
+  }
+
+  test("can make an array of 'RGB'") {
+
+    val actual =
+      array(4, List(RGB(1, 1, 1), RGB(2, 2, 2), RGB(3, 3, 3), RGB(4, 4, 4))).toArray
+
+    val expected =
+      Array[Float](1, 1, 1, 0, 2, 2, 2, 0, 3, 3, 3, 0, 4, 4, 4, 0)
+
+    assertEquals(actual.toList, expected.toList)
+
+  }
+
+  test("can make an array of 'RGBA'") {
+
+    val actual =
+      array(4, List(RGBA(1, 1, 1, 1), RGBA(2, 2, 2, 2), RGBA(3, 3, 3, 3), RGBA(4, 4, 4, 4))).toArray
+
+    val expected =
+      Array[Float](1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4)
+
+    assertEquals(actual.toList, expected.toList)
+
+  }
+
+  test("can make a rawArray") {
+
+    val actual =
+      rawArray(
+        List[List[Float]](List(1, 1, 1, 1), List(2, 2, 2, 2), List(3, 3, 3, 3), List(4, 4, 4, 4)).flatten
+      ).toArray
+
+    val expected =
+      Array[Float](1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4)
+
+    assertEquals(actual.toList, expected.toList)
+
+  }
+
+  test("can make an array from 'mat4'") {
+
+    val actual =
+      mat4.fromMatrix4(Matrix4.identity).toArray
+
+    val expected =
+      List[List[Float]](List(1, 0, 0, 0), List(0, 1, 0, 0), List(0, 0, 1, 0), List(0, 0, 0, 1)).flatten.toArray
+
+    assertEquals(actual.toList, expected.toList)
+
+  }
+
+}


### PR DESCRIPTION
In response to issue #174.

Particularly an improvement if you're using arrays, as more types are supported and you can now use raw arrays - if you know what you're doing!

You still have to create `UniformBlock`s with `ShaderPrimitives` (which now have nice aliases) but there are additional constructors to make them out of common indigo data types.