### PR TITLE
Each layer can have a Camera

### DIFF
--- a/indigo/indigo/src/main/scala/indigo/platform/renderer/webgl1/RendererWebGL1.scala
+++ b/indigo/indigo/src/main/scala/indigo/platform/renderer/webgl1/RendererWebGL1.scala
@@ -17,6 +17,7 @@ import indigo.shared.events.ViewportResize
 import indigo.shared.config.GameViewport
 import indigo.shared.shader.RawShaderCode
 import indigo.shared.time.Seconds
+import indigo.shared.scenegraph.Camera
 
 import scala.scalajs.js.typedarray.Float32Array
 import org.scalajs.dom.html
@@ -97,8 +98,11 @@ final class RendererWebGL1(
     val gameProjection = orthographicProjectionMatrix.mat.toJSArray
 
     sceneData.layers.foreach { layer =>
+      val maybeCamera: Option[Camera] =
+        layer.camera.orElse(sceneData.camera)
+
       val projection =
-        (layer.magnification, sceneData.camera) match {
+        (layer.magnification, maybeCamera) match {
           case (None, None) =>
             gameProjection
 

--- a/indigo/indigo/src/main/scala/indigo/platform/renderer/webgl2/RendererWebGL2.scala
+++ b/indigo/indigo/src/main/scala/indigo/platform/renderer/webgl2/RendererWebGL2.scala
@@ -36,6 +36,7 @@ import indigo.shared.scenegraph.Blend
 import indigo.shared.scenegraph.BlendFactor
 import indigo.shared.shader.StandardShaders
 import indigo.shared.QuickCache
+import indigo.shared.scenegraph.Camera
 
 import indigo.platform.assets.DynamicText
 
@@ -251,8 +252,11 @@ final class RendererWebGL2(
       def makeCacheName(m: Int, w: Int, h: Int, cx: Int, cy: Int, cz: Double): String =
         s"${m.toString}_${w.toString()}x${h.toString()}-${cx.toString},${cy.toString}_${cz.toString}"
 
+      val maybeCamera: Option[Camera] =
+        layer.camera.orElse(sceneData.camera)
+
       val projection =
-        (layer.magnification, sceneData.camera) match {
+        (layer.magnification, maybeCamera) match {
           case (None, None) =>
             defaultLayerProjectionMatrix
 

--- a/indigo/indigo/src/main/scala/indigo/shared/display/DisplayLayer.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/display/DisplayLayer.scala
@@ -5,6 +5,7 @@ import indigo.shared.scenegraph.Blend
 import indigo.shared.shader.ShaderId
 import indigo.shared.datatypes.RGBA
 import indigo.shared.datatypes.Depth
+import indigo.shared.scenegraph.Camera
 
 final case class DisplayLayer(
     entities: ListBuffer[DisplayEntity],
@@ -15,5 +16,6 @@ final case class DisplayLayer(
     entityBlend: Blend,
     layerBlend: Blend,
     shaderId: ShaderId,
-    shaderUniformData: List[DisplayObjectUniformData]
+    shaderUniformData: List[DisplayObjectUniformData],
+    camera: Option[Camera]
 ) derives CanEqual

--- a/indigo/indigo/src/main/scala/indigo/shared/platform/SceneProcessor.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/platform/SceneProcessor.scala
@@ -102,7 +102,8 @@ final class SceneProcessor(
             blending.entity,
             blending.layer,
             shaderData.shaderId,
-            SceneProcessor.mergeShaderToUniformData(shaderData)
+            SceneProcessor.mergeShaderToUniformData(shaderData),
+            l.camera
           )
         }
         .sortBy(_.depth.toInt)

--- a/indigo/indigo/src/main/scala/indigo/shared/scenegraph/Layer.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/scenegraph/Layer.scala
@@ -29,6 +29,8 @@ import indigo.shared.materials.BlendMaterial
   *   Optionally set the visiblity, defaults to visible
   * @param blending
   *   Optionally describes how to blend this layer onto the one below, by default, simply overlays on onto the other.
+  * @param camera
+  *   Optional camera specifically for this layer. If None, fallback to scene camera, or default camera.
   */
 final case class Layer(
     nodes: List[SceneNode],
@@ -37,7 +39,8 @@ final case class Layer(
     magnification: Option[Int],
     depth: Option[Depth],
     visible: Option[Boolean],
-    blending: Option[Blending]
+    blending: Option[Blending],
+    camera: Option[Camera]
 ) derives CanEqual {
 
   def |+|(other: Layer): Layer =
@@ -104,32 +107,39 @@ final case class Layer(
     this.copy(blending = blending.map(_.withBlendMaterial(newBlendMaterial)))
   def modifyBlending(modifier: Blending => Blending): Layer =
     this.copy(blending = blending.map(modifier))
+
+  def withCamera(newCamera: Camera): Layer =
+    this.copy(camera = Option(newCamera))
+  def modifyCamera(modifier: Camera => Camera): Layer =
+    this.copy(camera = Option(modifier(camera.getOrElse(Camera.default))))
+  def noCamera: Layer =
+    this.copy(camera = None)
 }
 
 object Layer {
 
   def empty: Layer =
-    Layer(Nil, Nil, None, None, None, None, None)
+    Layer(Nil, Nil, None, None, None, None, None, None)
 
   def apply(key: BindingKey): Layer =
-    Layer(Nil, Nil, Option(key), None, None, None, None)
+    Layer(Nil, Nil, Option(key), None, None, None, None, None)
 
   def apply(nodes: SceneNode*): Layer =
-    Layer(nodes.toList, Nil, None, None, None, None, None)
+    Layer(nodes.toList, Nil, None, None, None, None, None, None)
 
   def apply(nodes: List[SceneNode]): Layer =
-    Layer(nodes, Nil, None, None, None, None, None)
+    Layer(nodes, Nil, None, None, None, None, None, None)
 
   def apply(key: BindingKey, nodes: List[SceneNode]): Layer =
-    Layer(nodes, Nil, Option(key), None, None, None, None)
+    Layer(nodes, Nil, Option(key), None, None, None, None, None)
 
   def apply(key: BindingKey, nodes: SceneNode*): Layer =
-    Layer(nodes.toList, Nil, Option(key), None, None, None, None)
+    Layer(nodes.toList, Nil, Option(key), None, None, None, None, None)
 
   def apply(key: BindingKey, magnification: Int, depth: Depth): Layer =
-    Layer(Nil, Nil, Option(key), Option(magnification), Option(depth), None, None)
+    Layer(Nil, Nil, Option(key), Option(magnification), Option(depth), None, None, None)
 
   def apply(key: BindingKey, magnification: Int, depth: Depth, nodes: List[SceneNode]): Layer =
-    Layer(nodes.toList, Nil, Option(key), Option(magnification), Option(depth), None, None)
+    Layer(nodes.toList, Nil, Option(key), Option(magnification), Option(depth), None, None, None)
 
 }

--- a/indigo/indigo/src/main/scala/indigo/shared/scenegraph/SceneUpdateFragment.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/scenegraph/SceneUpdateFragment.scala
@@ -85,9 +85,10 @@ final case class SceneUpdateFragment(
 
   def withCamera(newCamera: Camera): SceneUpdateFragment =
     this.copy(camera = Option(newCamera))
-
   def modifyCamera(modifier: Camera => Camera): SceneUpdateFragment =
     this.copy(camera = Option(modifier(camera.getOrElse(Camera.default))))
+  def noCamera: SceneUpdateFragment =
+    this.copy(camera = None)
 }
 object SceneUpdateFragment {
 

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/SandboxGame.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/SandboxGame.scala
@@ -38,7 +38,7 @@ object SandboxGame extends IndigoGame[SandboxBootData, SandboxStartupData, Sandb
   private val viewportHeight: Int     = 128 * magnificationLevel
 
   def initialScene(bootData: SandboxBootData): Option[SceneName] =
-    Some(UiScene.name)
+    Some(CameraScene.name)
 
   def scenes(bootData: SandboxBootData): NonEmptyList[Scene[SandboxStartupData, SandboxGameModel, SandboxViewModel]] =
     NonEmptyList(

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/CameraScene.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/CameraScene.scala
@@ -63,7 +63,10 @@ object CameraScene extends Scene[SandboxStartupData, SandboxGameModel, SandboxVi
             1,
             SandboxAssets.foliageMaterial
           )
-        ).withMagnification(1)
+        ).withMagnification(1),
+        Layer(
+          Graphic(32, 32, Material.Bitmap(SandboxAssets.dots)).moveTo(context.startUpData.viewportCenter - Point(16))
+        ).withCamera(Camera.default) // Override scene camera, so this layer doesn't move.
       ).modifyCamera(
         _.moveTo(orbit.at(context.running * 0.3))
           .withZoom(zoom.at(context.running * 0.35))


### PR DESCRIPTION
The last release added simple, scene level Camera support! 🎉
This allows you to render you level and pan and zoom around it without repositioning your graphics. (Rotation is out of scope at the moment for reasons I won't go into here.)

...and it was immediately pointed out in conversation that while nice, if you used the camera to pan around your level, you'd also quickly loose sight of your UI since it was a global camera. Darn it. 👎

I raised an issue #171 that this PR should satisfy. Quite simply cameras now work like magnification, as a series of fallbacks:

If you declare a layer level camera, that's the one that will be used to draw your layer,
if not, then if you've declared a scene level camera, that one will be used,
if not, we'll use the default camera.

This add's little to no rendering cost but gives you much better control over how and where your scene is drawn.
