### PR TITLE
Vertex, Vector and Point rotation

### DIFF
--- a/indigo/indigo-extras/src/main/scala/indigoextras/geometry/Vertex.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/geometry/Vertex.scala
@@ -1,7 +1,7 @@
 package indigoextras.geometry
 
 import indigo.shared.datatypes.Point
-import indigo.shared.datatypes.Vector2
+import indigo.shared.datatypes.{Vector2,Radians}
 
 final case class Vertex(x: Double, y: Double) derives CanEqual {
 
@@ -58,8 +58,8 @@ final case class Vertex(x: Double, y: Double) derives CanEqual {
   def scaleBy(amount: Double): Vertex =
     scaleBy(Vertex(amount))
 
-  def rotateBy(angle: Double): Vertex = {
-    val a = if (angle >= 0) then angle else angle + Math.PI * 2.0
+  def rotateBy(angle: Radians): Vertex = {
+    val a = angle.wrap.toDouble
     val s = Math.sin(a)
     val c = Math.cos(a)
 
@@ -68,7 +68,7 @@ final case class Vertex(x: Double, y: Double) derives CanEqual {
       this.x * s + this.y * c
     )
   }
-  def rotateBy(angle: Double, origin: Vertex): Vertex = {
+  def rotateBy(angle: Radians, origin: Vertex): Vertex = {
     (this - origin).rotateBy(angle) + origin
   }
 

--- a/indigo/indigo-extras/src/main/scala/indigoextras/geometry/Vertex.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/geometry/Vertex.scala
@@ -58,6 +58,20 @@ final case class Vertex(x: Double, y: Double) derives CanEqual {
   def scaleBy(amount: Double): Vertex =
     scaleBy(Vertex(amount))
 
+  def rotateBy(angle: Double): Vertex = {
+    val a = if (angle >= 0) then angle else angle + Math.PI * 2.0
+    val s = Math.sin(a)
+    val c = Math.cos(a)
+
+    Vertex(
+      this.x * c - this.y * s,
+      this.x * s + this.y * c
+    )
+  }
+  def rotateBy(angle: Double, origin: Vertex): Vertex = {
+    (this - origin).rotateBy(angle) + origin
+  }
+
   def round: Vertex =
     Vertex(Math.round(x).toDouble, Math.round(y).toDouble)
 

--- a/indigo/indigo-extras/src/main/scala/indigoextras/geometry/Vertex.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/geometry/Vertex.scala
@@ -72,6 +72,13 @@ final case class Vertex(x: Double, y: Double) derives CanEqual {
     (this - origin).rotateBy(angle) + origin
   }
 
+  def rotateTo(angle: Radians): Vertex = {
+    val a = angle.wrap.toDouble
+    Vertex(this.length * Math.cos(a), this.length * Math.sin(a))
+  }
+
+  def angle: Radians = Radians(Math.atan2(this.y, this.x))
+
   def round: Vertex =
     Vertex(Math.round(x).toDouble, Math.round(y).toDouble)
 

--- a/indigo/indigo-extras/src/test/scala/indigoextras/geometry/VertexTests.scala
+++ b/indigo/indigo-extras/src/test/scala/indigoextras/geometry/VertexTests.scala
@@ -98,22 +98,22 @@ class VertexTests extends munit.FunSuite {
 
   test("rotate around origin") {
     // 90
-    assert(Vertex(1, 0).rotateBy(Radians.PIby2.toDouble) ~== Vertex(0, 1))
+    assert(Vertex(1, 0).rotateBy(Radians.PIby2) ~== Vertex(0, 1))
 
     // -90
-    assert(Vertex(1, 1).rotateBy((-1.0 * Radians.PIby2.toDouble).toDouble) ~== Vertex(1, -1))
+    assert(Vertex(1, 1).rotateBy(Radians.PIby2 * -1.0) ~== Vertex(1, -1))
 
     // 45
     val v = Vertex(1, 2)
     val expected = Vertex(-0.70710,2.12132)
-    assert(v.rotateBy(Radians.PIby2.toDouble / 2f) ~== expected)
+    assert(v.rotateBy(Radians.PIby2 / 2.0) ~== expected)
     // magnitude should remain the same
     assert(Math.abs(v.length - expected.length) <= 0.0001)
   }
 
   test("rotate around given point") {
-    assert(Vertex(3, 1).rotateBy(Radians.PIby2.toDouble, Vertex(-2,-2)) ~== Vertex(-5, 3))
-    assert(Vertex(-3, 4).rotateBy(-1.0 * Radians.PIby2.toDouble, Vertex(-1,2)) ~== Vertex(1, 4))
+    assert(Vertex(3, 1).rotateBy(Radians.PIby2, Vertex(-2,-2)) ~== Vertex(-5, 3))
+    assert(Vertex(-3, 4).rotateBy(Radians.PIby2 * -1.0, Vertex(-1,2)) ~== Vertex(1, 4))
   }
 
   test("round") {

--- a/indigo/indigo-extras/src/test/scala/indigoextras/geometry/VertexTests.scala
+++ b/indigo/indigo-extras/src/test/scala/indigoextras/geometry/VertexTests.scala
@@ -1,6 +1,6 @@
 package indigoextras.geometry
 
-import indigo.shared.datatypes.Vector2
+import indigo.shared.datatypes.{Radians,Vector2}
 
 class VertexTests extends munit.FunSuite {
 
@@ -94,6 +94,26 @@ class VertexTests extends munit.FunSuite {
 
   test("scaleBy") {
     assertEquals(Vertex(2, 2).scaleBy(Vertex(10, 2)), Vertex(20, 4))
+  }
+
+  test("rotate around origin") {
+    // 90
+    assert(Vertex(1, 0).rotateBy(Radians.PIby2.toDouble) ~== Vertex(0, 1))
+
+    // -90
+    assert(Vertex(1, 1).rotateBy((-1.0 * Radians.PIby2.toDouble).toDouble) ~== Vertex(1, -1))
+
+    // 45
+    val v = Vertex(1, 2)
+    val expected = Vertex(-0.70710,2.12132)
+    assert(v.rotateBy(Radians.PIby2.toDouble / 2f) ~== expected)
+    // magnitude should remain the same
+    assert(Math.abs(v.length - expected.length) <= 0.0001)
+  }
+
+  test("rotate around given point") {
+    assert(Vertex(3, 1).rotateBy(Radians.PIby2.toDouble, Vertex(-2,-2)) ~== Vertex(-5, 3))
+    assert(Vertex(-3, 4).rotateBy(-1.0 * Radians.PIby2.toDouble, Vertex(-1,2)) ~== Vertex(1, 4))
   }
 
   test("round") {

--- a/indigo/indigo-extras/src/test/scala/indigoextras/geometry/VertexTests.scala
+++ b/indigo/indigo-extras/src/test/scala/indigoextras/geometry/VertexTests.scala
@@ -116,6 +116,20 @@ class VertexTests extends munit.FunSuite {
     assert(Vertex(-3, 4).rotateBy(Radians.PIby2 * -1.0, Vertex(-1,2)) ~== Vertex(1, 4))
   }
 
+  test("rotate to") {
+    // 0 to 270
+    assert(Vertex(1, 0).rotateTo(Radians.PI + Radians.PIby2) ~== Vertex(0, -1))
+    // 45 to 270
+    assert(Vertex(1, 1).rotateTo(Radians.PI + Radians.PIby2) ~== Vertex(0, -1.41421))
+  }
+
+  test("angle") {
+    // -90
+    assertEquals(Vertex(0, -1).angle, Radians.PIby2 * -1.0)
+    // -90 at different magnitude
+    assertEquals(Vertex(0, -8.5).angle, Radians.PIby2 * -1.0)
+  }
+
   test("round") {
     assertEquals(Vertex(2.2, 2.6).round, Vertex(2, 3))
   }

--- a/indigo/indigo/src/main/scala/indigo/shared/datatypes/Point.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/datatypes/Point.scala
@@ -56,6 +56,17 @@ final case class Point(x: Int, y: Int) derives CanEqual {
     (this - origin).rotateBy(angle) + origin
   }
 
+  def rotateTo(angle: Radians): Point = {
+    val a = angle.wrap.toDouble
+    val r = this.distanceTo(Point.zero)
+    Point(
+      Math.round(r * Math.cos(a)).toInt,
+      Math.round(r * Math.sin(a)).toInt
+    )
+  }
+
+  def angle: Radians = Radians(Math.atan2(this.y, this.x))
+
   def distanceTo(other: Point): Double =
     Point.distanceBetween(this, other)
 

--- a/indigo/indigo/src/main/scala/indigo/shared/datatypes/Point.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/datatypes/Point.scala
@@ -42,6 +42,20 @@ final case class Point(x: Int, y: Int) derives CanEqual {
   def moveBy(x: Int, y: Int): Point =
     moveBy(Point(x, y))
 
+  def rotateBy(angle: Radians): Point = {
+    val a = angle.wrap.toDouble
+    val s = Math.sin(a)
+    val c = Math.cos(a)
+
+    Point(
+      Math.round(this.x * c - this.y * s).toInt,
+      Math.round(this.x * s + this.y * c).toInt
+    )
+  }
+  def rotateBy(angle: Radians, origin: Point): Point = {
+    (this - origin).rotateBy(angle) + origin
+  }
+
   def distanceTo(other: Point): Double =
     Point.distanceBetween(this, other)
 

--- a/indigo/indigo/src/main/scala/indigo/shared/datatypes/Vector2.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/datatypes/Vector2.scala
@@ -48,8 +48,8 @@ final case class Vector2(x: Double, y: Double) derives CanEqual:
   def scaleBy(amount: Double): Vector2 =
     scaleBy(Vector2(amount))
 
-  def rotateBy(angle: Double): Vector2 = {
-    val a = if (angle >= 0) then angle else angle + Math.PI * 2.0
+  def rotateBy(angle: Radians): Vector2 = {
+    val a = angle.wrap.toDouble
     val s = Math.sin(a)
     val c = Math.cos(a)
 
@@ -58,7 +58,7 @@ final case class Vector2(x: Double, y: Double) derives CanEqual:
       this.x * s + this.y * c
     )
   }
-  def rotateBy(angle: Double, origin: Vector2): Vector2 = {
+  def rotateBy(angle: Radians, origin: Vector2): Vector2 = {
     Vector2.add(
       Vector2.subtract(this, origin).rotateBy(angle),
       origin

--- a/indigo/indigo/src/main/scala/indigo/shared/datatypes/Vector2.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/datatypes/Vector2.scala
@@ -48,6 +48,22 @@ final case class Vector2(x: Double, y: Double) derives CanEqual:
   def scaleBy(amount: Double): Vector2 =
     scaleBy(Vector2(amount))
 
+  def rotateBy(angle: Double): Vector2 = {
+    val s = Math.sin(angle)
+    val c = Math.cos(angle)
+
+    Vector2(
+      this.x * c - this.y * s,
+      this.x * s + this.y * c
+    )
+  }
+  def rotateBy(angle: Double, origin: Vector2): Vector2 = {
+    Vector2.add(
+      Vector2.subtract(this, origin).rotateBy(angle),
+      origin
+    )
+  }
+
   def round: Vector2 =
     Vector2(Math.round(x).toDouble, Math.round(y).toDouble)
 

--- a/indigo/indigo/src/main/scala/indigo/shared/datatypes/Vector2.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/datatypes/Vector2.scala
@@ -65,6 +65,13 @@ final case class Vector2(x: Double, y: Double) derives CanEqual:
     )
   }
 
+  def rotateTo(angle: Radians): Vector2 = {
+    val a = angle.wrap.toDouble
+    Vector2(this.length * Math.cos(a), this.length * Math.sin(a))
+  }
+
+  def angle: Radians = Radians(Math.atan2(this.y, this.x))
+
   def round: Vector2 =
     Vector2(Math.round(x).toDouble, Math.round(y).toDouble)
 

--- a/indigo/indigo/src/main/scala/indigo/shared/datatypes/Vector2.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/datatypes/Vector2.scala
@@ -49,8 +49,9 @@ final case class Vector2(x: Double, y: Double) derives CanEqual:
     scaleBy(Vector2(amount))
 
   def rotateBy(angle: Double): Vector2 = {
-    val s = Math.sin(angle)
-    val c = Math.cos(angle)
+    val a = if (angle >= 0) then angle else angle + Math.PI * 2.0
+    val s = Math.sin(a)
+    val c = Math.cos(a)
 
     Vector2(
       this.x * c - this.y * s,

--- a/indigo/indigo/src/test/scala/indigo/shared/datatypes/PointTests.scala
+++ b/indigo/indigo/src/test/scala/indigo/shared/datatypes/PointTests.scala
@@ -50,4 +50,18 @@ class PointTests extends munit.FunSuite {
     assertEquals(Point(3, 1).rotateBy(Radians.PIby2, Point(-2,-2)), Point(-5, 3))
     assertEquals(Point(-3, 4).rotateBy(Radians.PIby2 * -1.0, Point(-1,2)), Point(1, 4))
   }
+
+  test("rotate to") {
+    // 0 to 270
+    assertEquals(Point(1, 0).rotateTo(Radians.PI + Radians.PIby2), Point(0, -1))
+    // 45 to 270
+    assertEquals(Point(1, 1).rotateTo(Radians.PI + Radians.PIby2), Point(0, -1))
+  }
+
+  test("angle") {
+    // -90
+    assertEquals(Point(0, -1).angle, Radians.PIby2 * -1.0)
+    // -90 at different magnitude
+    assertEquals(Point(0, -8).angle, Radians.PIby2 * -1.0)
+  }
 }

--- a/indigo/indigo/src/test/scala/indigo/shared/datatypes/PointTests.scala
+++ b/indigo/indigo/src/test/scala/indigo/shared/datatypes/PointTests.scala
@@ -33,4 +33,21 @@ class PointTests extends munit.FunSuite {
     assertEquals(p1.distanceTo(p2), Math.sqrt((20d * 20d) + (20d * 20d)))
   }
 
+  test("rotate around origin") {
+    // 90
+    assertEquals(Point(1, 0).rotateBy(Radians.PIby2), Point(0, 1))
+
+    // -90
+    assertEquals(Point(1, 1).rotateBy(Radians.PIby2 * -1.0), Point(1, -1))
+
+    // 45
+    val v = Point(1, 2)
+    val expected = Point(-1, 2)
+    assertEquals(v.rotateBy(Radians.PIby2 / 2.0), expected)
+  }
+
+  test("rotate around given point") {
+    assertEquals(Point(3, 1).rotateBy(Radians.PIby2, Point(-2,-2)), Point(-5, 3))
+    assertEquals(Point(-3, 4).rotateBy(Radians.PIby2 * -1.0, Point(-1,2)), Point(1, 4))
+  }
 }

--- a/indigo/indigo/src/test/scala/indigo/shared/datatypes/Vector2Tests.scala
+++ b/indigo/indigo/src/test/scala/indigo/shared/datatypes/Vector2Tests.scala
@@ -135,34 +135,34 @@ class Vector2Tests extends munit.FunSuite {
 
   test("rotate around origin") {
     // 0
-    assert(Vector2(1, 0).rotateBy(0) ~== Vector2(1, 0))
+    assert(Vector2(1, 0).rotateBy(Radians(0)) ~== Vector2(1, 0))
     // 90
-    assert(Vector2(1, 0).rotateBy(Radians.PIby2.toDouble) ~== Vector2(0, 1))
+    assert(Vector2(1, 0).rotateBy(Radians.PIby2) ~== Vector2(0, 1))
     // 180
-    assert(Vector2(1, 1).rotateBy(Radians.PI.toDouble) ~== Vector2(-1, -1))
+    assert(Vector2(1, 1).rotateBy(Radians.PI) ~== Vector2(-1, -1))
     // 270
-    assert(Vector2(1, 0).rotateBy(Radians.PI.toDouble + Radians.PIby2.toDouble) ~== Vector2(0, -1))
+    assert(Vector2(1, 0).rotateBy(Radians.PI + Radians.PIby2) ~== Vector2(0, -1))
     // 360
-    assert(Vector2(1, 0).rotateBy(Radians.TAU.toDouble) ~== Vector2(1, 0))
+    assert(Vector2(1, 0).rotateBy(Radians.TAU) ~== Vector2(1, 0))
 
     // 45
     val v = Vector2(1, 2)
     val expected = Vector2(-0.70710,2.12132)
-    assert(v.rotateBy(Radians.PIby2.toDouble / 2f) ~== expected)
+    assert(v.rotateBy(Radians.PIby2 / 2f) ~== expected)
     // magnitude should remain the same
     assert(Math.abs(v.length - expected.length) <= 0.0001)
 
     // -90
-    assert(Vector2(1, 1).rotateBy((-1.0 * Radians.PIby2.toDouble).toDouble) ~== Vector2(1, -1))
+    assert(Vector2(1, 1).rotateBy(Radians.PIby2 * -1f) ~== Vector2(1, -1))
   }
 
   test("rotate around given point") {
     // Same quadrant
-    assert(Vector2(3, 3).rotateBy(Radians.PIby2.toDouble, Vector2(2,2)) ~== Vector2(1, 3))
+    assert(Vector2(3, 3).rotateBy(Radians.PIby2, Vector2(2,2)) ~== Vector2(1, 3))
     // Adjacent quadrant
-    assert(Vector2(3, 1).rotateBy(Radians.PIby2.toDouble, Vector2(-2,-2)) ~== Vector2(-5, 3))
+    assert(Vector2(3, 1).rotateBy(Radians.PIby2, Vector2(-2,-2)) ~== Vector2(-5, 3))
     // Negative
-    assert(Vector2(-3, 4).rotateBy(-1.0 * Radians.PIby2.toDouble, Vector2(-1,2)) ~== Vector2(1, 4))
+    assert(Vector2(-3, 4).rotateBy(Radians.PIby2 * -1f, Vector2(-1,2)) ~== Vector2(1, 4))
   }
 
   def to2dp(d: Double): Double =

--- a/indigo/indigo/src/test/scala/indigo/shared/datatypes/Vector2Tests.scala
+++ b/indigo/indigo/src/test/scala/indigo/shared/datatypes/Vector2Tests.scala
@@ -143,7 +143,7 @@ class Vector2Tests extends munit.FunSuite {
     // 270
     assert(Vector2(1, 0).rotateBy(Radians.PI.toDouble + Radians.PIby2.toDouble) ~== Vector2(0, -1))
     // 360
-    assert(Vector2(1, 0).rotateBy(Radians.`2PI`.toDouble) ~== Vector2(1, 0))
+    assert(Vector2(1, 0).rotateBy(Radians.TAU.toDouble) ~== Vector2(1, 0))
 
     // 45
     val v = Vector2(1, 2)
@@ -151,10 +151,18 @@ class Vector2Tests extends munit.FunSuite {
     assert(v.rotateBy(Radians.PIby2.toDouble / 2f) ~== expected)
     // magnitude should remain the same
     assert(Math.abs(v.length - expected.length) <= 0.0001)
+
+    // -90
+    assert(Vector2(1, 1).rotateBy((-1.0 * Radians.PIby2.toDouble).toDouble) ~== Vector2(1, -1))
   }
 
   test("rotate around given point") {
+    // Same quadrant
     assert(Vector2(3, 3).rotateBy(Radians.PIby2.toDouble, Vector2(2,2)) ~== Vector2(1, 3))
+    // Adjacent quadrant
+    assert(Vector2(3, 1).rotateBy(Radians.PIby2.toDouble, Vector2(-2,-2)) ~== Vector2(-5, 3))
+    // Negative
+    assert(Vector2(-3, 4).rotateBy(-1.0 * Radians.PIby2.toDouble, Vector2(-1,2)) ~== Vector2(1, 4))
   }
 
   def to2dp(d: Double): Double =

--- a/indigo/indigo/src/test/scala/indigo/shared/datatypes/Vector2Tests.scala
+++ b/indigo/indigo/src/test/scala/indigo/shared/datatypes/Vector2Tests.scala
@@ -165,6 +165,20 @@ class Vector2Tests extends munit.FunSuite {
     assert(Vector2(-3, 4).rotateBy(Radians.PIby2 * -1f, Vector2(-1,2)) ~== Vector2(1, 4))
   }
 
+  test("rotate to") {
+    // 0 to 270
+    assert(Vector2(1, 0).rotateTo(Radians.PI + Radians.PIby2) ~== Vector2(0, -1))
+    // 45 to 270
+    assert(Vector2(1, 1).rotateTo(Radians.PI + Radians.PIby2) ~== Vector2(0, -1.41421))
+  }
+
+  test("angle") {
+    // -90
+    assertEquals(Vector2(0, -1).angle, Radians.PIby2 * -1.0)
+    // -90 at different magnitude
+    assertEquals(Vector2(0, -8.5).angle, Radians.PIby2 * -1.0)
+  }
+
   def to2dp(d: Double): Double =
     Math.round(d * 100).toDouble / 100
 

--- a/indigo/indigo/src/test/scala/indigo/shared/datatypes/Vector2Tests.scala
+++ b/indigo/indigo/src/test/scala/indigo/shared/datatypes/Vector2Tests.scala
@@ -133,6 +133,30 @@ class Vector2Tests extends munit.FunSuite {
     assert(!(Vector2(5.0, 5.0) ~== Vector2(-4.999999, 5.00001)))
   }
 
+  test("rotate around origin") {
+    // 0
+    assert(Vector2(1, 0).rotateBy(0) ~== Vector2(1, 0))
+    // 90
+    assert(Vector2(1, 0).rotateBy(Radians.PIby2.toDouble) ~== Vector2(0, 1))
+    // 180
+    assert(Vector2(1, 1).rotateBy(Radians.PI.toDouble) ~== Vector2(-1, -1))
+    // 270
+    assert(Vector2(1, 0).rotateBy(Radians.PI.toDouble + Radians.PIby2.toDouble) ~== Vector2(0, -1))
+    // 360
+    assert(Vector2(1, 0).rotateBy(Radians.`2PI`.toDouble) ~== Vector2(1, 0))
+
+    // 45
+    val v = Vector2(1, 2)
+    val expected = Vector2(-0.70710,2.12132)
+    assert(v.rotateBy(Radians.PIby2.toDouble / 2f) ~== expected)
+    // magnitude should remain the same
+    assert(Math.abs(v.length - expected.length) <= 0.0001)
+  }
+
+  test("rotate around given point") {
+    assert(Vector2(3, 3).rotateBy(Radians.PIby2.toDouble, Vector2(2,2)) ~== Vector2(1, 3))
+  }
+
   def to2dp(d: Double): Double =
     Math.round(d * 100).toDouble / 100
 


### PR DESCRIPTION
Added rotateBy for Vertex and Vector2
Added unit tests for both

Possible changes:
- Use Radians instead of Double
- Add rotateBy to Point as well