### PR TITLE
#133 Support hold down actions on buttons

### DIFF
--- a/indigo/indigo-extras/src/main/scala/indigoextras/ui/Button.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/ui/Button.scala
@@ -24,7 +24,8 @@ final case class Button(
     onDown: () => List[GlobalEvent],
     onHoverOver: () => List[GlobalEvent],
     onHoverOut: () => List[GlobalEvent],
-    onClick: () => List[GlobalEvent]
+    onClick: () => List[GlobalEvent],
+    onHoldDown: () => List[GlobalEvent],
 ) derives CanEqual {
 
   def update(mouse: Mouse): Outcome[Button] = {
@@ -48,7 +49,7 @@ final case class Button(
     state match
       // Stay in Down state
       case ButtonState.Down if mouseInBounds && mouse.leftMouseIsDown =>
-        Outcome(this).addGlobalEvents(mouseButtonEvents)
+        Outcome(this).addGlobalEvents(onHoldDown() ++ mouseButtonEvents)
 
       // Move to Down state
       case ButtonState.Up if mouseInBounds && mouse.mousePressed =>
@@ -123,6 +124,11 @@ final case class Button(
   def withClickActions(actions: => List[GlobalEvent]): Button =
     this.copy(onClick = () => actions)
 
+  def withHoldDownActions(actions: GlobalEvent*): Button =
+    withHoldDownActions(actions.toList)
+  def withHoldDownActions(actions: => List[GlobalEvent]): Button =
+    this.copy(onHoldDown = () => actions)
+
   def toUpState: Button =
     this.copy(state = ButtonState.Up)
 
@@ -145,7 +151,8 @@ object Button {
       onDown = () => Nil,
       onHoverOver = () => Nil,
       onHoverOut = () => Nil,
-      onClick = () => Nil
+      onClick = () => Nil,
+      onHoldDown = () => Nil,
     )
 
 }

--- a/indigo/indigo-extras/src/test/scala/indigoextras/ui/ButtonTests.scala
+++ b/indigo/indigo-extras/src/test/scala/indigoextras/ui/ButtonTests.scala
@@ -15,6 +15,8 @@ class ButtonTests extends munit.FunSuite {
   val bounds =
     Rectangle(10, 10, 100, 100)
 
+  val holdDownEvent = FakeEvent("mouse held down")
+
   val button =
     Button(
       ButtonAssets(
@@ -28,6 +30,7 @@ class ButtonTests extends munit.FunSuite {
       .withHoverOutActions(FakeEvent("mouse out"))
       .withDownActions(FakeEvent("mouse down"))
       .withUpActions(FakeEvent("mouse up"))
+      .withHoldDownActions(holdDownEvent)
 
   test("Initial state is up") {
     assertEquals(button.state.isUp, true)
@@ -162,6 +165,17 @@ class ButtonTests extends munit.FunSuite {
     assert(clue(actual.unsafeGlobalEvents.contains(FakeEvent("mouse out"))))
   }
 
+  test("If the button is down and we keep the mouse pressed, hold down actions are performed.") {
+    val mouse = new Mouse(Nil, button.bounds.position, true)
+    val actual = for {
+      holdDown <- button.toDownState.update(mouse)
+      holdDownLonger <- holdDown.update(mouse)
+    } yield (holdDown, holdDownLonger)
+
+    assert(actual.unsafeGlobalEvents.length == 2)
+    assert(actual.unsafeGlobalEvents(0) == holdDownEvent)
+    assert(actual.unsafeGlobalEvents(1) == holdDownEvent)
+  }
 }
 
 final case class FakeEvent(message: String) extends GlobalEvent

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/SandboxGame.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/SandboxGame.scala
@@ -176,6 +176,7 @@ object SandboxGame extends IndigoGame[SandboxBootData, SandboxStartupData, Sandb
           .withDownActions(Log("Down!"))
           .withHoverOverActions(Log("Over!"))
           .withHoverOutActions(Log("Out!"))
+          .withHoldDownActions(Log("Hold down!"))
       )
     )
   }


### PR DESCRIPTION
This PR updates the `Button` class to support actions that are fired when a button is held down. I will update `HitArea` as well once we're satisfied with the implementation.

@davesmith00000 `Button.update` appears to be called once per frame tick, in the sandbox game at least: https://github.com/PurpleKingdomGames/indigo/blob/2674fc306070e98372af428642bbded3f68a845a/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/UiScene.scala#L39-L52

Close #133