### PR TITLE
#133 Support hold down actions on hit areas

### DIFF
--- a/indigo/indigo-extras/src/test/scala/indigoextras/ui/ButtonTests.scala
+++ b/indigo/indigo-extras/src/test/scala/indigoextras/ui/ButtonTests.scala
@@ -177,5 +177,3 @@ class ButtonTests extends munit.FunSuite {
     assert(actual.unsafeGlobalEvents(1) == holdDownEvent)
   }
 }
-
-final case class FakeEvent(message: String) extends GlobalEvent

--- a/indigo/indigo-extras/src/test/scala/indigoextras/ui/FakeEvent.scala
+++ b/indigo/indigo-extras/src/test/scala/indigoextras/ui/FakeEvent.scala
@@ -1,0 +1,5 @@
+package indigoextras.ui
+
+import indigo.shared.events.GlobalEvent
+
+final case class FakeEvent(message: String) extends GlobalEvent

--- a/indigo/indigo-extras/src/test/scala/indigoextras/ui/HitAreaTests.scala
+++ b/indigo/indigo-extras/src/test/scala/indigoextras/ui/HitAreaTests.scala
@@ -1,0 +1,41 @@
+package indigoextras.ui
+
+import indigo.shared.assets.AssetName
+import indigo.shared.datatypes.Depth
+import indigo.shared.datatypes.Point
+import indigo.shared.datatypes.Rectangle
+import indigo.shared.events.GlobalEvent
+import indigo.shared.events.MouseEvent
+import indigo.shared.input.Mouse
+import indigo.shared.materials.Material
+import indigo.shared.scenegraph.Graphic
+
+class HitAreaTests extends munit.FunSuite {
+  val bounds = Rectangle(10, 10, 100, 100)
+  val holdDownEvent = FakeEvent("mouse held down")
+  val hitArea = HitArea(bounds).withHoldDownActions(holdDownEvent)
+
+  test("If the hit area is down and we keep the mouse pressed, hold down actions are performed.") {
+    val mouse = new Mouse(Nil, bounds.position, true)
+    val actual = for {
+      holdDown <- hitArea.toDownState.update(mouse)
+      holdDownLonger <- holdDown.update(mouse)
+    } yield (holdDown, holdDownLonger)
+
+    assert(actual.unsafeGlobalEvents.length == 2)
+    assert(actual.unsafeGlobalEvents(0) == holdDownEvent)
+    assert(actual.unsafeGlobalEvents(1) == holdDownEvent)
+  }
+
+  test("If the hit area is down and we release the mouse, the state is set to over.") {
+    val mouse = new Mouse(Nil, bounds.position, false)
+    val actual = hitArea.toDownState.update(mouse).unsafeGet
+    assert(actual.state == ButtonState.Over)
+  }
+
+  test("If the hit area is hovered and we release the mouse, the state is set to down.") {
+    val mouse = new Mouse(List(MouseEvent.MouseDown(bounds.x, bounds.y)), bounds.position, true)
+    val actual = hitArea.toOverState.update(mouse).unsafeGet
+    assert(actual.state == ButtonState.Down)
+  }
+}

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/SandboxGame.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/SandboxGame.scala
@@ -166,7 +166,8 @@ object SandboxGame extends IndigoGame[SandboxBootData, SandboxStartupData, Sandb
           .withClickActions(Log("Click!"))
           .withDownActions(Log("Down!"))
           .withHoverOverActions(Log("Over!"))
-          .withHoverOutActions(Log("Out!")),
+          .withHoverOutActions(Log("Out!"))
+          .withHoldDownActions(Log("Hold down!")),
         Button(
           buttonAssets = buttonAssets,
           bounds = Rectangle(10, 10, 16, 16),


### PR DESCRIPTION
This PR updates the `HitArea` class to support actions that are fired when a hit area is held down. See also #240.