### PR TITLE
Use `CloneTiles` for `Text` in WebGL 2

### DIFF
--- a/indigo/indigo/src/main/scala/indigo/gameengine/GameLoop.scala
+++ b/indigo/indigo/src/main/scala/indigo/gameengine/GameLoop.scala
@@ -49,7 +49,8 @@ class GameLoop[StartUpData, GameModel, ViewModel](
       // Model updates cut off
       if (gameConfig.advanced.disableSkipModelUpdates || timeDelta < gameConfig.haltModelUpdatesAt) {
 
-        val gameTime        = new GameTime(Millis(time).toSeconds, Seconds(timeDelta.toDouble / 1000d), GameTime.FPS(gameConfig.frameRate))
+        val gameTime =
+          new GameTime(Millis(time).toSeconds, Seconds(timeDelta.toDouble / 1000d), GameTime.FPS(gameConfig.frameRate))
         val collectedEvents = gameEngine.globalEventStream.collect ++ List(FrameTick)
         val dice            = Dice.fromSeconds(gameTime.running)
 
@@ -62,7 +63,16 @@ class GameLoop[StartUpData, GameModel, ViewModel](
 
         if (gameConfig.advanced.disableSkipViewUpdates || timeDelta < gameConfig.haltViewUpdatesAt) {
           val processedFrame: Outcome[(GameModel, ViewModel, SceneUpdateFragment)] =
-            frameProcessor.run(startUpData, gameModelState, viewModelState, gameTime, collectedEvents, inputState, dice, boundaryLocator)
+            frameProcessor.run(
+              startUpData,
+              gameModelState,
+              viewModelState,
+              gameTime,
+              collectedEvents,
+              inputState,
+              dice,
+              boundaryLocator
+            )
 
           // Persist frame state
           val scene =
@@ -80,7 +90,12 @@ class GameLoop[StartUpData, GameModel, ViewModel](
 
           // Process events
           scene.layers.foreach { layer =>
-            SceneGraphViewEvents.collectViewEvents(boundaryLocator, layer.nodes, collectedEvents, gameEngine.globalEventStream.pushGlobalEvent)
+            SceneGraphViewEvents.collectViewEvents(
+              boundaryLocator,
+              layer.nodes,
+              collectedEvents,
+              gameEngine.globalEventStream.pushGlobalEvent
+            )
           }
 
           // Play audio
@@ -98,7 +113,16 @@ class GameLoop[StartUpData, GameModel, ViewModel](
           gameEngine.renderer.drawScene(sceneData, gameTime.running)
         } else {
           val processedFrame: Outcome[(GameModel, ViewModel)] =
-            frameProcessor.runSkipView(startUpData, gameModelState, viewModelState, gameTime, collectedEvents, inputState, dice, boundaryLocator)
+            frameProcessor.runSkipView(
+              startUpData,
+              gameModelState,
+              viewModelState,
+              gameTime,
+              collectedEvents,
+              inputState,
+              dice,
+              boundaryLocator
+            )
 
           // Persist frame state
           processedFrame match {
@@ -117,8 +141,7 @@ class GameLoop[StartUpData, GameModel, ViewModel](
       }
 
       gameEngine.platform.tick(gameEngine.gameLoop(time))
-    } else
-      gameEngine.platform.tick(loop(lastUpdateTime))
+    } else gameEngine.platform.tick(loop(lastUpdateTime))
   }
 
 }

--- a/indigo/indigo/src/main/scala/indigo/gameengine/GameLoop.scala
+++ b/indigo/indigo/src/main/scala/indigo/gameengine/GameLoop.scala
@@ -106,7 +106,8 @@ class GameLoop[StartUpData, GameModel, ViewModel](
             gameTime,
             scene,
             gameEngine.assetMapping,
-            gameEngine.renderer.renderingTechnology
+            gameEngine.renderer.renderingTechnology,
+            gameConfig.advanced.batchSize
           )
 
           // Render scene

--- a/indigo/indigo/src/main/scala/indigo/gameengine/GameLoop.scala
+++ b/indigo/indigo/src/main/scala/indigo/gameengine/GameLoop.scala
@@ -90,7 +90,8 @@ class GameLoop[StartUpData, GameModel, ViewModel](
           val sceneData = sceneProcessor.processScene(
             gameTime,
             scene,
-            gameEngine.assetMapping
+            gameEngine.assetMapping,
+            gameEngine.renderer.renderingTechnology
           )
 
           // Render scene

--- a/indigo/indigo/src/main/scala/indigo/platform/renderer/Renderer.scala
+++ b/indigo/indigo/src/main/scala/indigo/platform/renderer/Renderer.scala
@@ -1,16 +1,16 @@
 package indigo.platform.renderer
 
+import indigo.shared.config.RenderingTechnology
 import indigo.shared.datatypes.mutable.CheapMatrix4
 import indigo.shared.platform.ProcessedSceneData
 import indigo.shared.shader.RawShaderCode
 import indigo.shared.time.Seconds
 
-trait Renderer {
-
+trait Renderer:
+  def renderingTechnology: RenderingTechnology
   def screenWidth: Int
   def screenHeight: Int
   def orthographicProjectionMatrix: CheapMatrix4
 
   def init(shaders: Set[RawShaderCode]): Unit
   def drawScene(sceneData: ProcessedSceneData, runningTime: Seconds): Unit
-}

--- a/indigo/indigo/src/main/scala/indigo/platform/renderer/webgl1/RendererWebGL1.scala
+++ b/indigo/indigo/src/main/scala/indigo/platform/renderer/webgl1/RendererWebGL1.scala
@@ -15,6 +15,7 @@ import indigo.shared.datatypes.mutable.CheapMatrix4
 import indigo.shared.display.DisplayEntity
 import indigo.shared.display.DisplayGroup
 import indigo.shared.display.DisplayObject
+import indigo.shared.display.DisplayTextLetters
 import indigo.shared.events.ViewportResize
 import indigo.shared.platform.ProcessedSceneData
 import indigo.shared.platform.RendererConfig
@@ -202,9 +203,16 @@ final class RendererWebGL1(
 
         case g: DisplayGroup =>
           (g, AtlasId(""))
+
+        case l: DisplayTextLetters =>
+          (l, AtlasId(""))
       }
       .sortWith((d1, d2) => d1._1.z > d2._1.z)
       .foreach {
+        case (letters: DisplayTextLetters, _) =>
+          renderEntities(letters.letters, shaderProgram, baseTransform)
+          setBaseTransform
+
         case (group: DisplayGroup, _) =>
           renderEntities(group.entities, shaderProgram, group.transform)
           setBaseTransform

--- a/indigo/indigo/src/main/scala/indigo/platform/renderer/webgl1/RendererWebGL1.scala
+++ b/indigo/indigo/src/main/scala/indigo/platform/renderer/webgl1/RendererWebGL1.scala
@@ -9,6 +9,7 @@ import indigo.platform.renderer.shared.LoadedTextureAsset
 import indigo.platform.renderer.shared.TextureLookupResult
 import indigo.platform.renderer.shared.WebGLHelper
 import indigo.shared.config.GameViewport
+import indigo.shared.config.RenderingTechnology
 import indigo.shared.datatypes.Radians
 import indigo.shared.datatypes.mutable.CheapMatrix4
 import indigo.shared.display.DisplayEntity
@@ -36,6 +37,8 @@ final class RendererWebGL1(
     cNc: ContextAndCanvas,
     globalEventStream: GlobalEventStream
 ) extends Renderer {
+
+  val renderingTechnology: RenderingTechnology = RenderingTechnology.WebGL1
 
   @SuppressWarnings(Array("scalafix:DisableSyntax.var"))
   private var resizeRun: Boolean = false

--- a/indigo/indigo/src/main/scala/indigo/platform/renderer/webgl2/RendererWebGL2.scala
+++ b/indigo/indigo/src/main/scala/indigo/platform/renderer/webgl2/RendererWebGL2.scala
@@ -13,6 +13,7 @@ import indigo.platform.renderer.shared.TextureLookupResult
 import indigo.platform.renderer.shared.WebGLHelper
 import indigo.shared.QuickCache
 import indigo.shared.config.GameViewport
+import indigo.shared.config.RenderingTechnology
 import indigo.shared.datatypes.RGBA
 import indigo.shared.datatypes.Radians
 import indigo.shared.datatypes.mutable.CheapMatrix4
@@ -48,6 +49,8 @@ final class RendererWebGL2(
     globalEventStream: GlobalEventStream,
     dynamicText: DynamicText
 ) extends Renderer {
+
+  val renderingTechnology: RenderingTechnology = RenderingTechnology.WebGL2
 
   implicit private val projectionsCache: QuickCache[scalajs.js.Array[Float]] = QuickCache.empty
 

--- a/indigo/indigo/src/main/scala/indigo/shared/BoundaryLocator.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/BoundaryLocator.scala
@@ -9,7 +9,6 @@ import indigo.shared.datatypes.Size
 import indigo.shared.datatypes.TextAlignment
 import indigo.shared.datatypes.Vector3
 import indigo.shared.datatypes.mutable.CheapMatrix4
-import indigo.shared.platform.DisplayObjectConversions
 import indigo.shared.scenegraph.CloneBatch
 import indigo.shared.scenegraph.CloneTiles
 import indigo.shared.scenegraph.EntityNode

--- a/indigo/indigo/src/main/scala/indigo/shared/config/AdvancedGameConfig.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/config/AdvancedGameConfig.scala
@@ -83,6 +83,22 @@ object AdvancedGameConfig {
 enum RenderingTechnology derives CanEqual:
   case WebGL1, WebGL2, WebGL2WithFallback
 
+  def isWebGL1: Boolean =
+    this match
+      case WebGL1 => true
+      case _      => false
+
+  def isWebGL2: Boolean =
+    this match
+      case WebGL2 => true
+      case _      => false
+
+  // Note: This isn't really a thing. Immediately after initialisation the rendering tech is decided to be 1.0 or 2.0
+  def isWebGL2WithFallback: Boolean =
+    this match
+      case WebGL2WithFallback => true
+      case _                  => false
+
 object RenderingTechnology:
   extension (t: RenderingTechnology)
     def name: String =

--- a/indigo/indigo/src/main/scala/indigo/shared/datatypes/Rectangle.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/datatypes/Rectangle.scala
@@ -82,7 +82,7 @@ object Rectangle:
   given CanEqual[Option[Rectangle], Option[Rectangle]] = CanEqual.derived
 
   val zero: Rectangle = Rectangle(0, 0, 0, 0)
-  val one: Rectangle = Rectangle(0, 0, 1, 1)
+  val one: Rectangle  = Rectangle(0, 0, 1, 1)
 
   def apply(x: Int, y: Int, width: Int, height: Int): Rectangle =
     Rectangle(Point(x, y), Size(width, height))

--- a/indigo/indigo/src/main/scala/indigo/shared/datatypes/Rectangle.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/datatypes/Rectangle.scala
@@ -82,6 +82,7 @@ object Rectangle:
   given CanEqual[Option[Rectangle], Option[Rectangle]] = CanEqual.derived
 
   val zero: Rectangle = Rectangle(0, 0, 0, 0)
+  val one: Rectangle = Rectangle(0, 0, 1, 1)
 
   def apply(x: Int, y: Int, width: Int, height: Int): Rectangle =
     Rectangle(Point(x, y), Size(width, height))

--- a/indigo/indigo/src/main/scala/indigo/shared/platform/DisplayObjectConversions.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/platform/DisplayObjectConversions.scala
@@ -52,7 +52,6 @@ import indigo.shared.shader.ShaderPrimitive
 import indigo.shared.shader.Uniform
 import indigo.shared.shader.UniformBlock
 import indigo.shared.time.GameTime
-import org.w3c.dom.css.Rect
 
 import scala.annotation.tailrec
 import scala.collection.immutable.HashMap

--- a/indigo/indigo/src/main/scala/indigo/shared/platform/SceneProcessor.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/platform/SceneProcessor.scala
@@ -57,7 +57,8 @@ final class SceneProcessor(
       gameTime: GameTime,
       scene: SceneUpdateFragment,
       assetMapping: AssetMapping,
-      renderingTechnology: RenderingTechnology
+      renderingTechnology: RenderingTechnology,
+      maxBatchSize: Int
   ): ProcessedSceneData = {
 
     def cloneBlankToDisplayObject(blank: CloneBlank): Option[DisplayObject] =
@@ -114,7 +115,14 @@ final class SceneProcessor(
           val shaderData = blending.blendMaterial.toShaderData
 
           val conversionResults = displayObjectConverter
-            .sceneNodesToDisplayObjects(l.nodes, gameTime, assetMapping, cloneBlankDisplayObjects, renderingTechnology)
+            .sceneNodesToDisplayObjects(
+              l.nodes,
+              gameTime,
+              assetMapping,
+              cloneBlankDisplayObjects,
+              renderingTechnology,
+              maxBatchSize
+            )
 
           val layer = DisplayLayer(
             conversionResults._1,

--- a/indigo/indigo/src/test/scala/indigo/shared/platform/DisplayObjectConversionsTests.scala
+++ b/indigo/indigo/src/test/scala/indigo/shared/platform/DisplayObjectConversionsTests.scala
@@ -7,6 +7,7 @@ import indigo.shared.BoundaryLocator
 import indigo.shared.FontRegister
 import indigo.shared.QuickCache
 import indigo.shared.assets.AssetName
+import indigo.shared.config.RenderingTechnology
 import indigo.shared.datatypes.Depth
 import indigo.shared.datatypes.Point
 import indigo.shared.datatypes.Radians
@@ -63,8 +64,10 @@ class DisplayObjectConversionsTests extends munit.FunSuite {
         List(node),
         GameTime.is(Seconds(1)),
         assetMapping,
-        cloneBlankMapping
+        cloneBlankMapping,
+        RenderingTechnology.WebGL2
       )
+      ._1
       .head match {
       case _: DisplayCloneBatch =>
         throw new Exception("failed (DisplayCloneBatch)")
@@ -97,8 +100,10 @@ class DisplayObjectConversionsTests extends munit.FunSuite {
         List(node),
         GameTime.is(Seconds(1)),
         assetMapping,
-        cloneBlankMapping
+        cloneBlankMapping,
+        RenderingTechnology.WebGL2
       )
+      ._1
       .head match {
       case _: DisplayCloneBatch =>
         throw new Exception("failed (DisplayCloneBatch)")

--- a/indigo/indigo/src/test/scala/indigo/shared/platform/DisplayObjectConversionsTests.scala
+++ b/indigo/indigo/src/test/scala/indigo/shared/platform/DisplayObjectConversionsTests.scala
@@ -65,7 +65,8 @@ class DisplayObjectConversionsTests extends munit.FunSuite {
         GameTime.is(Seconds(1)),
         assetMapping,
         cloneBlankMapping,
-        RenderingTechnology.WebGL2
+        RenderingTechnology.WebGL2,
+        256
       )
       ._1
       .head match {
@@ -101,7 +102,8 @@ class DisplayObjectConversionsTests extends munit.FunSuite {
         GameTime.is(Seconds(1)),
         assetMapping,
         cloneBlankMapping,
-        RenderingTechnology.WebGL2
+        RenderingTechnology.WebGL2,
+        256
       )
       ._1
       .head match {


### PR DESCRIPTION
This PR is an attempt to make the standard `Text` primitive much less resource hungry.

The way the current version works, and will continue to work for WebGL 1.0, is that for each letter in the text to be rendered, and individual entity is spawned in the right location, with the right crop of the font sheet to draw that letter.

This has worked well for years now, with the caveat that it was never intended to work for large bodies of text. The advantage of `Text` over `TextBox` (which will support lots of text) is that `Text` is pixel perfect and `TextBox` cannot be because of the way browsers render text to canvas elements.

Unfortunately the game I'm working on needs lots of text. In the game, thanks to the [roguelike-starterkit](https://github.com/PurpleKingdomGames/roguelike-starterkit) we have 4 methods of drawing text, but the most convenient is still good old `Text` and so it needs to be faster. Faster here means "allocate less and therefore trigger fewer damaging Major GC pauses".

The solution is to replace the "one entity per letter" method with the use of the same mechanism used to render `CloneTiles`, which will at most result in one entity per _line_ of text, and possible one entity per text entity.

A secondary advantage to this is that we heavily cache the render pipeline transform results internally, and this approach results in fewer and smaller cache entries.
