### PR TITLE
Add mouse multi-button support to mouse event

### DIFF
--- a/examples/confetti/src/main/scala/com/example/confetti/Confetti.scala
+++ b/examples/confetti/src/main/scala/com/example/confetti/Confetti.scala
@@ -34,8 +34,8 @@ object Confetti extends IndigoDemo[Unit, Unit, Model, Unit]:
     Outcome(())
 
   def updateModel(context: FrameContext[Unit], model: Model): GlobalEvent => Outcome[Model] = event =>
-    val isLeftDown  = context.mouse.isButtonDown(MouseButton.LeftMouseButton)
-    val isRightDown = context.mouse.isButtonDown(MouseButton.RightMouseButton)
+    val isLeftDown  = context.mouse.isLeftDown
+    val isRightDown = context.mouse.isRightDown
 
     event match
       case FrameTick if isLeftDown || isRightDown =>

--- a/indigo/docs/gameloop/events.md
+++ b/indigo/docs/gameloop/events.md
@@ -65,12 +65,12 @@ Up to five mouse buttons are supported, including the most common left, middle a
 
 Convenience functions are provided for the left mouse button.
 
-- `Click(x, y, button)`
+- `Click(x, y)`
 - `MouseUp(x, y, button)`
 - `MouseDown(x, y, button)`
 - `Move(x, y)`
 
-Notice how the `Move` event is independent of any button.
+Notice however that the `Click` event is restricted to the left mouse button, and `Move` is independent of any button.
 
 #### `KeyboardEvent`s
 

--- a/indigo/docs/gameloop/events.md
+++ b/indigo/docs/gameloop/events.md
@@ -61,10 +61,16 @@ You can create your own events by simply extending `GlobalEvent`.
 
 What did the mouse do and at what location?
 
-- `Click(x, y)`
-- `MouseUp(x, y)`
-- `MouseDown(x, y)`
+Up to five mouse buttons are supported, including the most common left, middle and right buttons.
+
+Convenience functions are provided for the left mouse button.
+
+- `Click(x, y, button)`
+- `MouseUp(x, y, button)`
+- `MouseDown(x, y, button)`
 - `Move(x, y)`
+
+Notice how the `Move` event is independent of any button.
 
 #### `KeyboardEvent`s
 

--- a/indigo/docs/uicomponents/ui-components.md
+++ b/indigo/docs/uicomponents/ui-components.md
@@ -9,7 +9,7 @@ UI components are generally the kinds of elements your expect to see in any web 
 
 Indigo does not provide a large suite of UI Components out of the box although we hope to expand, [see issue for progress](https://github.com/PurpleKingdomGames/indigo/issues/41). This is because _basic_ UI components are not terribly complicated to build on top of Indigo by aspiring game devs, and so have been pushed down the priority list in favor of more fundamental / specialized pieces of functionality. Help is welcome!
 
-> A word of caution about UI components depending on mouse actions: currently, only the left mouse button is supported for the sake of simplicity. But you can always create another UI component allowing the usage of other mouse actions like the right mouse button click, as Indigo supports it, along with other mouse buttons actions, as you can see at the [events](gamelooop/events.md) page.
+> A word of caution about UI components depending on mouse actions: currently, only the left mouse button is supported for the sake of simplicity. But you can always create another UI component allowing the usage of other mouse actions like the right mouse button up or down, as Indigo supports it, along with other mouse buttons actions, as you can see at the [events](gamelooop/events.md) page.
 
 ## The Pattern
 

--- a/indigo/docs/uicomponents/ui-components.md
+++ b/indigo/docs/uicomponents/ui-components.md
@@ -9,6 +9,8 @@ UI components are generally the kinds of elements your expect to see in any web 
 
 Indigo does not provide a large suite of UI Components out of the box although we hope to expand, [see issue for progress](https://github.com/PurpleKingdomGames/indigo/issues/41). This is because _basic_ UI components are not terribly complicated to build on top of Indigo by aspiring game devs, and so have been pushed down the priority list in favor of more fundamental / specialized pieces of functionality. Help is welcome!
 
+> A word of caution about UI components depending on mouse actions: currently, only the left mouse button is supported for the sake of simplicity. But you can always create another UI component allowing the usage of other mouse actions like the right mouse button click, as Indigo supports it, along with other mouse buttons actions, as you can see at the [events](gamelooop/events.md) page.
+
 ## The Pattern
 
 The components Indigo does provide (with the exception of hit areas) follow a very specific pattern. The idea is that while the values UI components temporarily represent are interesting, and should be stored in the model (e.g. the players name for their character), the UI Components themselves are not interesting and should be somewhat ephemeral. In other words, you'd want to save the characters name, but not the state of an input field. Therefore in their current design, UI Components are only supposed to live in the view model and the view.

--- a/indigo/indigo-extras/src/main/scala/indigoextras/ui/Button.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/ui/Button.scala
@@ -15,6 +15,9 @@ import indigo.shared.scenegraph.Sprite
 import indigo.shared.scenegraph.Text
 import indigo.shared.scenegraph.TextBox
 
+import scala.annotation.nowarn
+
+@nowarn("msg=value leftMouseIsDown in class Mouse is deprecated")
 final case class Button(
     buttonAssets: ButtonAssets,
     bounds: Rectangle,

--- a/indigo/indigo-extras/src/main/scala/indigoextras/ui/HitArea.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/ui/HitArea.scala
@@ -8,6 +8,9 @@ import indigo.shared.input.Mouse
 import indigoextras.geometry.Polygon
 import indigoextras.geometry.Vertex
 
+import scala.annotation.nowarn
+
+@nowarn("msg=value leftMouseIsDown in class Mouse is deprecated")
 final case class HitArea(
     area: Polygon.Closed,
     state: ButtonState,

--- a/indigo/indigo-extras/src/main/scala/indigoextras/ui/RadioButtonGroup.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/ui/RadioButtonGroup.scala
@@ -15,6 +15,7 @@ import indigo.shared.scenegraph.Sprite
 import indigo.shared.scenegraph.Text
 import indigo.shared.scenegraph.TextBox
 
+import scala.annotation.nowarn
 import scala.annotation.tailrec
 
 /** Represents an individual option button in a radio button group. This class just containing the distinct information
@@ -33,6 +34,7 @@ import scala.annotation.tailrec
   * @param state
   *   The current state of the radio button i.e., selected, hover, or normal
   */
+@nowarn("msg=value leftMouseIsDown in class Mouse is deprecated")
 final case class RadioButton(
     position: Point,
     onSelected: () => List[GlobalEvent],
@@ -213,6 +215,7 @@ object RadioButton {
   * @param depth
   *   The depth at which to present the buttons
   */
+@nowarn("msg=value leftMouseIsDown in class Mouse is deprecated")
 final case class RadioButtonGroup(
     buttonAssets: ButtonAssets,
     hitArea: Rectangle,

--- a/indigo/indigo-extras/src/test/scala/indigoextras/ui/ButtonTests.scala
+++ b/indigo/indigo-extras/src/test/scala/indigoextras/ui/ButtonTests.scala
@@ -10,6 +10,9 @@ import indigo.shared.input.Mouse
 import indigo.shared.materials.Material
 import indigo.shared.scenegraph.Graphic
 
+import scala.annotation.nowarn
+
+@nowarn("msg=value leftMouseIsDown in class Mouse is deprecated")
 class ButtonTests extends munit.FunSuite {
 
   val bounds =

--- a/indigo/indigo/src/main/scala/indigo/package.scala
+++ b/indigo/indigo/src/main/scala/indigo/package.scala
@@ -234,6 +234,9 @@ val MouseInput: shared.events.MouseInput.type = shared.events.MouseInput
 type MouseEvent = shared.events.MouseEvent
 val MouseEvent: shared.events.MouseEvent.type = shared.events.MouseEvent
 
+type MouseButton = shared.events.MouseButton
+val MouseButton: shared.events.MouseButton.type = shared.events.MouseButton
+
 type Keyboard = shared.input.Keyboard
 val Keyboard: shared.input.Keyboard.type = shared.input.Keyboard
 

--- a/indigo/indigo/src/main/scala/indigo/platform/events/WorldEvents.scala
+++ b/indigo/indigo/src/main/scala/indigo/platform/events/WorldEvents.scala
@@ -2,6 +2,7 @@ package indigo.platform.events
 
 import indigo.shared.constants.Key
 import indigo.shared.events.KeyboardEvent
+import indigo.shared.events.MouseButton
 import indigo.shared.events.MouseEvent
 import org.scalajs.dom
 import org.scalajs.dom.document
@@ -35,7 +36,8 @@ object WorldEvents {
       globalEventStream.pushGlobalEvent(
         MouseEvent.Click(
           absoluteCoordsX(e.clientX) / magnification,
-          absoluteCoordsY(e.clientY) / magnification
+          absoluteCoordsY(e.clientY) / magnification,
+          MouseButton.fromOrdinal(e.button)
         )
       )
     }
@@ -44,7 +46,8 @@ object WorldEvents {
       globalEventStream.pushGlobalEvent(
         MouseEvent.Move(
           absoluteCoordsX(e.clientX) / magnification,
-          absoluteCoordsY(e.clientY) / magnification
+          absoluteCoordsY(e.clientY) / magnification,
+          MouseButton.fromOrdinal(e.button)
         )
       )
     }
@@ -53,7 +56,8 @@ object WorldEvents {
       globalEventStream.pushGlobalEvent(
         MouseEvent.MouseDown(
           absoluteCoordsX(e.clientX) / magnification,
-          absoluteCoordsY(e.clientY) / magnification
+          absoluteCoordsY(e.clientY) / magnification,
+          MouseButton.fromOrdinal(e.button)
         )
       )
     }
@@ -62,10 +66,14 @@ object WorldEvents {
       globalEventStream.pushGlobalEvent(
         MouseEvent.MouseUp(
           absoluteCoordsX(e.clientX) / magnification,
-          absoluteCoordsY(e.clientY) / magnification
+          absoluteCoordsY(e.clientY) / magnification,
+          MouseButton.fromOrdinal(e.button)
         )
       )
     }
+
+    // Prevent right mouse button from popping up the context menu
+    canvas.oncontextmenu = _.preventDefault()
 
     document.onkeydown = { (e: dom.KeyboardEvent) =>
       globalEventStream.pushGlobalEvent(KeyboardEvent.KeyDown(Key(e.keyCode, e.key)))

--- a/indigo/indigo/src/main/scala/indigo/platform/events/WorldEvents.scala
+++ b/indigo/indigo/src/main/scala/indigo/platform/events/WorldEvents.scala
@@ -32,12 +32,12 @@ object WorldEvents {
   }
 
   def init(canvas: html.Canvas, magnification: Int, globalEventStream: GlobalEventStream): Unit = {
+    // Onclick only supports the left mouse button
     canvas.onclick = { (e: dom.MouseEvent) =>
       globalEventStream.pushGlobalEvent(
         MouseEvent.Click(
           absoluteCoordsX(e.clientX) / magnification,
-          absoluteCoordsY(e.clientY) / magnification,
-          MouseButton.fromOrdinal(e.button)
+          absoluteCoordsY(e.clientY) / magnification
         )
       )
     }
@@ -46,8 +46,7 @@ object WorldEvents {
       globalEventStream.pushGlobalEvent(
         MouseEvent.Move(
           absoluteCoordsX(e.clientX) / magnification,
-          absoluteCoordsY(e.clientY) / magnification,
-          MouseButton.fromOrdinal(e.button)
+          absoluteCoordsY(e.clientY) / magnification
         )
       )
     }

--- a/indigo/indigo/src/main/scala/indigo/platform/events/WorldEvents.scala
+++ b/indigo/indigo/src/main/scala/indigo/platform/events/WorldEvents.scala
@@ -52,23 +52,27 @@ object WorldEvents {
     }
 
     canvas.onmousedown = { (e: dom.MouseEvent) =>
-      globalEventStream.pushGlobalEvent(
-        MouseEvent.MouseDown(
-          absoluteCoordsX(e.clientX) / magnification,
-          absoluteCoordsY(e.clientY) / magnification,
-          MouseButton.fromOrdinal(e.button)
+      MouseButton.fromOrdinalOpt(e.button).foreach { mouseButton =>
+        globalEventStream.pushGlobalEvent(
+          MouseEvent.MouseDown(
+            absoluteCoordsX(e.clientX) / magnification,
+            absoluteCoordsY(e.clientY) / magnification,
+            mouseButton
+          )
         )
-      )
+      }
     }
 
     canvas.onmouseup = { (e: dom.MouseEvent) =>
-      globalEventStream.pushGlobalEvent(
-        MouseEvent.MouseUp(
-          absoluteCoordsX(e.clientX) / magnification,
-          absoluteCoordsY(e.clientY) / magnification,
-          MouseButton.fromOrdinal(e.button)
+      MouseButton.fromOrdinalOpt(e.button).foreach { mouseButton =>
+        globalEventStream.pushGlobalEvent(
+          MouseEvent.MouseUp(
+            absoluteCoordsX(e.clientX) / magnification,
+            absoluteCoordsY(e.clientY) / magnification,
+            mouseButton
+          )
         )
-      )
+      }
     }
 
     // Prevent right mouse button from popping up the context menu

--- a/indigo/indigo/src/main/scala/indigo/shared/events/GlobalEvent.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/events/GlobalEvent.scala
@@ -87,12 +87,23 @@ case object FullScreenExited extends ViewEvent
   */
 case object FullScreenExitError extends ViewEvent
 
+/** Follows the MDN spec values https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button
+ *  Relies on the ordinal behavior of Scala 3 enums to match the button number
+  */
+enum MouseButton derives CanEqual:
+  case LeftMouseButton      extends MouseButton
+  case MiddleMouseButton    extends MouseButton
+  case RightMouseButton     extends MouseButton
+  case BrowserBackButton    extends MouseButton
+  case BrowserForwardButton extends MouseButton
+
 /** Represents all mouse events
   */
 sealed trait MouseEvent extends InputEvent {
   val position: Point
   val x: Int
   val y: Int
+  val button: MouseButton
 }
 object MouseEvent {
 
@@ -102,13 +113,19 @@ object MouseEvent {
     *   X coord relative to magnification level
     * @param y
     *   Y coord relative to magnification level
+    * @param button
+    *   Button that triggered this event
     */
-  final case class Click(position: Point) extends MouseEvent:
+  final case class Click(position: Point, button: MouseButton) extends MouseEvent:
     val x: Int = position.x
     val y: Int = position.y
   object Click:
+    def apply(position: Point): Click =
+      Click(position, MouseButton.LeftMouseButton)
     def apply(x: Int, y: Int): Click =
-      Click(Point(x, y))
+      Click(Point(x, y), MouseButton.LeftMouseButton)
+    def apply(x: Int, y: Int, button: MouseButton): Click =
+      Click(Point(x, y), button)
 
   /** The left mouse button was released.
     *
@@ -116,13 +133,19 @@ object MouseEvent {
     *   X coord relative to magnification level
     * @param y
     *   Y coord relative to magnification level
+    * @param button
+    *   Button that triggered this event
     */
-  final case class MouseUp(position: Point) extends MouseEvent:
+  final case class MouseUp(position: Point, button: MouseButton) extends MouseEvent:
     val x: Int = position.x
     val y: Int = position.y
   object MouseUp:
+    def apply(position: Point): MouseUp =
+      MouseUp(position, MouseButton.LeftMouseButton)
     def apply(x: Int, y: Int): MouseUp =
-      MouseUp(Point(x, y))
+      MouseUp(Point(x, y), MouseButton.LeftMouseButton)
+    def apply(x: Int, y: Int, button: MouseButton): MouseUp =
+      MouseUp(Point(x, y), button)
 
   /** The left mouse button was pressed down.
     *
@@ -130,13 +153,19 @@ object MouseEvent {
     *   X coord relative to magnification level
     * @param y
     *   Y coord relative to magnification level
+    * @param button
+    *   Button that triggered this event
     */
-  final case class MouseDown(position: Point) extends MouseEvent:
+  final case class MouseDown(position: Point, button: MouseButton) extends MouseEvent:
     val x: Int = position.x
     val y: Int = position.y
   object MouseDown:
+    def apply(position: Point): MouseDown =
+      MouseDown(position, MouseButton.LeftMouseButton)
     def apply(x: Int, y: Int): MouseDown =
-      MouseDown(Point(x, y))
+      MouseDown(Point(x, y), MouseButton.LeftMouseButton)
+    def apply(x: Int, y: Int, button: MouseButton): MouseDown =
+      MouseDown(Point(x, y), button)
 
   /** The mouse was moved to a new position.
     *
@@ -144,13 +173,19 @@ object MouseEvent {
     *   X coord relative to magnification level
     * @param y
     *   Y coord relative to magnification level
+    * @param button
+    *   Button that triggered this event
     */
-  final case class Move(position: Point) extends MouseEvent:
+  final case class Move(position: Point, button: MouseButton) extends MouseEvent:
     val x: Int = position.x
     val y: Int = position.y
   object Move:
+    def apply(position: Point): Move =
+      Move(position, MouseButton.LeftMouseButton)
     def apply(x: Int, y: Int): Move =
-      Move(Point(x, y))
+      Move(Point(x, y), MouseButton.LeftMouseButton)
+    def apply(x: Int, y: Int, button: MouseButton): Move =
+      Move(Point(x, y), button)
 }
 
 /** Represents all keyboard events

--- a/indigo/indigo/src/main/scala/indigo/shared/events/GlobalEvent.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/events/GlobalEvent.scala
@@ -103,9 +103,8 @@ sealed trait MouseEvent extends InputEvent {
   val position: Point
   val x: Int
   val y: Int
-  val button: MouseButton
 }
-object MouseEvent {
+object MouseEvent:
 
   /** The mouse has been clicked.
     *
@@ -113,19 +112,13 @@ object MouseEvent {
     *   X coord relative to magnification level
     * @param y
     *   Y coord relative to magnification level
-    * @param button
-    *   Button that triggered this event
     */
-  final case class Click(position: Point, button: MouseButton) extends MouseEvent:
+  final case class Click(position: Point) extends MouseEvent:
     val x: Int = position.x
     val y: Int = position.y
   object Click:
-    def apply(position: Point): Click =
-      Click(position, MouseButton.LeftMouseButton)
     def apply(x: Int, y: Int): Click =
-      Click(Point(x, y), MouseButton.LeftMouseButton)
-    def apply(x: Int, y: Int, button: MouseButton): Click =
-      Click(Point(x, y), button)
+      Click(Point(x, y))
 
   /** The left mouse button was released.
     *
@@ -173,20 +166,16 @@ object MouseEvent {
     *   X coord relative to magnification level
     * @param y
     *   Y coord relative to magnification level
-    * @param button
-    *   Button that triggered this event
     */
-  final case class Move(position: Point, button: MouseButton) extends MouseEvent:
+  final case class Move(position: Point) extends MouseEvent:
     val x: Int = position.x
     val y: Int = position.y
+
   object Move:
-    def apply(position: Point): Move =
-      Move(position, MouseButton.LeftMouseButton)
     def apply(x: Int, y: Int): Move =
-      Move(Point(x, y), MouseButton.LeftMouseButton)
-    def apply(x: Int, y: Int, button: MouseButton): Move =
-      Move(Point(x, y), button)
-}
+      Move(Point(x, y))
+
+end MouseEvent
 
 /** Represents all keyboard events
   */

--- a/indigo/indigo/src/main/scala/indigo/shared/events/GlobalEvent.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/events/GlobalEvent.scala
@@ -87,8 +87,8 @@ case object FullScreenExited extends ViewEvent
   */
 case object FullScreenExitError extends ViewEvent
 
-/** Follows the MDN spec values https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button
- *  Relies on the ordinal behavior of Scala 3 enums to match the button number
+/** Follows the MDN spec values https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button Relies on the ordinal
+  * behavior of Scala 3 enums to match the button number
   */
 enum MouseButton derives CanEqual:
   case LeftMouseButton      extends MouseButton
@@ -96,6 +96,12 @@ enum MouseButton derives CanEqual:
   case RightMouseButton     extends MouseButton
   case BrowserBackButton    extends MouseButton
   case BrowserForwardButton extends MouseButton
+
+object MouseButton:
+  def fromOrdinalOpt(ordinal: Int): Option[MouseButton] =
+    if ordinal >= LeftMouseButton.ordinal && ordinal <= BrowserForwardButton.ordinal then
+      Some(MouseButton.fromOrdinal(ordinal))
+    else Option.empty[MouseButton]
 
 /** Represents all mouse events
   */

--- a/indigo/indigo/src/main/scala/indigo/shared/events/InputMapping.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/events/InputMapping.scala
@@ -20,10 +20,13 @@ final case class InputMapping[A](oneOf: List[(Combo, A)]) {
     oneOf
       .find { c =>
         c._1.mouseInputs.forall {
-          case MouseInput.MouseUp     => mouse.mouseReleased
-          case MouseInput.MouseDown   => mouse.mousePressed
-          case MouseInput.MouseClick  => mouse.mouseClicked
-          case MouseInput.MouseAt(pt) => mouse.position == pt
+          case MouseInput.MouseUp                  => mouse.mouseButtonReleased(MouseButton.LeftMouseButton)
+          case MouseInput.MouseDown                => mouse.mouseButtonPressed(MouseButton.LeftMouseButton)
+          case MouseInput.MouseClick               => mouse.mouseButtonClicked(MouseButton.LeftMouseButton)
+          case MouseInput.MouseAt(pt)              => mouse.position == pt
+          case MouseInput.MouseButtonUp(button)    => mouse.mouseButtonReleased(button)
+          case MouseInput.MouseButtonDown(button)  => mouse.mouseButtonClicked(button)
+          case MouseInput.MouseButtonClick(button) => mouse.mouseButtonPressed(button)
         } &&
         c._1.keyInputs.forall(k => keyboard.keysDown.contains(k)) &&
         c._1.gamepadInputs.forall {
@@ -124,22 +127,22 @@ object Combo {
 }
 
 enum GamepadInput derives CanEqual:
-  case DPAD_UP extends GamepadInput
-  case DPAD_LEFT extends GamepadInput
+  case DPAD_UP    extends GamepadInput
+  case DPAD_LEFT  extends GamepadInput
   case DPAD_RIGHT extends GamepadInput
-  case DPAD_DOWN extends GamepadInput
-  case Cross extends GamepadInput
-  case Circle extends GamepadInput
-  case Square extends GamepadInput
-  case Triangle extends GamepadInput
-  case L1 extends GamepadInput
-  case L2 extends GamepadInput
-  case R1 extends GamepadInput
-  case R2 extends GamepadInput
-  case Options extends GamepadInput
-  case Share extends GamepadInput
-  case PS extends GamepadInput
-  case TouchPad extends GamepadInput
+  case DPAD_DOWN  extends GamepadInput
+  case Cross      extends GamepadInput
+  case Circle     extends GamepadInput
+  case Square     extends GamepadInput
+  case Triangle   extends GamepadInput
+  case L1         extends GamepadInput
+  case L2         extends GamepadInput
+  case R1         extends GamepadInput
+  case R2         extends GamepadInput
+  case Options    extends GamepadInput
+  case Share      extends GamepadInput
+  case PS         extends GamepadInput
+  case TouchPad   extends GamepadInput
   case LEFT_ANALOG(
       x: Double => Boolean,
       y: Double => Boolean,
@@ -152,10 +155,13 @@ enum GamepadInput derives CanEqual:
   ) extends GamepadInput
 
 enum MouseInput derives CanEqual:
-  case MouseDown extends MouseInput
-  case MouseUp extends MouseInput
-  case MouseClick extends MouseInput
-  case MouseAt(position: Point) extends MouseInput
+  case MouseDown                             extends MouseInput
+  case MouseUp                               extends MouseInput
+  case MouseClick                            extends MouseInput
+  case MouseAt(position: Point)              extends MouseInput
+  case MouseButtonDown(button: MouseButton)  extends MouseInput
+  case MouseButtonUp(button: MouseButton)    extends MouseInput
+  case MouseButtonClick(button: MouseButton) extends MouseInput
 
 object MouseInput:
   object MouseAt:

--- a/indigo/indigo/src/main/scala/indigo/shared/events/InputMapping.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/events/InputMapping.scala
@@ -20,9 +20,9 @@ final case class InputMapping[A](oneOf: List[(Combo, A)]) {
     oneOf
       .find { c =>
         c._1.mouseInputs.forall {
-          case MouseInput.MouseUp                  => mouse.mouseButtonReleased(MouseButton.LeftMouseButton)
-          case MouseInput.MouseDown                => mouse.mouseButtonPressed(MouseButton.LeftMouseButton)
-          case MouseInput.MouseClick               => mouse.mouseButtonClicked(MouseButton.LeftMouseButton)
+          case MouseInput.MouseUp                  => mouse.mouseReleased
+          case MouseInput.MouseDown                => mouse.mousePressed
+          case MouseInput.MouseClick               => mouse.mouseClicked
           case MouseInput.MouseAt(pt)              => mouse.position == pt
           case MouseInput.MouseButtonUp(button)    => mouse.mouseButtonReleased(button)
           case MouseInput.MouseButtonDown(button)  => mouse.mouseButtonClicked(button)

--- a/indigo/indigo/src/main/scala/indigo/shared/events/InputMapping.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/events/InputMapping.scala
@@ -20,13 +20,12 @@ final case class InputMapping[A](oneOf: List[(Combo, A)]) {
     oneOf
       .find { c =>
         c._1.mouseInputs.forall {
-          case MouseInput.MouseUp                  => mouse.mouseReleased
-          case MouseInput.MouseDown                => mouse.mousePressed
-          case MouseInput.MouseClick               => mouse.mouseClicked
-          case MouseInput.MouseAt(pt)              => mouse.position == pt
-          case MouseInput.MouseButtonUp(button)    => mouse.mouseButtonReleased(button)
-          case MouseInput.MouseButtonDown(button)  => mouse.mouseButtonClicked(button)
-          case MouseInput.MouseButtonClick(button) => mouse.mouseButtonPressed(button)
+          case MouseInput.MouseUp                 => mouse.mouseReleased
+          case MouseInput.MouseDown               => mouse.mousePressed
+          case MouseInput.MouseClick              => mouse.mouseClicked
+          case MouseInput.MouseAt(pt)             => mouse.position == pt
+          case MouseInput.MouseButtonUp(button)   => mouse.mouseButtonReleased(button)
+          case MouseInput.MouseButtonDown(button) => mouse.mouseButtonPressed(button)
         } &&
         c._1.keyInputs.forall(k => keyboard.keysDown.contains(k)) &&
         c._1.gamepadInputs.forall {
@@ -155,13 +154,12 @@ enum GamepadInput derives CanEqual:
   ) extends GamepadInput
 
 enum MouseInput derives CanEqual:
-  case MouseDown                             extends MouseInput
-  case MouseUp                               extends MouseInput
-  case MouseClick                            extends MouseInput
-  case MouseAt(position: Point)              extends MouseInput
-  case MouseButtonDown(button: MouseButton)  extends MouseInput
-  case MouseButtonUp(button: MouseButton)    extends MouseInput
-  case MouseButtonClick(button: MouseButton) extends MouseInput
+  case MouseDown                            extends MouseInput
+  case MouseUp                              extends MouseInput
+  case MouseClick                           extends MouseInput
+  case MouseAt(position: Point)             extends MouseInput
+  case MouseButtonDown(button: MouseButton) extends MouseInput
+  case MouseButtonUp(button: MouseButton)   extends MouseInput
 
 object MouseInput:
   object MouseAt:

--- a/indigo/indigo/src/main/scala/indigo/shared/events/InputMapping.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/events/InputMapping.scala
@@ -24,8 +24,8 @@ final case class InputMapping[A](oneOf: List[(Combo, A)]) {
           case MouseInput.MouseDown               => mouse.mousePressed
           case MouseInput.MouseClick              => mouse.mouseClicked
           case MouseInput.MouseAt(pt)             => mouse.position == pt
-          case MouseInput.MouseButtonUp(button)   => mouse.mouseButtonReleased(button)
-          case MouseInput.MouseButtonDown(button) => mouse.mouseButtonPressed(button)
+          case MouseInput.MouseButtonUp(button)   => mouse.released(button)
+          case MouseInput.MouseButtonDown(button) => mouse.pressed(button)
         } &&
         c._1.keyInputs.forall(k => keyboard.keysDown.contains(k)) &&
         c._1.gamepadInputs.forall {

--- a/indigo/indigo/src/main/scala/indigo/shared/input/Mouse.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/input/Mouse.scala
@@ -9,9 +9,12 @@ import scala.annotation.tailrec
 
 final class Mouse(mouseEvents: List[MouseEvent], val position: Point, val leftMouseIsDown: Boolean) {
 
+  lazy val mouseClicked: Boolean = mouseEvents.exists {
+    case _: MouseEvent.Click => true
+    case _                   => false
+  }
   lazy val mousePressed  = mouseButtonPressed(MouseButton.LeftMouseButton)
   lazy val mouseReleased = mouseButtonReleased(MouseButton.LeftMouseButton)
-  lazy val mouseClicked  = mouseButtonClicked(MouseButton.LeftMouseButton)
 
   def mouseButtonPressed(button: MouseButton): Boolean =
     mouseEvents.exists {
@@ -25,19 +28,12 @@ final class Mouse(mouseEvents: List[MouseEvent], val position: Point, val leftMo
       case _                             => false
     }
 
-  def mouseButtonClicked(button: MouseButton): Boolean =
-    mouseEvents.exists {
-      case MouseEvent.Click(_, button) => true
-      case _                           => false
-    }
-
-  lazy val mouseClickAt: Option[Point] = mouseButtonClickedAt(MouseButton.LeftMouseButton)
-  lazy val mouseUpAt: Option[Point]    = mouseButtonUpAt(MouseButton.LeftMouseButton)
-  lazy val mouseDownAt: Option[Point]  = mouseButtonDownAt(MouseButton.LeftMouseButton)
-
-  def mouseButtonClickedAt(mouseButton: MouseButton): Option[Point] = mouseEvents.collectFirst {
-    case m: MouseEvent.Click if m.button == mouseButton => m.position
+  lazy val mouseClickAt: Option[Point] = mouseEvents.collectFirst { case m: MouseEvent.Click =>
+    m.position
   }
+  lazy val mouseUpAt: Option[Point]   = mouseButtonUpAt(MouseButton.LeftMouseButton)
+  lazy val mouseDownAt: Option[Point] = mouseButtonDownAt(MouseButton.LeftMouseButton)
+
   def mouseButtonUpAt(mouseButton: MouseButton): Option[Point] = mouseEvents.collectFirst {
     case m: MouseEvent.MouseUp if m.button == mouseButton => m.position
   }
@@ -46,17 +42,12 @@ final class Mouse(mouseEvents: List[MouseEvent], val position: Point, val leftMo
   }
 
   private def wasMouseAt(position: Point, maybePosition: Option[Point]): Boolean =
-    maybePosition match {
+    maybePosition match
       case Some(pt) => position == pt
       case None     => false
-    }
 
   def wasMouseClickedAt(position: Point): Boolean = wasMouseAt(position, mouseClickAt)
   def wasMouseClickedAt(x: Int, y: Int): Boolean  = wasMouseClickedAt(Point(x, y))
-  def wasMouseButtonClickedAt(position: Point, button: MouseButton): Boolean =
-    wasMouseAt(position, mouseButtonClickedAt(button))
-  def wasMouseButtonClickedAt(x: Int, y: Int, button: MouseButton): Boolean =
-    wasMouseButtonClickedAt(Point(x, y), button)
 
   def wasMouseUpAt(position: Point): Boolean = wasMouseAt(position, mouseUpAt)
   def wasMouseUpAt(x: Int, y: Int): Boolean  = wasMouseUpAt(Point(x, y))
@@ -85,10 +76,6 @@ final class Mouse(mouseEvents: List[MouseEvent], val position: Point, val leftMo
   def wasMouseClickedWithin(bounds: Rectangle): Boolean = wasMouseWithin(bounds, mouseClickAt)
   def wasMouseClickedWithin(x: Int, y: Int, width: Int, height: Int): Boolean =
     wasMouseClickedWithin(Rectangle(x, y, width, height))
-  def wasMouseButtonClickedWithin(bounds: Rectangle, button: MouseButton): Boolean =
-    wasMouseWithin(bounds, mouseButtonClickedAt(button))
-  def wasMouseButtonClickedWithin(x: Int, y: Int, width: Int, height: Int, button: MouseButton): Boolean =
-    wasMouseButtonClickedWithin(Rectangle(x, y, width, height), button)
 
   def wasMouseUpWithin(bounds: Rectangle): Boolean = wasMouseWithin(bounds, mouseUpAt)
   def wasMouseUpWithin(x: Int, y: Int, width: Int, height: Int): Boolean = wasMouseUpWithin(
@@ -134,17 +121,13 @@ object Mouse {
 
   @tailrec
   private def isLeftMouseDown(isDown: Boolean, events: List[MouseEvent]): Boolean =
-    events match {
+    events match
       case Nil =>
         isDown
-
       case MouseEvent.MouseDown(_, MouseButton.LeftMouseButton) :: xs =>
         isLeftMouseDown(true, xs)
-
       case MouseEvent.MouseUp(_, MouseButton.LeftMouseButton) :: xs =>
         isLeftMouseDown(false, xs)
-
       case _ :: xs =>
         isLeftMouseDown(isDown, xs)
-    }
 }

--- a/indigo/indigo/src/main/scala/indigo/shared/input/Mouse.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/input/Mouse.scala
@@ -9,22 +9,22 @@ import scala.annotation.tailrec
 
 final class Mouse(mouseEvents: List[MouseEvent], val position: Point, val leftMouseIsDown: Boolean) {
 
-  lazy val mousePressed: Boolean =
+  def mouseButtonPressed(button: MouseButton): Boolean =
     mouseEvents.exists {
-      case MouseEvent.MouseDown(_, MouseButton.LeftMouseButton) => true
-      case _                                                    => false
+      case MouseEvent.MouseDown(_, mouseButton) => true
+      case _                                    => false
     }
 
-  lazy val mouseReleased: Boolean =
+  def mouseButtonReleased(button: MouseButton): Boolean =
     mouseEvents.exists {
-      case MouseEvent.MouseUp(_, MouseButton.LeftMouseButton) => true
-      case _                                                  => false
+      case MouseEvent.MouseUp(_, button) => true
+      case _                             => false
     }
 
-  lazy val mouseClicked: Boolean =
+  def mouseButtonClicked(button: MouseButton): Boolean =
     mouseEvents.exists {
-      case MouseEvent.Click(_, MouseButton.LeftMouseButton) => true
-      case _                                                => false
+      case MouseEvent.Click(_, button) => true
+      case _                           => false
     }
 
   def mouseButtonClickedAt(mouseButton: MouseButton): Option[Point] = mouseEvents.collectFirst {

--- a/indigo/indigo/src/main/scala/indigo/shared/input/Mouse.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/input/Mouse.scala
@@ -9,6 +9,10 @@ import scala.annotation.tailrec
 
 final class Mouse(mouseEvents: List[MouseEvent], val position: Point, val leftMouseIsDown: Boolean) {
 
+  lazy val mousePressed  = mouseButtonPressed(MouseButton.LeftMouseButton)
+  lazy val mouseReleased = mouseButtonReleased(MouseButton.LeftMouseButton)
+  lazy val mouseClicked  = mouseButtonClicked(MouseButton.LeftMouseButton)
+
   def mouseButtonPressed(button: MouseButton): Boolean =
     mouseEvents.exists {
       case MouseEvent.MouseDown(_, mouseButton) => true
@@ -27,6 +31,10 @@ final class Mouse(mouseEvents: List[MouseEvent], val position: Point, val leftMo
       case _                           => false
     }
 
+  lazy val mouseClickAt: Option[Point] = mouseButtonClickedAt(MouseButton.LeftMouseButton)
+  lazy val mouseUpAt: Option[Point]    = mouseButtonUpAt(MouseButton.LeftMouseButton)
+  lazy val mouseDownAt: Option[Point]  = mouseButtonDownAt(MouseButton.LeftMouseButton)
+
   def mouseButtonClickedAt(mouseButton: MouseButton): Option[Point] = mouseEvents.collectFirst {
     case m: MouseEvent.Click if m.button == mouseButton => m.position
   }
@@ -37,10 +45,6 @@ final class Mouse(mouseEvents: List[MouseEvent], val position: Point, val leftMo
     case m: MouseEvent.MouseDown if m.button == mouseButton => m.position
   }
 
-  lazy val mouseClickAt: Option[Point] = mouseButtonClickedAt(MouseButton.LeftMouseButton)
-  lazy val mouseUpAt: Option[Point]    = mouseButtonUpAt(MouseButton.LeftMouseButton)
-  lazy val mouseDownAt: Option[Point]  = mouseButtonDownAt(MouseButton.LeftMouseButton)
-
   private def wasMouseAt(position: Point, maybePosition: Option[Point]): Boolean =
     maybePosition match {
       case Some(pt) => position == pt
@@ -49,12 +53,24 @@ final class Mouse(mouseEvents: List[MouseEvent], val position: Point, val leftMo
 
   def wasMouseClickedAt(position: Point): Boolean = wasMouseAt(position, mouseClickAt)
   def wasMouseClickedAt(x: Int, y: Int): Boolean  = wasMouseClickedAt(Point(x, y))
+  def wasMouseButtonClickedAt(position: Point, button: MouseButton): Boolean =
+    wasMouseAt(position, mouseButtonClickedAt(button))
+  def wasMouseButtonClickedAt(x: Int, y: Int, button: MouseButton): Boolean =
+    wasMouseButtonClickedAt(Point(x, y), button)
 
   def wasMouseUpAt(position: Point): Boolean = wasMouseAt(position, mouseUpAt)
   def wasMouseUpAt(x: Int, y: Int): Boolean  = wasMouseUpAt(Point(x, y))
+  def wasMouseButtonUpAt(position: Point, button: MouseButton): Boolean =
+    wasMouseAt(position, mouseButtonUpAt(button))
+  def wasMouseButtonUpAt(x: Int, y: Int, button: MouseButton): Boolean =
+    wasMouseButtonUpAt(Point(x, y), button)
 
   def wasMouseDownAt(position: Point): Boolean = wasMouseAt(position, mouseDownAt)
   def wasMouseDownAt(x: Int, y: Int): Boolean  = wasMouseDownAt(Point(x, y))
+  def wasMouseButtonDownAt(position: Point, button: MouseButton): Boolean =
+    wasMouseAt(position, mouseButtonDownAt(button))
+  def wasMouseButtonDownAt(x: Int, y: Int, button: MouseButton): Boolean =
+    wasMouseButtonDownAt(Point(x, y), button)
 
   def wasMousePositionAt(target: Point): Boolean  = target == position
   def wasMousePositionAt(x: Int, y: Int): Boolean = wasMousePositionAt(Point(x, y))
@@ -69,16 +85,28 @@ final class Mouse(mouseEvents: List[MouseEvent], val position: Point, val leftMo
   def wasMouseClickedWithin(bounds: Rectangle): Boolean = wasMouseWithin(bounds, mouseClickAt)
   def wasMouseClickedWithin(x: Int, y: Int, width: Int, height: Int): Boolean =
     wasMouseClickedWithin(Rectangle(x, y, width, height))
+  def wasMouseButtonClickedWithin(bounds: Rectangle, button: MouseButton): Boolean =
+    wasMouseWithin(bounds, mouseButtonClickedAt(button))
+  def wasMouseButtonClickedWithin(x: Int, y: Int, width: Int, height: Int, button: MouseButton): Boolean =
+    wasMouseButtonClickedWithin(Rectangle(x, y, width, height), button)
 
   def wasMouseUpWithin(bounds: Rectangle): Boolean = wasMouseWithin(bounds, mouseUpAt)
   def wasMouseUpWithin(x: Int, y: Int, width: Int, height: Int): Boolean = wasMouseUpWithin(
     Rectangle(x, y, width, height)
   )
+  def wasMouseButtonUpWithin(bounds: Rectangle, button: MouseButton): Boolean =
+    wasMouseWithin(bounds, mouseButtonUpAt(button))
+  def wasMouseButtonUpWithin(x: Int, y: Int, width: Int, height: Int, button: MouseButton): Boolean =
+    wasMouseButtonUpWithin(Rectangle(x, y, width, height), button)
 
   def wasMouseDownWithin(bounds: Rectangle): Boolean = wasMouseWithin(bounds, mouseDownAt)
   def wasMouseDownWithin(x: Int, y: Int, width: Int, height: Int): Boolean = wasMouseDownWithin(
     Rectangle(x, y, width, height)
   )
+  def wasMouseButtonDownWithin(bounds: Rectangle, button: MouseButton): Boolean =
+    wasMouseWithin(bounds, mouseButtonDownAt(button))
+  def wasMouseButtonDownWithin(x: Int, y: Int, width: Int, height: Int, button: MouseButton): Boolean =
+    wasMouseButtonDownWithin(Rectangle(x, y, width, height), button)
 
   def wasMousePositionWithin(bounds: Rectangle): Boolean = bounds.isPointWithin(position)
   def wasMousePositionWithin(x: Int, y: Int, width: Int, height: Int): Boolean =

--- a/indigo/indigo/src/main/scala/indigo/shared/input/Mouse.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/input/Mouse.scala
@@ -25,6 +25,9 @@ final class Mouse(
 
   def isButtonDown(button: MouseButton): Boolean = buttonsDown.contains(button)
 
+  lazy val isLeftDown: Boolean = buttonsDown.contains(MouseButton.LeftMouseButton)
+  lazy val isRightDown: Boolean = buttonsDown.contains(MouseButton.RightMouseButton)
+
   lazy val mouseClicked: Boolean = mouseEvents.exists {
     case _: MouseEvent.Click => true
     case _                   => false

--- a/indigo/indigo/src/main/scala/indigo/shared/input/Mouse.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/input/Mouse.scala
@@ -2,6 +2,7 @@ package indigo.shared.input
 
 import indigo.shared.datatypes.Point
 import indigo.shared.datatypes.Rectangle
+import indigo.shared.events.MouseButton
 import indigo.shared.events.MouseEvent
 
 import scala.annotation.tailrec
@@ -95,10 +96,10 @@ object Mouse {
       case Nil =>
         isDown
 
-      case MouseEvent.MouseDown(_) :: xs =>
+      case MouseEvent.MouseDown(_, MouseButton.LeftMouseButton) :: xs =>
         isLeftMouseDown(true, xs)
 
-      case MouseEvent.MouseUp(_) :: xs =>
+      case MouseEvent.MouseUp(_, MouseButton.LeftMouseButton) :: xs =>
         isLeftMouseDown(false, xs)
 
       case _ :: xs =>

--- a/indigo/indigo/src/main/scala/indigo/shared/input/Mouse.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/input/Mouse.scala
@@ -11,25 +11,35 @@ final class Mouse(mouseEvents: List[MouseEvent], val position: Point, val leftMo
 
   lazy val mousePressed: Boolean =
     mouseEvents.exists {
-      case _: MouseEvent.MouseDown => true
-      case _                       => false
+      case MouseEvent.MouseDown(_, MouseButton.LeftMouseButton) => true
+      case _                                                    => false
     }
 
   lazy val mouseReleased: Boolean =
     mouseEvents.exists {
-      case _: MouseEvent.MouseUp => true
-      case _                     => false
+      case MouseEvent.MouseUp(_, MouseButton.LeftMouseButton) => true
+      case _                                                  => false
     }
 
   lazy val mouseClicked: Boolean =
     mouseEvents.exists {
-      case _: MouseEvent.Click => true
-      case _                   => false
+      case MouseEvent.Click(_, MouseButton.LeftMouseButton) => true
+      case _                                                => false
     }
 
-  lazy val mouseClickAt: Option[Point] = mouseEvents.collectFirst { case m: MouseEvent.Click     => m.position }
-  lazy val mouseUpAt: Option[Point]    = mouseEvents.collectFirst { case m: MouseEvent.MouseUp   => m.position }
-  lazy val mouseDownAt: Option[Point]  = mouseEvents.collectFirst { case m: MouseEvent.MouseDown => m.position }
+  def mouseButtonClickedAt(mouseButton: MouseButton): Option[Point] = mouseEvents.collectFirst {
+    case m: MouseEvent.Click if m.button == mouseButton => m.position
+  }
+  def mouseButtonUpAt(mouseButton: MouseButton): Option[Point] = mouseEvents.collectFirst {
+    case m: MouseEvent.MouseUp if m.button == mouseButton => m.position
+  }
+  def mouseButtonDownAt(mouseButton: MouseButton): Option[Point] = mouseEvents.collectFirst {
+    case m: MouseEvent.MouseDown if m.button == mouseButton => m.position
+  }
+
+  lazy val mouseClickAt: Option[Point] = mouseButtonClickedAt(MouseButton.LeftMouseButton)
+  lazy val mouseUpAt: Option[Point]    = mouseButtonUpAt(MouseButton.LeftMouseButton)
+  lazy val mouseDownAt: Option[Point]  = mouseButtonDownAt(MouseButton.LeftMouseButton)
 
   private def wasMouseAt(position: Point, maybePosition: Option[Point]): Boolean =
     maybePosition match {
@@ -49,7 +59,7 @@ final class Mouse(mouseEvents: List[MouseEvent], val position: Point, val leftMo
   def wasMousePositionAt(target: Point): Boolean  = target == position
   def wasMousePositionAt(x: Int, y: Int): Boolean = wasMousePositionAt(Point(x, y))
 
-  //Within
+  // Within
   private def wasMouseWithin(bounds: Rectangle, maybePosition: Option[Point]): Boolean =
     maybePosition match {
       case Some(pt) => bounds.isPointWithin(pt)
@@ -60,11 +70,15 @@ final class Mouse(mouseEvents: List[MouseEvent], val position: Point, val leftMo
   def wasMouseClickedWithin(x: Int, y: Int, width: Int, height: Int): Boolean =
     wasMouseClickedWithin(Rectangle(x, y, width, height))
 
-  def wasMouseUpWithin(bounds: Rectangle): Boolean                       = wasMouseWithin(bounds, mouseUpAt)
-  def wasMouseUpWithin(x: Int, y: Int, width: Int, height: Int): Boolean = wasMouseUpWithin(Rectangle(x, y, width, height))
+  def wasMouseUpWithin(bounds: Rectangle): Boolean = wasMouseWithin(bounds, mouseUpAt)
+  def wasMouseUpWithin(x: Int, y: Int, width: Int, height: Int): Boolean = wasMouseUpWithin(
+    Rectangle(x, y, width, height)
+  )
 
-  def wasMouseDownWithin(bounds: Rectangle): Boolean                       = wasMouseWithin(bounds, mouseDownAt)
-  def wasMouseDownWithin(x: Int, y: Int, width: Int, height: Int): Boolean = wasMouseDownWithin(Rectangle(x, y, width, height))
+  def wasMouseDownWithin(bounds: Rectangle): Boolean = wasMouseWithin(bounds, mouseDownAt)
+  def wasMouseDownWithin(x: Int, y: Int, width: Int, height: Int): Boolean = wasMouseDownWithin(
+    Rectangle(x, y, width, height)
+  )
 
   def wasMousePositionWithin(bounds: Rectangle): Boolean = bounds.isPointWithin(position)
   def wasMousePositionWithin(x: Int, y: Int, width: Int, height: Int): Boolean =

--- a/indigo/indigo/src/main/scala/indigo/shared/input/Mouse.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/input/Mouse.scala
@@ -13,16 +13,16 @@ final class Mouse(mouseEvents: List[MouseEvent], val position: Point, val leftMo
     case _: MouseEvent.Click => true
     case _                   => false
   }
-  lazy val mousePressed  = mouseButtonPressed(MouseButton.LeftMouseButton)
-  lazy val mouseReleased = mouseButtonReleased(MouseButton.LeftMouseButton)
+  lazy val mousePressed  = pressed(MouseButton.LeftMouseButton)
+  lazy val mouseReleased = released(MouseButton.LeftMouseButton)
 
-  def mouseButtonPressed(button: MouseButton): Boolean =
+  def pressed(button: MouseButton): Boolean =
     mouseEvents.exists {
       case md: MouseEvent.MouseDown if md.button == button => true
       case _                                               => false
     }
 
-  def mouseButtonReleased(button: MouseButton): Boolean =
+  def released(button: MouseButton): Boolean =
     mouseEvents.exists {
       case mu: MouseEvent.MouseUp if mu.button == button => true
       case _                                             => false
@@ -31,14 +31,14 @@ final class Mouse(mouseEvents: List[MouseEvent], val position: Point, val leftMo
   lazy val mouseClickAt: Option[Point] = mouseEvents.collectFirst { case m: MouseEvent.Click =>
     m.position
   }
-  lazy val mouseUpAt: Option[Point]   = mouseButtonUpAt(MouseButton.LeftMouseButton)
-  lazy val mouseDownAt: Option[Point] = mouseButtonDownAt(MouseButton.LeftMouseButton)
+  lazy val mouseUpAt: Option[Point]   = maybeUpAtPositionWith(MouseButton.LeftMouseButton)
+  lazy val mouseDownAt: Option[Point] = maybeDownAtPositionWith(MouseButton.LeftMouseButton)
 
-  def mouseButtonUpAt(mouseButton: MouseButton): Option[Point] = mouseEvents.collectFirst {
-    case m: MouseEvent.MouseUp if m.button == mouseButton => m.position
+  def maybeUpAtPositionWith(button: MouseButton): Option[Point] = mouseEvents.collectFirst {
+    case m: MouseEvent.MouseUp if m.button == button => m.position
   }
-  def mouseButtonDownAt(mouseButton: MouseButton): Option[Point] = mouseEvents.collectFirst {
-    case m: MouseEvent.MouseDown if m.button == mouseButton => m.position
+  def maybeDownAtPositionWith(button: MouseButton): Option[Point] = mouseEvents.collectFirst {
+    case m: MouseEvent.MouseDown if m.button == button => m.position
   }
 
   private def wasMouseAt(position: Point, maybePosition: Option[Point]): Boolean =
@@ -51,17 +51,17 @@ final class Mouse(mouseEvents: List[MouseEvent], val position: Point, val leftMo
 
   def wasMouseUpAt(position: Point): Boolean = wasMouseAt(position, mouseUpAt)
   def wasMouseUpAt(x: Int, y: Int): Boolean  = wasMouseUpAt(Point(x, y))
-  def wasMouseButtonUpAt(position: Point, button: MouseButton): Boolean =
-    wasMouseAt(position, mouseButtonUpAt(button))
-  def wasMouseButtonUpAt(x: Int, y: Int, button: MouseButton): Boolean =
-    wasMouseButtonUpAt(Point(x, y), button)
+  def wasUpAt(position: Point, button: MouseButton): Boolean =
+    wasMouseAt(position, maybeUpAtPositionWith(button))
+  def wasUpAt(x: Int, y: Int, button: MouseButton): Boolean =
+    wasUpAt(Point(x, y), button)
 
   def wasMouseDownAt(position: Point): Boolean = wasMouseAt(position, mouseDownAt)
   def wasMouseDownAt(x: Int, y: Int): Boolean  = wasMouseDownAt(Point(x, y))
-  def wasMouseButtonDownAt(position: Point, button: MouseButton): Boolean =
-    wasMouseAt(position, mouseButtonDownAt(button))
-  def wasMouseButtonDownAt(x: Int, y: Int, button: MouseButton): Boolean =
-    wasMouseButtonDownAt(Point(x, y), button)
+  def wasDownAt(position: Point, button: MouseButton): Boolean =
+    wasMouseAt(position, maybeDownAtPositionWith(button))
+  def wasDownAt(x: Int, y: Int, button: MouseButton): Boolean =
+    wasDownAt(Point(x, y), button)
 
   def wasMousePositionAt(target: Point): Boolean  = target == position
   def wasMousePositionAt(x: Int, y: Int): Boolean = wasMousePositionAt(Point(x, y))
@@ -81,19 +81,19 @@ final class Mouse(mouseEvents: List[MouseEvent], val position: Point, val leftMo
   def wasMouseUpWithin(x: Int, y: Int, width: Int, height: Int): Boolean = wasMouseUpWithin(
     Rectangle(x, y, width, height)
   )
-  def wasMouseButtonUpWithin(bounds: Rectangle, button: MouseButton): Boolean =
-    wasMouseWithin(bounds, mouseButtonUpAt(button))
-  def wasMouseButtonUpWithin(x: Int, y: Int, width: Int, height: Int, button: MouseButton): Boolean =
-    wasMouseButtonUpWithin(Rectangle(x, y, width, height), button)
+  def wasUpWithin(bounds: Rectangle, button: MouseButton): Boolean =
+    wasMouseWithin(bounds, maybeUpAtPositionWith(button))
+  def wasUpWithin(x: Int, y: Int, width: Int, height: Int, button: MouseButton): Boolean =
+    wasUpWithin(Rectangle(x, y, width, height), button)
 
   def wasMouseDownWithin(bounds: Rectangle): Boolean = wasMouseWithin(bounds, mouseDownAt)
   def wasMouseDownWithin(x: Int, y: Int, width: Int, height: Int): Boolean = wasMouseDownWithin(
     Rectangle(x, y, width, height)
   )
-  def wasMouseButtonDownWithin(bounds: Rectangle, button: MouseButton): Boolean =
-    wasMouseWithin(bounds, mouseButtonDownAt(button))
-  def wasMouseButtonDownWithin(x: Int, y: Int, width: Int, height: Int, button: MouseButton): Boolean =
-    wasMouseButtonDownWithin(Rectangle(x, y, width, height), button)
+  def wasDownWithin(bounds: Rectangle, button: MouseButton): Boolean =
+    wasMouseWithin(bounds, maybeDownAtPositionWith(button))
+  def wasDownWithin(x: Int, y: Int, width: Int, height: Int, button: MouseButton): Boolean =
+    wasDownWithin(Rectangle(x, y, width, height), button)
 
   def wasMousePositionWithin(bounds: Rectangle): Boolean = bounds.isPointWithin(position)
   def wasMousePositionWithin(x: Int, y: Int, width: Int, height: Int): Boolean =

--- a/indigo/indigo/src/main/scala/indigo/shared/input/Mouse.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/input/Mouse.scala
@@ -18,14 +18,14 @@ final class Mouse(mouseEvents: List[MouseEvent], val position: Point, val leftMo
 
   def mouseButtonPressed(button: MouseButton): Boolean =
     mouseEvents.exists {
-      case MouseEvent.MouseDown(_, mouseButton) => true
-      case _                                    => false
+      case md: MouseEvent.MouseDown if md.button == button => true
+      case _                                               => false
     }
 
   def mouseButtonReleased(button: MouseButton): Boolean =
     mouseEvents.exists {
-      case MouseEvent.MouseUp(_, button) => true
-      case _                             => false
+      case mu: MouseEvent.MouseUp if mu.button == button => true
+      case _                                             => false
     }
 
   lazy val mouseClickAt: Option[Point] = mouseEvents.collectFirst { case m: MouseEvent.Click =>

--- a/indigo/indigo/src/test/scala/indigo/shared/events/InputStateTests.scala
+++ b/indigo/indigo/src/test/scala/indigo/shared/events/InputStateTests.scala
@@ -9,6 +9,9 @@ import indigo.shared.input.GamepadAnalogControls
 import indigo.shared.input.GamepadButtons
 import indigo.shared.input.GamepadDPad
 
+import scala.annotation.nowarn
+
+@nowarn("msg=value leftMouseIsDown in class Mouse is deprecated")
 class InputStateTests extends munit.FunSuite {
 
   val bounds: Rectangle =
@@ -52,25 +55,37 @@ class InputStateTests extends munit.FunSuite {
   test("Mouse state.mouseClicked") {
     assertEquals(state.mouse.mouseClicked, true)
 
-    assertEquals(InputState.calculateNext(inputState, List(MouseEvent.MouseDown(0, 0)), gamepadState1).mouse.mouseClicked, false)
+    assertEquals(
+      InputState.calculateNext(inputState, List(MouseEvent.MouseDown(0, 0)), gamepadState1).mouse.mouseClicked,
+      false
+    )
   }
 
   test("Mouse state.mouseClickAt") {
     assertEquals(state.mouse.mouseClickAt, Some(Point(10, 10)))
 
-    assertEquals(InputState.calculateNext(inputState, List(MouseEvent.MouseDown(0, 0)), gamepadState1).mouse.mouseClickAt, None)
+    assertEquals(
+      InputState.calculateNext(inputState, List(MouseEvent.MouseDown(0, 0)), gamepadState1).mouse.mouseClickAt,
+      None
+    )
   }
 
   test("Mouse state.mouseUpAt") {
     assertEquals(state.mouse.mouseUpAt, Some(Point(10, 10)))
 
-    assertEquals(InputState.calculateNext(inputState, List(MouseEvent.MouseDown(0, 0)), gamepadState1).mouse.mouseUpAt, None)
+    assertEquals(
+      InputState.calculateNext(inputState, List(MouseEvent.MouseDown(0, 0)), gamepadState1).mouse.mouseUpAt,
+      None
+    )
   }
 
   test("Mouse state.mouseDownAt") {
     assertEquals(state.mouse.mouseDownAt, Some(Point(10, 10)))
 
-    assertEquals(InputState.calculateNext(inputState, List(MouseEvent.MouseUp(0, 0)), gamepadState1).mouse.mouseDownAt, None)
+    assertEquals(
+      InputState.calculateNext(inputState, List(MouseEvent.MouseUp(0, 0)), gamepadState1).mouse.mouseDownAt,
+      None
+    )
   }
 
   test("Mouse state.wasMouseClickedAt") {
@@ -119,12 +134,20 @@ class InputStateTests extends munit.FunSuite {
 
   test("Mouse state.leftMouseIsDown") {
 
-    val state2 = InputState.calculateNext(state, List(MouseEvent.MouseDown(0, 0)), gamepadState1)                                // true
-    val state3 = InputState.calculateNext(state2, Nil, gamepadState1)                                                            // still true
-    val state4 = InputState.calculateNext(state3, List(MouseEvent.MouseDown(20, 20)), gamepadState1)                             // still true
-    val state5 = InputState.calculateNext(state4, List(MouseEvent.MouseUp(20, 20), MouseEvent.MouseDown(20, 20)), gamepadState1) // Still true
-    val state6 = InputState.calculateNext(state5, List(MouseEvent.MouseUp(20, 20)), gamepadState1)                               // false
-    val state7 = InputState.calculateNext(state6, List(MouseEvent.MouseDown(20, 20), MouseEvent.MouseUp(20, 20)), gamepadState1) // Still false
+    val state2 = InputState.calculateNext(state, List(MouseEvent.MouseDown(0, 0)), gamepadState1)     // true
+    val state3 = InputState.calculateNext(state2, Nil, gamepadState1)                                 // still true
+    val state4 = InputState.calculateNext(state3, List(MouseEvent.MouseDown(20, 20)), gamepadState1)  // still true
+    val state5 = InputState.calculateNext(                                                            // Still true
+      state4,
+      List(MouseEvent.MouseUp(20, 20), MouseEvent.MouseDown(20, 20)),
+      gamepadState1
+    )                                                                                               
+    val state6 = InputState.calculateNext(state5, List(MouseEvent.MouseUp(20, 20)), gamepadState1)    // false
+    val state7 = InputState.calculateNext(                                                            // Still false
+      state6,
+      List(MouseEvent.MouseDown(20, 20), MouseEvent.MouseUp(20, 20)),
+      gamepadState1
+    )
 
     assertEquals(state.mouse.leftMouseIsDown, false)
     assertEquals(state2.mouse.leftMouseIsDown, true)
@@ -133,6 +156,39 @@ class InputStateTests extends munit.FunSuite {
     assertEquals(state5.mouse.leftMouseIsDown, true)
     assertEquals(state6.mouse.leftMouseIsDown, false)
     assertEquals(state7.mouse.leftMouseIsDown, false)
+  }
+
+  test("Mouse state.rigthMouseIsDown") {
+    import MouseButton._
+
+    val state2 =
+      InputState.calculateNext(state, List(MouseEvent.MouseDown(0, 0, RightMouseButton)), gamepadState1)  // true
+    val state3 = InputState.calculateNext(state2, Nil, gamepadState1)                                     // still true
+    val state4 = InputState.calculateNext(                                                                // still true
+      state3,
+      List(MouseEvent.MouseDown(20, 20, RightMouseButton)),
+      gamepadState1
+    )
+    val state5 = InputState.calculateNext(                                                                // Still true
+      state4,
+      List(MouseEvent.MouseUp(20, 20, RightMouseButton), MouseEvent.MouseDown(20, 20, RightMouseButton)),
+      gamepadState1
+    )
+    val state6 =                                                                                          // false
+      InputState.calculateNext(state5, List(MouseEvent.MouseUp(20, 20, RightMouseButton)), gamepadState1)
+    val state7 = InputState.calculateNext(                                                                // Still false
+      state6,
+      List(MouseEvent.MouseDown(20, 20, RightMouseButton), MouseEvent.MouseUp(20, 20, RightMouseButton)),
+      gamepadState1
+    )
+
+    assertEquals(state.mouse.isButtonDown(RightMouseButton), false)
+    assertEquals(state2.mouse.isButtonDown(RightMouseButton), true)
+    assertEquals(state3.mouse.isButtonDown(RightMouseButton), true)
+    assertEquals(state4.mouse.isButtonDown(RightMouseButton), true)
+    assertEquals(state5.mouse.isButtonDown(RightMouseButton), true)
+    assertEquals(state6.mouse.isButtonDown(RightMouseButton), false)
+    assertEquals(state7.mouse.isButtonDown(RightMouseButton), false)
   }
 
   val events2: List[KeyboardEvent] =
@@ -409,7 +465,11 @@ class InputStateTests extends munit.FunSuite {
 
     val mappingResult2 =
       InputState
-        .calculateNext(inputState, List(KeyboardEvent.KeyDown(Key.UP_ARROW), KeyboardEvent.KeyDown(Key.RIGHT_ARROW)), gamepadState2)
+        .calculateNext(
+          inputState,
+          List(KeyboardEvent.KeyDown(Key.UP_ARROW), KeyboardEvent.KeyDown(Key.RIGHT_ARROW)),
+          gamepadState2
+        )
         .mapInputs(mappings, "Combo not met! (2)")
 
     val mappingResult3 =

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/SandboxView.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/SandboxView.scala
@@ -96,7 +96,7 @@ object SandboxView {
       Text("AB!\n!C", 2, 2, 5, Fonts.fontKey, SandboxAssets.fontMaterial.withAlpha(0.5)).alignLeft,
       Text("AB!\n!C", 100, 2, 5, Fonts.fontKey, SandboxAssets.fontMaterial.withAlpha(0.5)).alignCenter,
       Text("AB!\n!C", 200, 2, 5, Fonts.fontKey, SandboxAssets.fontMaterial.withAlpha(0.5)).alignRight.onEvent {
-        case (bounds, MouseEvent.Click(_)) =>
+        case (bounds, _: MouseEvent.Click) =>
           if (inputState.mouse.wasMouseClickedWithin(bounds))
             println("Hit me!")
           Nil


### PR DESCRIPTION
My initial idea was to only add support for the right mouse button, but it looks like it can be generic enough to support more than only left and right buttons.

This PR is still in progress, as I need to add tests, refactor the `Mouse` class, as it's now too much left-button-biased, and probably bake in any other ideas from the review feedback.