### PR TITLE
Remove Model/View update skipping

### DIFF
--- a/indigo/indigo/src/main/scala/indigo/gameengine/FrameProcessor.scala
+++ b/indigo/indigo/src/main/scala/indigo/gameengine/FrameProcessor.scala
@@ -8,7 +8,7 @@ import indigo.shared.events.InputState
 import indigo.shared.scenegraph.SceneUpdateFragment
 import indigo.shared.time.GameTime
 
-trait FrameProcessor[StartUpData, Model, ViewModel] {
+trait FrameProcessor[StartUpData, Model, ViewModel]:
   def run(
       startUpData: => StartUpData,
       model: => Model,
@@ -19,15 +19,3 @@ trait FrameProcessor[StartUpData, Model, ViewModel] {
       dice: Dice,
       boundaryLocator: BoundaryLocator
   ): Outcome[(Model, ViewModel, SceneUpdateFragment)]
-
-  def runSkipView(
-      startUpData: => StartUpData,
-      model: => Model,
-      viewModel: => ViewModel,
-      gameTime: GameTime,
-      globalEvents: List[GlobalEvent],
-      inputState: InputState,
-      dice: Dice,
-      boundaryLocator: BoundaryLocator
-  ): Outcome[(Model, ViewModel)]
-}

--- a/indigo/indigo/src/main/scala/indigo/shared/config/AdvancedGameConfig.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/config/AdvancedGameConfig.scala
@@ -22,8 +22,6 @@ final case class AdvancedGameConfig(
     antiAliasing: Boolean,
     batchSize: Int,
     premultipliedAlpha: Boolean,
-    disableSkipModelUpdates: Boolean,
-    disableSkipViewUpdates: Boolean,
     autoLoadStandardShaders: Boolean
 ) derives CanEqual {
 
@@ -53,12 +51,6 @@ final case class AdvancedGameConfig(
   def withBatchSize(size: Int): AdvancedGameConfig =
     this.copy(batchSize = size)
 
-  def withSkipModelUpdates(skip: Boolean): AdvancedGameConfig =
-    this.copy(disableSkipModelUpdates = skip)
-
-  def withSkipViewUpdates(skip: Boolean): AdvancedGameConfig =
-    this.copy(disableSkipViewUpdates = skip)
-
   def withAutoLoadStandardShaders(autoLoad: Boolean): AdvancedGameConfig =
     this.copy(autoLoadStandardShaders = autoLoad)
 
@@ -68,8 +60,6 @@ final case class AdvancedGameConfig(
        |- Rendering technology:        ${renderingTechnology.name}
        |- AntiAliasing enabled:        ${antiAliasing.toString()}
        |- Render batch size:           ${batchSize.toString()}
-       |- Disabled skip model updates: ${disableSkipModelUpdates.toString()}
-       |- Disabled skip view updates:  ${disableSkipViewUpdates.toString()}
        |""".stripMargin
 }
 
@@ -80,8 +70,6 @@ object AdvancedGameConfig {
       antiAliasing = false,
       premultipliedAlpha = true,
       batchSize = 256,
-      disableSkipModelUpdates = false,
-      disableSkipViewUpdates = false,
       autoLoadStandardShaders = true
     )
 }

--- a/indigo/indigo/src/main/scala/indigo/shared/config/GameConfig.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/config/GameConfig.scala
@@ -29,8 +29,6 @@ final case class GameConfig(
     advanced: AdvancedGameConfig
 ) derives CanEqual:
   val frameRateDeltaMillis: Int = 1000 / frameRate.toInt
-  val haltViewUpdatesAt: Int    = frameRateDeltaMillis * 2
-  val haltModelUpdatesAt: Int   = frameRateDeltaMillis * 3
 
   def screenDimensions: Rectangle =
     viewport.giveDimensions(magnification)
@@ -40,8 +38,7 @@ final case class GameConfig(
        |Standard settings
        |- Viewpoint:      [${viewport.width.toString()}, ${viewport.height.toString()}]
        |- FPS:            ${frameRate.toString()}
-       |- frameRateDelta: ${frameRateDeltaMillis.toString()} (view updates stop at: ${haltViewUpdatesAt
-      .toString()}, model at: ${haltModelUpdatesAt.toString()}
+       |- frameRateDelta: ${frameRateDeltaMillis.toString()}
        |- Clear color:    {red: ${clearColor.r.toString()}, green: ${clearColor.g.toString()}, blue: ${clearColor.b
       .toString()}, alpha: ${clearColor.a.toString()}}
        |- Magnification:  ${magnification.toString()}

--- a/indigo/perf/src/main/scala/com/example/perf/PerfGame.scala
+++ b/indigo/perf/src/main/scala/com/example/perf/PerfGame.scala
@@ -47,8 +47,6 @@ object PerfGame extends IndigoDemo[Unit, Dude, DudeModel, Unit] {
               antiAliasing = false,
               premultipliedAlpha = true,
               batchSize = 512,
-              disableSkipModelUpdates = true,
-              disableSkipViewUpdates = true,
               autoLoadStandardShaders = false
             )
           )


### PR DESCRIPTION
~~**Needs further testing.**~~ (done)

I've been considering removing the option to disable update and view skipping for a while, largely because it seems unnecessary.

Removing it does mean that Indigo makes no attempt to smooth out the frames, and leaves it to the browser to decide when to drop frames ...but the browser does that anyway.

This code was also masking a nasty bug.

Say your game is running at 60 fps, this means you have 16.7ms to do everything. Prior to this PR, if Indigo notices the time delta between the last frame and this one was greater than (16.7 * 2), then it would skip this update - but not before draining the event queue, resulting in skipped events. This was really only noticeable on games with really regular/long frame updates, typically exacerbated by the browser dropping frames at the same time. This all combined made it noticeable that events were being lost somewhere, but the circumstances were very hard to nail down.

Part of the reason this bug has crept in is because the skipping mechanism has been in place since the beginning of time, but game loop process changed a lot when the notion of frame processors arrived.

This PR removes the ability to skip updates, simplifies the code, and removes the need for the frame processor to have any notion of running without rendering.

