### PR TITLE
Fixed #128: Add standard modifiers to UI elements

### DIFF
--- a/indigo/indigo-extras/src/main/scala/indigoextras/ui/Button.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/ui/Button.scala
@@ -4,6 +4,7 @@ import indigo.shared.Outcome
 import indigo.shared.datatypes.Depth
 import indigo.shared.datatypes.Point
 import indigo.shared.datatypes.Rectangle
+import indigo.shared.datatypes.Size
 import indigo.shared.events.GlobalEvent
 import indigo.shared.input.Mouse
 import indigo.shared.scenegraph.EntityNode
@@ -28,8 +29,29 @@ final case class Button(
     onHoverOver: () => List[GlobalEvent],
     onHoverOut: () => List[GlobalEvent],
     onClick: () => List[GlobalEvent],
-    onHoldDown: () => List[GlobalEvent],
-) derives CanEqual {
+    onHoldDown: () => List[GlobalEvent]
+) derives CanEqual:
+
+  def moveBy(point: Point): Button =
+    this.copy(bounds = bounds.moveBy(point))
+  def moveBy(x: Int, y: Int): Button =
+    moveBy(Point(x, y))
+
+  def moveTo(point: Point): Button =
+    this.copy(bounds = bounds.moveTo(point))
+  def moveTo(x: Int, y: Int): Button =
+    moveTo(Point(x, y))
+
+  def resize(newSize: Size): Button =
+    this.copy(bounds = bounds.resize(newSize))
+  def resize(x: Int, y: Int): Button =
+    resize(Size(x, y))
+
+  def withBounds(newBounds: Rectangle): Button =
+    this.copy(bounds = newBounds)
+
+  def withDepth(newDepth: Depth): Button =
+    this.copy(depth = newDepth)
 
   def update(mouse: Mouse): Outcome[Button] = {
     val mouseInBounds = bounds.isPointWithin(mouse.position)
@@ -140,9 +162,14 @@ final case class Button(
 
   def toDownState: Button =
     this.copy(state = ButtonState.Down)
-}
 
-object Button {
+  def withButtonState(newState: ButtonState): Button =
+    this.copy(state = newState)
+
+  def withButtonAssets(newButtonAssets: ButtonAssets): Button =
+    this.copy(buttonAssets = newButtonAssets)
+
+object Button:
 
   def apply(buttonAssets: ButtonAssets, bounds: Rectangle, depth: Depth): Button =
     Button(
@@ -155,10 +182,8 @@ object Button {
       onHoverOver = () => Nil,
       onHoverOut = () => Nil,
       onClick = () => Nil,
-      onHoldDown = () => Nil,
+      onHoldDown = () => Nil
     )
-
-}
 
 sealed trait ButtonState derives CanEqual {
   def isUp: Boolean

--- a/indigo/indigo-extras/src/main/scala/indigoextras/ui/HitArea.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/ui/HitArea.scala
@@ -20,7 +20,7 @@ final case class HitArea(
     onHoverOut: () => List[GlobalEvent],
     onClick: () => List[GlobalEvent],
     onHoldDown: () => List[GlobalEvent],
-) derives CanEqual {
+) derives CanEqual:
 
   def update(mouse: Mouse): Outcome[HitArea] = {
     val mouseInBounds = area.contains(Vertex.fromPoint(mouse.position))
@@ -108,8 +108,6 @@ final case class HitArea(
     moveBy(Point(x, y))
   def moveBy(positionDiff: Point): HitArea =
     this.copy(area = area.moveBy(Vertex.fromPoint(positionDiff)))
-
-}
 
 object HitArea:
 

--- a/indigo/indigo-extras/src/main/scala/indigoextras/ui/InputField.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/ui/InputField.scala
@@ -31,7 +31,7 @@ final case class InputField(
     key: Option[BindingKey],
     onFocus: () => List[GlobalEvent],
     onLoseFocus: () => List[GlobalEvent]
-) derives CanEqual {
+) derives CanEqual:
 
   def bounds(boundaryLocator: BoundaryLocator): Option[Rectangle] =
     assets.text.withText(text).moveTo(position).calculatedBounds(boundaryLocator)
@@ -286,9 +286,7 @@ final case class InputField(
     } else List(field)
   }
 
-}
-
-object InputField {
+object InputField:
 
   def apply(text: String, assets: InputFieldAssets): InputField =
     InputField(
@@ -324,13 +322,10 @@ object InputField {
       () => Nil
     )
 
-}
-
-final case class InputFieldAssets(text: Text[_], cursor: Graphic[_]) derives CanEqual {
+final case class InputFieldAssets(text: Text[_], cursor: Graphic[_]) derives CanEqual:
   def withText(newText: Text[_]): InputFieldAssets =
     this.copy(text = newText)
   def withCursor(newCursor: Graphic[_]): InputFieldAssets =
     this.copy(cursor = newCursor)
-}
 
 final case class InputFieldChange(key: BindingKey, updatedText: String) extends GlobalEvent derives CanEqual

--- a/indigo/indigo-extras/src/main/scala/indigoextras/ui/RadioButtonGroup.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/ui/RadioButtonGroup.scala
@@ -44,7 +44,17 @@ final case class RadioButton(
     hitArea: Option[Rectangle],
     buttonAssets: Option[ButtonAssets],
     state: RadioButtonState
-) derives CanEqual {
+) derives CanEqual:
+
+  def moveBy(point: Point): RadioButton =
+    this.copy(position = position + point)
+  def moveBy(x: Int, y: Int): RadioButton =
+    moveBy(Point(x, y))
+
+  def moveTo(point: Point): RadioButton =
+    this.copy(position = point)
+  def moveTo(x: Int, y: Int): RadioButton =
+    moveTo(Point(x, y))
 
   /** Events to fire when selected.
     *
@@ -191,9 +201,8 @@ final case class RadioButton(
     */
   def inHoverState: Boolean =
     state.inHoverState
-}
 
-object RadioButton {
+object RadioButton:
 
   /** Build a individual radio button by specifying it's position.
     *
@@ -202,7 +211,6 @@ object RadioButton {
     */
   def apply(position: Point): RadioButton =
     RadioButton(position, () => Nil, () => Nil, () => Nil, () => Nil, None, None, RadioButtonState.Normal)
-}
 
 /** A group of mutually exclusive radio buttons.
   *
@@ -221,7 +229,7 @@ final case class RadioButtonGroup(
     hitArea: Rectangle,
     depth: Depth,
     options: List[RadioButton]
-) derives CanEqual {
+) derives CanEqual:
 
   /** Specify a new hit area for the radio buttons
     *
@@ -404,9 +412,8 @@ final case class RadioButtonGroup(
         }
       }
     )
-}
 
-object RadioButtonGroup {
+object RadioButtonGroup:
 
   /** Construct a bare bones radio button group, with no buttons in it.
     *
@@ -441,9 +448,7 @@ object RadioButtonGroup {
   ): RadioButtonGroup =
     RadioButtonGroup(buttonAssets, hitArea, Depth.zero, Nil)
 
-}
-
-sealed trait RadioButtonState derives CanEqual {
+sealed trait RadioButtonState derives CanEqual:
   def toButtonState: ButtonState =
     this match {
       case RadioButtonState.Selected => ButtonState.Down
@@ -453,18 +458,16 @@ sealed trait RadioButtonState derives CanEqual {
 
   def inSelectedState: Boolean
   def inHoverState: Boolean
-}
-object RadioButtonState {
-  case object Selected extends RadioButtonState {
+
+object RadioButtonState:
+  case object Selected extends RadioButtonState:
     val inSelectedState: Boolean = true
     val inHoverState: Boolean    = false
-  }
-  case object Hover extends RadioButtonState {
+
+  case object Hover extends RadioButtonState:
     val inSelectedState: Boolean = false
     val inHoverState: Boolean    = true
-  }
-  case object Normal extends RadioButtonState {
+
+  case object Normal extends RadioButtonState:
     val inSelectedState: Boolean = false
     val inHoverState: Boolean    = false
-  }
-}


### PR DESCRIPTION
I've added some of the standard modifiers you find in Indigo. The button move is a bit deceptive though, you have to move the button in the model where it's stored. If you move it just before it's rendered, then the hit area doesn't move with it. Still it's an improvement.