### PR TITLE
More accurate mouse positions

### DIFF
--- a/indigo/indigo/src/main/scala/indigo/platform/events/WorldEvents.scala
+++ b/indigo/indigo/src/main/scala/indigo/platform/events/WorldEvents.scala
@@ -35,10 +35,12 @@ object WorldEvents {
   def init(canvas: html.Canvas, magnification: Int, globalEventStream: GlobalEventStream): Unit = {
     // Onclick only supports the left mouse button
     canvas.onclick = { (e: dom.MouseEvent) =>
+      val rect = canvas.getBoundingClientRect()
+
       globalEventStream.pushGlobalEvent(
         MouseEvent.Click(
-          absoluteCoordsX(e.clientX) / magnification,
-          absoluteCoordsY(e.clientY) / magnification
+          (absoluteCoordsX(e.clientX) - rect.left.toInt) / magnification,
+          (absoluteCoordsY(e.clientY) - rect.top.toInt) / magnification
         )
       )
     }
@@ -48,7 +50,7 @@ object WorldEvents {
       To be fair, the wheel event doesn't necessarily means that the device is a mouse, or even that the
       deltaY represents the direction of the vertical scrolling (usually negative is upwards and positive downwards).
       For the sake of simplicity, we're assuming a common mouse with a simple wheel.
-     
+
       More info: https://developer.mozilla.org/en-US/docs/Web/API/WheelEvent
      */
     canvas.onwheel = { (e: dom.WheelEvent) =>
@@ -64,20 +66,24 @@ object WorldEvents {
     }
 
     canvas.onmousemove = { (e: dom.MouseEvent) =>
+      val rect = canvas.getBoundingClientRect()
+
       globalEventStream.pushGlobalEvent(
         MouseEvent.Move(
-          absoluteCoordsX(e.clientX) / magnification,
-          absoluteCoordsY(e.clientY) / magnification
+          (absoluteCoordsX(e.clientX) - rect.left.toInt) / magnification,
+          (absoluteCoordsY(e.clientY) - rect.top.toInt) / magnification
         )
       )
     }
 
     canvas.onmousedown = { (e: dom.MouseEvent) =>
+      val rect = canvas.getBoundingClientRect()
+
       MouseButton.fromOrdinalOpt(e.button).foreach { mouseButton =>
         globalEventStream.pushGlobalEvent(
           MouseEvent.MouseDown(
-            absoluteCoordsX(e.clientX) / magnification,
-            absoluteCoordsY(e.clientY) / magnification,
+            (absoluteCoordsX(e.clientX) - rect.left.toInt) / magnification,
+            (absoluteCoordsY(e.clientY) - rect.top.toInt) / magnification,
             mouseButton
           )
         )
@@ -85,11 +91,13 @@ object WorldEvents {
     }
 
     canvas.onmouseup = { (e: dom.MouseEvent) =>
+      val rect = canvas.getBoundingClientRect()
+
       MouseButton.fromOrdinalOpt(e.button).foreach { mouseButton =>
         globalEventStream.pushGlobalEvent(
           MouseEvent.MouseUp(
-            absoluteCoordsX(e.clientX) / magnification,
-            absoluteCoordsY(e.clientY) / magnification,
+            (absoluteCoordsX(e.clientX) - rect.left.toInt) / magnification,
+            (absoluteCoordsY(e.clientY) - rect.top.toInt) / magnification,
             mouseButton
           )
         )

--- a/indigo/indigo/src/main/scala/indigo/platform/events/WorldEvents.scala
+++ b/indigo/indigo/src/main/scala/indigo/platform/events/WorldEvents.scala
@@ -54,10 +54,11 @@ object WorldEvents {
       More info: https://developer.mozilla.org/en-US/docs/Web/API/WheelEvent
      */
     canvas.onwheel = { (e: dom.WheelEvent) =>
+      val rect = canvas.getBoundingClientRect()
       val wheel = MouseEvent.Wheel(
         Point(
-          absoluteCoordsX(e.clientX) / magnification,
-          absoluteCoordsY(e.clientY) / magnification
+          absoluteCoordsX(e.pageX.toInt - rect.left.toInt) / magnification,
+          absoluteCoordsY(e.pageY.toInt - rect.top.toInt) / magnification
         ),
         e.deltaY
       )

--- a/indigo/indigo/src/main/scala/indigo/platform/events/WorldEvents.scala
+++ b/indigo/indigo/src/main/scala/indigo/platform/events/WorldEvents.scala
@@ -19,7 +19,7 @@ object WorldEvents {
       else if (document.body.scrollLeft > 0) document.body.scrollLeft
       else 0
 
-    (relativeX + offset).toInt
+    (relativeX - offset).toInt
   }
 
   def absoluteCoordsY(relativeY: Double): Int = {
@@ -29,7 +29,7 @@ object WorldEvents {
       else if (document.body.scrollTop > 0) document.body.scrollTop
       else 0
 
-    (relativeY + offset).toInt
+    (relativeY - offset).toInt
   }
 
   def init(canvas: html.Canvas, magnification: Int, globalEventStream: GlobalEventStream): Unit = {
@@ -39,8 +39,8 @@ object WorldEvents {
 
       globalEventStream.pushGlobalEvent(
         MouseEvent.Click(
-          (absoluteCoordsX(e.clientX) - rect.left.toInt) / magnification,
-          (absoluteCoordsY(e.clientY) - rect.top.toInt) / magnification
+          absoluteCoordsX(e.pageX.toInt - rect.left.toInt) / magnification,
+          absoluteCoordsY(e.pageY.toInt - rect.top.toInt) / magnification
         )
       )
     }
@@ -70,8 +70,8 @@ object WorldEvents {
 
       globalEventStream.pushGlobalEvent(
         MouseEvent.Move(
-          (absoluteCoordsX(e.clientX) - rect.left.toInt) / magnification,
-          (absoluteCoordsY(e.clientY) - rect.top.toInt) / magnification
+          absoluteCoordsX(e.pageX.toInt - rect.left.toInt) / magnification,
+          absoluteCoordsY(e.pageY.toInt - rect.top.toInt) / magnification
         )
       )
     }
@@ -82,8 +82,8 @@ object WorldEvents {
       MouseButton.fromOrdinalOpt(e.button).foreach { mouseButton =>
         globalEventStream.pushGlobalEvent(
           MouseEvent.MouseDown(
-            (absoluteCoordsX(e.clientX) - rect.left.toInt) / magnification,
-            (absoluteCoordsY(e.clientY) - rect.top.toInt) / magnification,
+            absoluteCoordsX(e.pageX.toInt - rect.left.toInt) / magnification,
+            absoluteCoordsY(e.pageY.toInt - rect.top.toInt) / magnification,
             mouseButton
           )
         )
@@ -96,8 +96,8 @@ object WorldEvents {
       MouseButton.fromOrdinalOpt(e.button).foreach { mouseButton =>
         globalEventStream.pushGlobalEvent(
           MouseEvent.MouseUp(
-            (absoluteCoordsX(e.clientX) - rect.left.toInt) / magnification,
-            (absoluteCoordsY(e.clientY) - rect.top.toInt) / magnification,
+            absoluteCoordsX(e.pageX.toInt - rect.left.toInt) / magnification,
+            absoluteCoordsY(e.pageY.toInt - rect.top.toInt) / magnification,
             mouseButton
           )
         )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.6.1


### PR DESCRIPTION
The mouse position was relative to the page rather than relative to the canvas (see issue #316). This fixes that for unscaled and untransformed canvas elements such that the mouse position is now relative to the canvas in all mouse events.