### PR TITLE
Fix typos in docs

### DIFF
--- a/indigo/docs/guides/howto-custom-entity.md
+++ b/indigo/docs/guides/howto-custom-entity.md
@@ -96,7 +96,7 @@ Walking through it, `position` and `depth` have been moved to be case class argu
 
 Then things get a little more complicated. `toShaderData` has been implemented by creating a `ShaderData` instance that only takes a `ShaderId`, which it sources from the companion object.
 
-The companion object defines the shader that is going to color in our entity by declaring an `EntityShader` (as a pose to a `BlendShader`). `Shader` instances whether a `BlendShader` or an `EntityShader` come in two forms: `EnityShader.Source(..)` or `EnityShader.External(..)`. The difference is that `Source` instances literally take the GLSL program as a `String`, and `External` instances look for loaded assets, which is a much nicer editing experience.
+The companion object defines the shader that is going to color in our entity by declaring an `EntityShader` (as opposed to a `BlendShader`). `Shader` instances whether a `BlendShader` or an `EntityShader` come in two forms: `EnityShader.Source(..)` or `EnityShader.External(..)`. The difference is that `Source` instances literally take the GLSL program as a `String`, and `External` instances look for loaded assets, which is a much nicer editing experience.
 
 There are several parts to an Indigo shader program that can be set (or default implementations are used), but in this case we're only setting the fragment program as follows:
 

--- a/indigo/docs/presentation/materials.md
+++ b/indigo/docs/presentation/materials.md
@@ -117,7 +117,7 @@ To light a pixel on a surface we need to know it's [normal](https://en.wikipedia
 
 The normal is used to work out how much light from a light source makes it to the camera / eye and therefore allows us (as people) to interpret what angle the surface was at.
 
-Consider a sphere - which is a single surface. The angle of the normal of a sphere's surface rotates around depending on which point of the sphere you're looking at. This change in normal is what gives the appearance of a smooth spherical surface, as a pose to a flat circle.
+Consider a sphere - which is a single surface. The angle of the normal of a sphere's surface rotates around depending on which point of the sphere you're looking at. This change in normal is what gives the appearance of a smooth spherical surface, as opposed to a flat circle.
 
 Knowing that, we can take a completely flat image and _pretend_ it's bumpy or textured by _bending_ the real normal to a new angle at different co-ordinates on the texture.
 

--- a/indigo/docs/time/signals.md
+++ b/indigo/docs/time/signals.md
@@ -11,7 +11,7 @@ We want pure, referentially transparent, testable, procedural animations.
 
 ## Background
 
-The goal of Indigo is to make programming games (as a pose to making them...), easier to reason about and easier to test by leveraging the good ideas that come with functional programming.
+The goal of Indigo is to make programming games (as opposed to making them...), easier to reason about and easier to test by leveraging the good ideas that come with functional programming.
 
 One of those good ideas that Indigo borrows is the notion of Signals and Signal Functions. Signals for animation were first proposed in the Functional Reactive ANimation (FRAN) system, but are most readily seen in [Yampa](https://github.com/ivanperez-keera/Yampa).
 


### PR DESCRIPTION
This patch fixes some typos I came across while reading the docs.