### PR TITLE
Fixed #331: Option to disable frame rate

### DIFF
--- a/demos/pirate/build.sbt
+++ b/demos/pirate/build.sbt
@@ -11,12 +11,12 @@ lazy val pirate =
       SbtIndigo      //  Enable Indigo plugin
     )
     .settings( // Standard SBT settings
-      name := "pirate",
-      version := "0.0.1",
+      name         := "pirate",
+      version      := "0.0.1",
       scalaVersion := scala3Version,
       organization := "pirate",
       libraryDependencies ++= Seq(
-        "org.scalameta" %%% "munit" % "0.7.26" % Test,
+        "org.scalameta"  %%% "munit"      % "0.7.26" % Test,
         "org.scalacheck" %%% "scalacheck" % "1.15.3" % "test"
       ),
       scalacOptions ++= Seq("-language:strictEquality"),
@@ -25,15 +25,16 @@ lazy val pirate =
       Test / scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) }
     )
     .settings( // Indigo specific settings
-      showCursor := true,
-      title := "The Cursed Pirate",
-      gameAssetsDirectory := "assets",
-      windowStartWidth := 1280,
-      windowStartHeight := 720,
+      showCursor            := true,
+      title                 := "The Cursed Pirate",
+      gameAssetsDirectory   := "assets",
+      windowStartWidth      := 1280,
+      windowStartHeight     := 720,
+      disableFrameRateLimit := false,
       libraryDependencies ++= Seq(
         "io.indigoengine" %%% "indigo-json-circe" % IndigoVersion.getVersion, // Needed for Aseprite & Tiled support
         "io.indigoengine" %%% "indigo"            % IndigoVersion.getVersion, // Important! :-)
-        "io.indigoengine" %%% "indigo-extras"     % IndigoVersion.getVersion // Important! :-)
+        "io.indigoengine" %%% "indigo-extras"     % IndigoVersion.getVersion  // Important! :-)
       )
     )
 

--- a/demos/pirate/src/main/scala/pirate/CursedPirateDemo.scala
+++ b/demos/pirate/src/main/scala/pirate/CursedPirateDemo.scala
@@ -17,7 +17,7 @@ The parameter types are "boot data", "start up data", "model", "view model"
  */
 // This is the only line of Scala.js you *must* use!
 @JSExportTopLevel("IndigoGame")
-object CursedPirateDemo extends IndigoGame[BootInformation, StartupData, Model, ViewModel] {
+object CursedPirateDemo extends IndigoGame[BootInformation, StartupData, Model, ViewModel]:
 
   // The scene's list is ordered, so that you can go forward a backwards.
   // `initialScene` allows you to specify which scene to start at, but in
@@ -60,7 +60,7 @@ object CursedPirateDemo extends IndigoGame[BootInformation, StartupData, Model, 
       ).withAssets(Assets.initialAssets(assetPath))
         .withFonts(Assets.Fonts.fontInfo)
         .withSubSystems(
-          FPSCounter(Point(10, 10), FPS.`60`, Option(BindingKey("fps")))
+          FPSCounter(Point(10, 10), BindingKey("fps"))
         )
     }
 
@@ -97,7 +97,5 @@ object CursedPirateDemo extends IndigoGame[BootInformation, StartupData, Model, 
         .addLayer(Layer(BindingKey("ui")))
         .addLayer(Layer(BindingKey("fps")))
     )
-
-}
 
 final case class BootInformation(assetPath: String, screenDimensions: Rectangle)

--- a/demos/snake/build.sc
+++ b/demos/snake/build.sc
@@ -13,11 +13,12 @@ object snake extends ScalaJSModule with MillIndigo {
   def scalaVersion   = "3.1.1"
   def scalaJSVersion = "1.8.0"
 
-  val gameAssetsDirectory: os.Path = os.pwd / "assets"
-  val showCursor: Boolean          = true
-  val title: String                = "Snake - Made with Indigo"
-  val windowStartWidth: Int        = 720
-  val windowStartHeight: Int       = 516
+  val gameAssetsDirectory: os.Path   = os.pwd / "assets"
+  val showCursor: Boolean            = true
+  val title: String                  = "Snake - Made with Indigo"
+  val windowStartWidth: Int          = 720
+  val windowStartHeight: Int         = 516
+  val disableFrameRateLimit: Boolean = false
 
   def buildGame() = T.command {
     T {

--- a/demos/snake/snake/src/snake/SnakeGame.scala
+++ b/demos/snake/snake/src/snake/SnakeGame.scala
@@ -10,9 +10,7 @@ import snake.scenes.{ControlsScene, GameOverScene, GameScene, StartScene}
 import scala.scalajs.js.annotation.JSExportTopLevel
 
 @JSExportTopLevel("IndigoGame")
-object SnakeGame extends IndigoGame[ViewConfig, StartupData, GameModel, ViewModel] {
-
-  val targetFPS: FPS = FPS.`60`
+object SnakeGame extends IndigoGame[ViewConfig, StartupData, GameModel, ViewModel]:
 
   def initialScene(bootData: ViewConfig): Option[SceneName] =
     Option(StartScene.name)
@@ -34,7 +32,6 @@ object SnakeGame extends IndigoGame[ViewConfig, StartupData, GameModel, ViewMode
       val config =
         GameConfig(
           viewport = viewConfig.viewport,
-          frameRate = targetFPS,
           clearColor = RGBA.Black,
           magnification = viewConfig.magnificationLevel
         )
@@ -43,7 +40,7 @@ object SnakeGame extends IndigoGame[ViewConfig, StartupData, GameModel, ViewMode
         .withAssets(GameAssets.assets(assetPath))
         .withFonts(GameAssets.fontInfo)
         .withSubSystems(
-          Set(FPSCounter(Point(5, 5), targetFPS, Option(BindingKey("fps"))))
+          Set(FPSCounter(Point(5, 5), BindingKey("fps")))
         )
     }
 
@@ -83,7 +80,5 @@ object SnakeGame extends IndigoGame[ViewConfig, StartupData, GameModel, ViewMode
         .addLayer(Layer(BindingKey("ui")))
         .addLayer(Layer(BindingKey("fps")))
     )
-
-}
 
 case object GameReset extends GlobalEvent

--- a/examples/build.sbt
+++ b/examples/build.sbt
@@ -221,12 +221,13 @@ lazy val fireworks =
     .enablePlugins(SbtIndigo)
     .enablePlugins(ScalaJSPlugin)
     .settings(
-      name                := "fireworks-example",
-      showCursor          := true,
-      title               := "Fireworks!",
-      gameAssetsDirectory := "assets",
-      windowStartWidth    := 1280,
-      windowStartHeight   := 720,
+      name                  := "fireworks-example",
+      showCursor            := true,
+      title                 := "Fireworks!",
+      gameAssetsDirectory   := "assets",
+      windowStartWidth      := 1280,
+      windowStartHeight     := 720,
+      disableFrameRateLimit := true,
       libraryDependencies ++= Seq(
         "org.scalacheck" %%% "scalacheck" % "1.15.3" % "test"
       )

--- a/examples/confetti/src/main/scala/com/example/confetti/Confetti.scala
+++ b/examples/confetti/src/main/scala/com/example/confetti/Confetti.scala
@@ -18,10 +18,9 @@ object Confetti extends IndigoDemo[Unit, Unit, Model, Unit]:
             .withViewport(640, 480)
             .withClearColor(RGBA(0.0, 0.2, 0.0, 1.0))
             .withMagnification(1)
-            .withFrameRate(60)
         )
         .withAssets(Assets.assets)
-        .withSubSystems(FPSCounter(Point.zero, FPS.`60`))
+        .withSubSystems(FPSCounter(Point.zero))
     )
 
   def setup(bootData: Unit, assetCollection: AssetCollection, dice: Dice): Outcome[Startup[Unit]] =

--- a/examples/distortion/src/main/scala/com/example/lighting/DistortionGame.scala
+++ b/examples/distortion/src/main/scala/com/example/lighting/DistortionGame.scala
@@ -7,9 +7,7 @@ import indigoextras.effectmaterials.RefractionEntity
 import scala.scalajs.js.annotation._
 
 @JSExportTopLevel("IndigoGame")
-object DistortionGame extends IndigoSandbox[Unit, Unit] {
-
-  val targetFPS: FPS = FPS.`60`
+object DistortionGame extends IndigoSandbox[Unit, Unit]:
 
   private val magnificationLevel: Int = 3
   private val viewportWidth: Int      = 228 * magnificationLevel
@@ -18,7 +16,6 @@ object DistortionGame extends IndigoSandbox[Unit, Unit] {
   val config: GameConfig =
     GameConfig(
       viewport = GameViewport(viewportWidth, viewportHeight),
-      frameRate = targetFPS,
       clearColor = RGBA(0.0, 0.0, 0.2, 1.0),
       magnification = magnificationLevel
     )
@@ -101,9 +98,8 @@ object DistortionGame extends IndigoSandbox[Unit, Unit] {
           )
       )
     )
-}
 
-object DistortionAssets {
+object DistortionAssets:
 
   val junctionBoxAlbedo: AssetName = AssetName("junctionbox_albedo")
   val junctionBoxEmission: Texture = Texture(AssetName("junctionbox_emission"), 1.0d)
@@ -137,5 +133,3 @@ object DistortionAssets {
         AssetType.Image(normalName, AssetPath("assets/" + normalName + ".png"))
       )
     )
-
-}

--- a/examples/effects/src/main/scala/com/example/effects/EffectsExample.scala
+++ b/examples/effects/src/main/scala/com/example/effects/EffectsExample.scala
@@ -9,9 +9,7 @@ import indigoextras.effectmaterials.Thickness
 import scala.scalajs.js.annotation._
 
 @JSExportTopLevel("IndigoGame")
-object EffectsExample extends IndigoSandbox[Unit, Unit] {
-
-  val targetFPS: FPS = FPS.`60`
+object EffectsExample extends IndigoSandbox[Unit, Unit]:
 
   private val magnificationLevel: Int = 2
   private val viewportWidth: Int      = 550
@@ -20,7 +18,6 @@ object EffectsExample extends IndigoSandbox[Unit, Unit] {
   val config: GameConfig =
     GameConfig(
       viewport = GameViewport(viewportWidth, viewportHeight),
-      frameRate = targetFPS,
       clearColor = RGBA(0.0, 0.0, 0.2, 1.0),
       magnification = magnificationLevel
     )
@@ -108,9 +105,8 @@ object EffectsExample extends IndigoSandbox[Unit, Unit] {
       )
     )
   }
-}
 
-object EffectsAssets {
+object EffectsAssets:
 
   val junctionBoxAlbedo: AssetName = AssetName("junctionbox_albedo")
 
@@ -121,5 +117,3 @@ object EffectsAssets {
     Set(
       AssetType.Image(junctionBoxAlbedo, AssetPath("assets/" + junctionBoxAlbedo + ".png"))
     )
-
-}

--- a/examples/fireworks/src/main/scala/indigoexamples/Fireworks.scala
+++ b/examples/fireworks/src/main/scala/indigoexamples/Fireworks.scala
@@ -16,7 +16,6 @@ import scala.scalajs.js.annotation._
 @JSExportTopLevel("IndigoGame")
 object Fireworks extends IndigoDemo[Vertex => Point, FireworksStartupData, Unit, Unit] {
 
-  val targetFPS: FPS     = FPS.`60`
   val magnification: Int = 3
 
   /** Fairly severe. The model only gets one event and the view model is never run.
@@ -37,7 +36,6 @@ object Fireworks extends IndigoDemo[Vertex => Point, FireworksStartupData, Unit,
     Outcome {
       val config =
         defaultGameConfig
-          .withFrameRate(targetFPS)
           .withMagnification(magnification)
           .withViewport(GameViewport.at720p)
 
@@ -50,7 +48,7 @@ object Fireworks extends IndigoDemo[Vertex => Point, FireworksStartupData, Unit,
       ).withAssets(Assets.assets)
         .withFonts(FontDetails.fontInfo)
         .withSubSystems(
-          FPSCounter(Point(5, 5), targetFPS, None),
+          FPSCounter(Point(5, 5)),
           LaunchPadAutomata.automata,
           RocketAutomata.automata(toScreenSpace),
           TrailAutomata.automata,

--- a/examples/lighting/src/main/scala/com/example/lighting/LightingGame.scala
+++ b/examples/lighting/src/main/scala/com/example/lighting/LightingGame.scala
@@ -5,9 +5,7 @@ import indigo._
 import scala.scalajs.js.annotation._
 
 @JSExportTopLevel("IndigoGame")
-object LightingGame extends IndigoSandbox[Unit, Unit] {
-
-  val targetFPS: FPS = FPS.`60`
+object LightingGame extends IndigoSandbox[Unit, Unit]:
 
   private val magnificationLevel: Int = 3
   private val viewportWidth: Int      = 228 * magnificationLevel
@@ -16,7 +14,6 @@ object LightingGame extends IndigoSandbox[Unit, Unit] {
   val config: GameConfig =
     GameConfig(
       viewport = GameViewport(viewportWidth, viewportHeight),
-      frameRate = targetFPS,
       clearColor = RGBA(0.0, 0.0, 0.2, 1.0),
       magnification = magnificationLevel
     )
@@ -111,9 +108,8 @@ object LightingGame extends IndigoSandbox[Unit, Unit] {
           .withFalloff(Falloff.None(15, 100))
       )
     )
-}
 
-object LightingAssets {
+object LightingAssets:
 
   val junctionBoxAlbedo: AssetName = AssetName("junctionbox_albedo")
   val junctionBoxEmission: Texture = Texture(AssetName("junctionbox_emission"), 1.0d)
@@ -157,5 +153,3 @@ object LightingAssets {
         AssetType.Image(trafficLightsName, AssetPath("assets/" + trafficLightsName + ".png"))
       )
     )
-
-}

--- a/examples/scenes-setup/src/main/scala/indigoexamples/ScenesSetup.scala
+++ b/examples/scenes-setup/src/main/scala/indigoexamples/ScenesSetup.scala
@@ -7,7 +7,7 @@ import indigoextras.subsystems.FPSCounter
 import scala.scalajs.js.annotation._
 
 @JSExportTopLevel("IndigoGame")
-object ScenesSetup extends IndigoGame[Unit, StartUpData, GameModel, Unit] {
+object ScenesSetup extends IndigoGame[Unit, StartUpData, GameModel, Unit]:
 
   val targetFPS: FPS = FPS.`30`
 
@@ -25,11 +25,11 @@ object ScenesSetup extends IndigoGame[Unit, StartUpData, GameModel, Unit] {
         .noData(
           defaultGameConfig
             .withClearColor(RGBA.fromHexString("0xAA3399"))
-            .withFrameRate(targetFPS)
+            .withFrameRateLimit(targetFPS)
         )
         .withAssets(AssetType.Image(FontStuff.fontName, AssetPath("assets/boxy_font.png")))
         .withFonts(FontStuff.fontInfo)
-        .withSubSystems(FPSCounter(Point(10, 360), targetFPS, None))
+        .withSubSystems(FPSCounter(Point(10, 360), targetFPS))
     )
 
   def setup(bootData: Unit, assetCollection: AssetCollection, dice: Dice): Outcome[Startup[StartUpData]] =
@@ -54,7 +54,6 @@ object ScenesSetup extends IndigoGame[Unit, StartUpData, GameModel, Unit] {
 
   def present(context: FrameContext[StartUpData], model: GameModel, viewModel: Unit): Outcome[SceneUpdateFragment] =
     Outcome(SceneUpdateFragment.empty)
-}
 
 final case class StartUpData(messageA: String, messageB: String)
 final case class GameModel(sceneA: MessageA, sceneB: MessageB)

--- a/indigo-plugin/indigo-plugin/src/indigoplugin/IndigoRun.scala
+++ b/indigo-plugin/indigo-plugin/src/indigoplugin/IndigoRun.scala
@@ -8,12 +8,19 @@ import indigoplugin.templates.SupportScriptTemplate
 
 object IndigoRun {
 
-  def run(outputDir: Path, buildDir: Path, title: String, windowWidth: Int, windowHeight: Int): Unit = {
+  def run(
+      outputDir: Path,
+      buildDir: Path,
+      title: String,
+      windowWidth: Int,
+      windowHeight: Int,
+      disableFrameRateLimit: Boolean
+  ): Unit = {
 
     os.remove.all(outputDir)
     os.makeDir.all(outputDir)
 
-    filesToWrite(windowWidth, windowHeight).foreach { f =>
+    filesToWrite(windowWidth, windowHeight, disableFrameRateLimit).foreach { f =>
       os.write.over(outputDir / f.name, f.contents)
     }
 
@@ -34,7 +41,7 @@ object IndigoRun {
         os.proc("cmd", "/C", "npm", "start")
           .call(cwd = outputDir, stdin = os.Inherit, stdout = os.Inherit, stderr = os.Inherit)
 
-      case _ =>        
+      case _ =>
         os.proc("npm", "start")
           .call(cwd = outputDir, stdin = os.Inherit, stdout = os.Inherit, stderr = os.Inherit)
     }
@@ -42,11 +49,11 @@ object IndigoRun {
     ()
   }
 
-  def filesToWrite(windowWidth: Int, windowHeight: Int): List[FileToWrite] =
+  def filesToWrite(windowWidth: Int, windowHeight: Int, disableFrameRateLimit: Boolean): List[FileToWrite] =
     List(
       FileToWrite("main.js", ElectronTemplates.mainFileTemplate(windowWidth, windowHeight)),
       FileToWrite("preload.js", ElectronTemplates.preloadFileTemplate),
-      FileToWrite("package.json", ElectronTemplates.packageFileTemplate)
+      FileToWrite("package.json", ElectronTemplates.packageFileTemplate(disableFrameRateLimit))
     )
 
 }

--- a/indigo-plugin/indigo-plugin/src/indigoplugin/templates/ElectronTemplates.scala
+++ b/indigo-plugin/indigo-plugin/src/indigoplugin/templates/ElectronTemplates.scala
@@ -51,15 +51,14 @@ app.on('window-all-closed', function () {
 // code. You can also put them in separate files and require them here.
     """
 
-  lazy val packageFileTemplate: String =
-    """
-{
+  def packageFileTemplate(disableFrameRateLimit: Boolean): String =
+    s"""{
   "name": "indigo-runner",
   "version": "1.0.0",
   "description": "Indigo Runner",
   "main": "main.js",
   "scripts": {
-    "start": "electron ."
+    "start": "electron${if(disableFrameRateLimit) " --disable-frame-rate-limit" else ""} ."
   },
   "repository": "",
   "author": "Purple Kingdom Games",
@@ -68,8 +67,7 @@ app.on('window-all-closed', function () {
     """
 
   lazy val preloadFileTemplate: String =
-    """
-// All of the Node.js APIs are available in the preload process.
+    """// All of the Node.js APIs are available in the preload process.
 // It has the same sandbox as a Chrome extension.
 window.addEventListener('DOMContentLoaded', () => {
   const replaceText = (selector, text) => {

--- a/indigo/build.sbt
+++ b/indigo/build.sbt
@@ -81,10 +81,11 @@ lazy val sandbox =
     .settings(
       neverPublish,
       commonSettings,
-      name                := "sandbox",
-      showCursor          := true,
-      title               := "Sandbox",
-      gameAssetsDirectory := "assets"
+      name                  := "sandbox",
+      showCursor            := true,
+      title                 := "Sandbox",
+      gameAssetsDirectory   := "assets",
+      disableFrameRateLimit := true
     )
 
 lazy val perf =
@@ -95,12 +96,13 @@ lazy val perf =
     .settings(
       neverPublish,
       commonSettings,
-      name                := "indigo-perf",
-      showCursor          := true,
-      title               := "Perf",
-      gameAssetsDirectory := "assets",
-      windowStartWidth    := 800,
-      windowStartHeight   := 600
+      name                  := "indigo-perf",
+      showCursor            := true,
+      title                 := "Perf",
+      gameAssetsDirectory   := "assets",
+      windowStartWidth      := 800,
+      windowStartHeight     := 600,
+      disableFrameRateLimit := true
     )
 
 // Indigo Extensions

--- a/indigo/indigo-extras/src/test/scala/indigoextras/jobs/WorkScheduleTests.scala
+++ b/indigo/indigo-extras/src/test/scala/indigoextras/jobs/WorkScheduleTests.scala
@@ -41,7 +41,7 @@ class WorkScheduleTests extends munit.FunSuite {
 
     val workSchedule = WorkSchedule[SampleActor, SampleContext](bindingKey, SampleActor.worker, Nil)
 
-    val gameTime = new GameTime(0, 0, FPS(0))
+    val gameTime = new GameTime(0, 0, None)
 
     val actual = workSchedule.update(gameTime, dice, actor, context)(FrameTick).unsafeGet.workSchedule.jobStack
 
@@ -56,7 +56,7 @@ class WorkScheduleTests extends munit.FunSuite {
     val jobs                   = Fishing(0) :: Nil
 
     val workSchedule = WorkSchedule[SampleActor, SampleContext](bindingKey, SampleActor.worker, jobs)
-    val gameTime     = new GameTime(0, 0, FPS(0))
+    val gameTime     = new GameTime(0, 0, None)
 
     workSchedule.update(gameTime, dice, actor, context)(FrameTick).unsafeGet.workSchedule.jobStack.headOption match {
       case Some(Fishing(done)) =>
@@ -76,7 +76,7 @@ class WorkScheduleTests extends munit.FunSuite {
     val expected: List[Job]    = Nil
 
     val workSchedule = WorkSchedule[SampleActor, SampleContext](bindingKey, SampleActor.worker, Nil)
-    val gameTime     = new GameTime(0, 0, FPS(0))
+    val gameTime     = new GameTime(0, 0, None)
 
     val actual = workSchedule
       .update(gameTime, dice, actor, context)(UnrelatedEvent("ignored!"))
@@ -94,7 +94,7 @@ class WorkScheduleTests extends munit.FunSuite {
     val expected: List[Job]    = jobToAllocate :: Nil
 
     val workSchedule = WorkSchedule[SampleActor, SampleContext](bindingKey, SampleActor.worker, Nil)
-    val gameTime     = new GameTime(0, 0, FPS(0))
+    val gameTime     = new GameTime(0, 0, None)
 
     val allocationId = bindingKey
 
@@ -113,7 +113,7 @@ class WorkScheduleTests extends munit.FunSuite {
     val expected: List[Job]    = WanderTo(100) :: Nil
 
     val workSchedule = WorkSchedule[SampleActor, SampleContext](bindingKey, SampleActor.worker, Nil)
-    val gameTime     = new GameTime(0, 0, FPS(0))
+    val gameTime     = new GameTime(0, 0, None)
 
     val allocationId = bindingKey
 
@@ -161,7 +161,7 @@ class WorkScheduleTests extends munit.FunSuite {
     }
   }
 
-  val gameTime = new GameTime(0, 0, FPS(0))
+  val gameTime = new GameTime(0, 0, None)
 
   val workSchedule2 = workSchedule.update(gameTime, dice, actor, context)(FrameTick).unsafeGet.workSchedule
 

--- a/indigo/indigo/src/main/scala/indigo/shared/time/FPS.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/time/FPS.scala
@@ -16,3 +16,5 @@ object FPS:
     def toDouble: Double   = fps.toDouble
     def toSeconds: Seconds = Seconds(1.0d / fps.toDouble)
     def toMillis: Millis   = toSeconds.toMillis
+
+  given CanEqual[FPS, FPS] = CanEqual.derived

--- a/indigo/indigo/src/main/scala/indigo/shared/time/GameTime.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/time/GameTime.scala
@@ -7,11 +7,11 @@ import annotation.targetName
   * current frame. The most commonly used fields (e.g. for animation) are the running time of the game and the time
   * delta since the last frame.
   */
-final case class GameTime(running: Seconds, delta: Seconds, targetFPS: FPS) derives CanEqual:
-  lazy val frameDuration: Millis = targetFPS.toMillis
+final case class GameTime(running: Seconds, delta: Seconds, targetFPS: Option[FPS]) derives CanEqual:
+  lazy val frameDuration: Option[Millis] = targetFPS.map(_.toMillis)
 
   def setTargetFPS(fps: FPS): GameTime =
-    this.copy(targetFPS = fps)
+    this.copy(targetFPS = Option(fps))
   @targetName("setTargetFPS_Int")
   def setTargetFPS(fps: Int): GameTime =
     setTargetFPS(FPS(fps))
@@ -19,10 +19,10 @@ final case class GameTime(running: Seconds, delta: Seconds, targetFPS: FPS) deri
 object GameTime:
 
   val zero: GameTime =
-    GameTime(Seconds.zero, Seconds.zero, FPS.Default)
+    GameTime(Seconds.zero, Seconds.zero, None)
 
   def is(running: Seconds): GameTime =
-    GameTime(running, Seconds.zero, FPS.Default)
+    GameTime(running, Seconds.zero, None)
 
   def withDelta(running: Seconds, delta: Seconds): GameTime =
-    GameTime(running, delta, FPS.Default)
+    GameTime(running, delta, None)

--- a/indigo/indigo/src/test/scala/indigo/shared/time/GameTimeTests.scala
+++ b/indigo/indigo/src/test/scala/indigo/shared/time/GameTimeTests.scala
@@ -2,9 +2,14 @@ package indigo.shared.time
 
 class GameTimeTests extends munit.FunSuite {
 
-  test("GameTime should be able to calculate the frame duration of the game") {
-    val gameTime: GameTime = GameTime(Seconds.zero, Seconds.zero, targetFPS = FPS(30))
-    assertEquals(gameTime.frameDuration, Millis(33L))
+  test("GameTime should be able to calculate the frame duration of the game (set)") {
+    val gameTime: GameTime = GameTime(Seconds.zero, Seconds.zero, targetFPS = Option(FPS(30)))
+    assertEquals(gameTime.frameDuration.get, Millis(33L))
+  }
+
+  test("GameTime should be able to calculate the frame duration of the game (unset)") {
+    val gameTime: GameTime = GameTime(Seconds.zero, Seconds.zero, targetFPS = None)
+    assertEquals(gameTime.frameDuration, None)
   }
 
 }

--- a/indigo/perf/src/main/scala/com/example/perf/PerfGame.scala
+++ b/indigo/perf/src/main/scala/com/example/perf/PerfGame.scala
@@ -9,7 +9,6 @@ import scala.scalajs.js.annotation._
 @JSExportTopLevel("IndigoGame")
 object PerfGame extends IndigoDemo[Unit, Dude, DudeModel, Unit] {
 
-  val targetFPS: FPS          = FPS.`60`
   val viewportWidth: Int      = 800
   val viewportHeight: Int     = 600
   val magnificationLevel: Int = 1
@@ -38,7 +37,7 @@ object PerfGame extends IndigoDemo[Unit, Dude, DudeModel, Unit] {
         .noData(
           GameConfig(
             viewport = GameViewport(viewportWidth, viewportHeight),
-            frameRate = targetFPS,
+            frameRateLimit = None,
             clearColor = RGBA(0.4, 0.2, 0.5, 1),
             magnification = magnificationLevel,
             transparentBackground = false,
@@ -53,7 +52,7 @@ object PerfGame extends IndigoDemo[Unit, Dude, DudeModel, Unit] {
         )
         .withAssets(PerfAssets.assets)
         .withFonts(Fonts.fontInfo)
-        .withSubSystems(FPSCounter(Point(10, 565), targetFPS, None))
+        .withSubSystems(FPSCounter(Point(10, 565)))
         .withShaders(
           StandardShaders.Bitmap,
           StandardShaders.ImageEffects,

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/SandboxGame.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/SandboxGame.scala
@@ -35,7 +35,6 @@ import scala.scalajs.js.annotation.*
 @JSExportTopLevel("IndigoGame")
 object SandboxGame extends IndigoGame[SandboxBootData, SandboxStartupData, SandboxGameModel, SandboxViewModel]:
 
-  val targetFPS: FPS          = FPS.`60`
   val magnificationLevel: Int = 2
   val gameWidth: Int          = 228
   val gameHeight: Int         = 128
@@ -82,7 +81,6 @@ object SandboxGame extends IndigoGame[SandboxBootData, SandboxStartupData, Sandb
       BootResult(
         GameConfig(
           viewport = gameViewport,
-          frameRate = targetFPS,
           clearColor = RGBA(0.4, 0.2, 0.5, 1),
           magnification = magnificationLevel
         ),
@@ -95,8 +93,7 @@ object SandboxGame extends IndigoGame[SandboxBootData, SandboxStartupData, Sandb
         .withSubSystems(
           FPSCounter(
             Point(5, 165),
-            targetFPS,
-            Option(BindingKey("fps counter"))
+            BindingKey("fps counter")
           )
         )
         .withShaders(

--- a/mill-indigo/mill-indigo/src/millindigo/MillIndigo.scala
+++ b/mill-indigo/mill-indigo/src/millindigo/MillIndigo.scala
@@ -11,15 +11,33 @@ import indigoplugin.IndigoCordova
 
 trait MillIndigo extends mill.Module {
 
+  /** Title of your game.
+    */
   val title: String
+
+  /** Show the cursor?
+    */
   val showCursor: Boolean
+
+  /** Project relative path to a directory that contains all of the assets the game needs to load.
+    */
   val gameAssetsDirectory: Path
+
+  /** Initial window width.
+    */
   val windowStartWidth: Int
+
+  /** Initial window height.
+    */
   val windowStartHeight: Int
+
+  /** If possible, disables the runtime's frame rate limit, recommended to be `false`.
+    */
+  val disableFrameRateLimit: Boolean
 
   def indigoBuild(): Command[Path] =
     T.command {
-      val scriptPathBase: Path =  T.dest / os.up / "fastOpt.dest"
+      val scriptPathBase: Path = T.dest / os.up / "fastOpt.dest"
 
       IndigoBuildMill.build(
         T.dest,
@@ -57,7 +75,7 @@ trait MillIndigo extends mill.Module {
       val outputDir: Path = T.dest
       val buildDir: Path  = indigoBuild()()
 
-      IndigoRun.run(outputDir, buildDir, title, windowStartWidth, windowStartHeight)
+      IndigoRun.run(outputDir, buildDir, title, windowStartWidth, windowStartHeight, disableFrameRateLimit)
     }
 
   def indigoRunFull(): Command[Unit] =
@@ -65,7 +83,7 @@ trait MillIndigo extends mill.Module {
       val outputDir: Path = T.dest
       val buildDir: Path  = indigoBuildFull()()
 
-      IndigoRun.run(outputDir, buildDir, title, windowStartWidth, windowStartHeight)
+      IndigoRun.run(outputDir, buildDir, title, windowStartWidth, windowStartHeight, disableFrameRateLimit)
     }
 
   def indigoCordovaBuild(): Command[Unit] =

--- a/sbt-indigo/src/main/scala/sbtindigo/SbtIndigo.scala
+++ b/sbt-indigo/src/main/scala/sbtindigo/SbtIndigo.scala
@@ -24,6 +24,7 @@ object SbtIndigo extends sbt.AutoPlugin {
     val title: SettingKey[String]          = settingKey[String]("Title of your game. Defaults to 'Made with Indigo'.")
     val windowStartWidth: SettingKey[Int]  = settingKey[Int]("Initial window width. Defaults to 550 pixels.")
     val windowStartHeight: SettingKey[Int] = settingKey[Int]("Initial window height. Defaults to 400 pixels.")
+    val disableFrameRateLimit: SettingKey[Boolean] = settingKey[Boolean]("If possible, disables the runtime's frame rate limit. Defaults to false.")
   }
 
   import autoImport._
@@ -39,7 +40,8 @@ object SbtIndigo extends sbt.AutoPlugin {
     title := "Made with Indigo",
     gameAssetsDirectory := ".",
     windowStartWidth := 550,
-    windowStartHeight := 400
+    windowStartHeight := 400,
+    disableFrameRateLimit := false
   )
 
   def giveScriptBasePath(baseDir: String, scalaVersion: String): String =
@@ -123,7 +125,8 @@ object SbtIndigo extends sbt.AutoPlugin {
         buildDir = buildDir,
         title = title.value,
         windowWidth = windowStartWidth.value,
-        windowHeight = windowStartHeight.value
+        windowHeight = windowStartHeight.value,
+        disableFrameRateLimit = disableFrameRateLimit.value
       )
     }
 
@@ -138,7 +141,8 @@ object SbtIndigo extends sbt.AutoPlugin {
         buildDir = buildDir,
         title = title.value,
         windowWidth = windowStartWidth.value,
-        windowHeight = windowStartHeight.value
+        windowHeight = windowStartHeight.value,
+        disableFrameRateLimit = disableFrameRateLimit.value
       )
     }
 


### PR DESCRIPTION
Adds two flags:

1. A plugin flag to disable the frame rate limit (in electron) means your game with run as fast as it possibly can.
2. A config flag that moves the long standing "frame rate" to an optional "frame rate limit".

The recommendation is to let the browser manage the frame rate unless you specifically want to go slower. To do that, you set the plugin flag to `false` and the frame rate limit config flag to `None`, and these are the defaults.
