### PR TITLE
Fixed #337: Ability to halt an Indigo game

### DIFF
--- a/indigo/docs/organisation/boot-and-start-up.md
+++ b/indigo/docs/organisation/boot-and-start-up.md
@@ -73,6 +73,16 @@ Flags can represent anything you like. In the Snake example we are providing the
 
 The main limitation on flags is that they are typed to `Map[String, String]`, which is bothersome if you're trying to supply a number for instance. Perhaps the best way to use more sophisticated data at start up would be to supply JSON by setting a data flag, e.g. `{ data = '{width: 10, height: 10}' }`, and then pulling out the data flag at boot time and parsing the JSON string.
 
+#### Halting a game
+
+If you are embedding your game in a web page, you may have the need to stop a running game and free up it's resources, which you can do by calling the opposite function to `launch`, called `halt`:
+
+```javascript
+IndigoGame.halt();
+```
+
+Calling `halt` does not clean up your page in any way, the assumption is that you will remove the relevant HTML dom nodes.
+
 #### BootResult[_]
 
 In a simple game, all of your animations, fonts, subsystems, shaders, and assets can be declared during the boot stage. For more complex games, such as ones that have a pre-loader, you should only include the elements you need for the preloader scene here.

--- a/indigo/indigo/src/main/scala/indigo/GameLauncher.scala
+++ b/indigo/indigo/src/main/scala/indigo/GameLauncher.scala
@@ -1,40 +1,60 @@
 package indigo
 
+import indigo.gameengine.GameEngine
+
 import scala.scalajs.js.annotation._
 
-trait GameLauncher:
+trait GameLauncher[StartUpData, Model, ViewModel]:
 
-  protected def ready(parentElementId: String, flags: Map[String, String]): Unit
+  @SuppressWarnings(Array("scalafix:DisableSyntax.null", "scalafix:DisableSyntax.var"))
+  private var game: GameEngine[StartUpData, Model, ViewModel] = null
+
+  protected def ready(parentElementId: String, flags: Map[String, String]): GameEngine[StartUpData, Model, ViewModel]
+
+  @SuppressWarnings(Array("scalafix:DisableSyntax.null"))
+  @JSExport
+  def halt(): Unit =
+    game.kill()
+    game = null
+    ()
 
   @JSExport
   def launch(): Unit =
-    ready(GameLauncher.DefaultContainerId, Map[String, String]())
+    game = ready(GameLauncher.DefaultContainerId, Map[String, String]())
+    ()
 
   @JSExport
   def launch(containerId: String): Unit =
-    ready(containerId, Map[String, String]())
+    game = ready(containerId, Map[String, String]())
+    ()
 
   // JS API
   @JSExport
   def launch(flags: scala.scalajs.js.Dictionary[String]): Unit =
-    ready(GameLauncher.DefaultContainerId, flags.toMap)
+    game = ready(GameLauncher.DefaultContainerId, flags.toMap)
+    ()
 
   @JSExport
   def launch(containerId: String, flags: scala.scalajs.js.Dictionary[String]): Unit =
-    ready(containerId, flags.toMap)
+    game = ready(containerId, flags.toMap)
+    ()
 
   // Scala API
   def launch(flags: Map[String, String]): Unit =
-    ready(GameLauncher.DefaultContainerId, flags)
+    game = ready(GameLauncher.DefaultContainerId, flags)
+    ()
 
   def launch(flags: (String, String)*): Unit =
-    ready(GameLauncher.DefaultContainerId, flags.toMap)
+    game = ready(GameLauncher.DefaultContainerId, flags.toMap)
+    ()
 
   def launch(containerId: String, flags: Map[String, String]): Unit =
-    ready(containerId, flags)
+    game = ready(containerId, flags)
+    ()
 
   def launch(containerId: String, flags: (String, String)*): Unit =
-    ready(containerId, flags.toMap)
+    game = ready(containerId, flags.toMap)
+    ()
 
 object GameLauncher:
   val DefaultContainerId: String = "indigo-container"

--- a/indigo/indigo/src/main/scala/indigo/IndigoDemo.scala
+++ b/indigo/indigo/src/main/scala/indigo/IndigoDemo.scala
@@ -7,109 +7,117 @@ import org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits._
 
 import scala.concurrent.Future
 
-/**
-  * A trait representing a minimal set of functions to get your game running
+/** A trait representing a minimal set of functions to get your game running
   *
-  * @example `object MyGame extends IndigoDemo[BootData, StartUpData, Model, ViewModel]`
+  * @example
+  *   `object MyGame extends IndigoDemo[BootData, StartUpData, Model, ViewModel]`
   *
-  * @tparam BootData The class type representing you a successful game boot up
-  * @tparam StartUpData The class type representing your successful startup data
-  * @tparam Model The class type representing your game's model
-  * @tparam ViewModel The class type representing your game's view model
+  * @tparam BootData
+  *   The class type representing you a successful game boot up
+  * @tparam StartUpData
+  *   The class type representing your successful startup data
+  * @tparam Model
+  *   The class type representing your game's model
+  * @tparam ViewModel
+  *   The class type representing your game's view model
   */
-trait IndigoDemo[BootData, StartUpData, Model, ViewModel] extends GameLauncher {
+trait IndigoDemo[BootData, StartUpData, Model, ViewModel] extends GameLauncher[StartUpData, Model, ViewModel] {
 
-  /**
-    * Event filters represent a mapping from events to possible events,
-    * and act like a firewall to prevent unnecessary event processing
-    * by the model or view model.
+  /** Event filters represent a mapping from events to possible events, and act like a firewall to prevent unnecessary
+    * event processing by the model or view model.
     */
   def eventFilters: EventFilters
 
-  /**
-    * `boot` provides the initial boot up function for your game, accepting
-    * commandline-like arguments and allowing you to declare pre-requist
-    * assets assets and data that must be in place for your game to get going.
+  /** `boot` provides the initial boot up function for your game, accepting commandline-like arguments and allowing you
+    * to declare pre-requist assets assets and data that must be in place for your game to get going.
     *
-    * @param flags A simply key-value object/map passed in during initial boot.
-    * @return Bootup data consisting of a custom data type, animations,
-    *         subsytems, assets, fonts, and the game's config.
+    * @param flags
+    *   A simply key-value object/map passed in during initial boot.
+    * @return
+    *   Bootup data consisting of a custom data type, animations, subsytems, assets, fonts, and the game's config.
     */
   def boot(flags: Map[String, String]): Outcome[BootResult[BootData]]
 
-  /**
-    * The `setup` function is your only opportunity to do an initial work
-    * to set up your game. For example, perhaps one of your assets was a
-    * JSON description of a map or an animation sequence, you could process
-    * that now, which is why you have access to the `AssetCollection` object.
-    * `setup` is typically only called when new assets are loaded. In a simple
-    * game this may only be once, but if assets are dynamically loaded, set up
-    * will be called again.
+  /** The `setup` function is your only opportunity to do an initial work to set up your game. For example, perhaps one
+    * of your assets was a JSON description of a map or an animation sequence, you could process that now, which is why
+    * you have access to the `AssetCollection` object. `setup` is typically only called when new assets are loaded. In a
+    * simple game this may only be once, but if assets are dynamically loaded, set up will be called again.
     *
-    * @param bootData Data created during initial game boot.
-    * @param assetCollection Access to the Asset collection in order to,
-    *                        for example, parse text files.
-    * @param dice Psuedorandom number generator
-    * @return Return start up data, which can include animations and fonts
-    *         that could not be declared at boot time.
+    * @param bootData
+    *   Data created during initial game boot.
+    * @param assetCollection
+    *   Access to the Asset collection in order to, for example, parse text files.
+    * @param dice
+    *   Psuedorandom number generator
+    * @return
+    *   Return start up data, which can include animations and fonts that could not be declared at boot time.
     */
   def setup(bootData: BootData, assetCollection: AssetCollection, dice: Dice): Outcome[Startup[StartUpData]]
 
-  /**
-    * Set up of your initial model state
+  /** Set up of your initial model state
     *
-    * @param startupData Access to Startup data in case you need it for the model
-    * @return An instance of your game model
+    * @param startupData
+    *   Access to Startup data in case you need it for the model
+    * @return
+    *   An instance of your game model
     */
   def initialModel(startupData: StartUpData): Outcome[Model]
 
-  /**
-    * Set up of your initial view model state
+  /** Set up of your initial view model state
     *
-    * @param startupData Access to Startup data in case you need it for the view model
-    * @return An instance of your game's view model
+    * @param startupData
+    *   Access to Startup data in case you need it for the view model
+    * @return
+    *   An instance of your game's view model
     */
   def initialViewModel(startupData: StartUpData, model: Model): Outcome[ViewModel]
 
-  /**
-    * A pure function for updating your game's model in the context of the
-    * running frame and the events acting upon it.
+  /** A pure function for updating your game's model in the context of the running frame and the events acting upon it.
     *
-    * @param context The context the frame should be produced in, including the time,
-    *                input state, a dice instance, the state of the inputs, and a
-    *                read only reference to your start up data.
-    * @param model The latest version of the model to read from.
-    * @return A function that maps GlobalEvent's to the next version of your model,
-    *         and encapsuates failures or resulting events within the Outcome wrapper.
+    * @param context
+    *   The context the frame should be produced in, including the time, input state, a dice instance, the state of the
+    *   inputs, and a read only reference to your start up data.
+    * @param model
+    *   The latest version of the model to read from.
+    * @return
+    *   A function that maps GlobalEvent's to the next version of your model, and encapsuates failures or resulting
+    *   events within the Outcome wrapper.
     */
   def updateModel(context: FrameContext[StartUpData], model: Model): GlobalEvent => Outcome[Model]
 
-  /**
-    * A pure function for updating your game's view model in the context of the
-    * running frame and the events acting upon it.
+  /** A pure function for updating your game's view model in the context of the running frame and the events acting upon
+    * it.
     *
-    *  @param context The context the frame should be produced in, including the time,
-    *                input state, a dice instance, the state of the inputs, and a
-    *                read only reference to your start up data.
-    * @param model The latest version of the model to read from.
-    * @param viewModel The latest version of the view model to read from.
-    * @return A function that maps GlobalEvent's to the next version of your view model,
-    *         and encapsuates failures or resulting events within the Outcome wrapper.
+    * @param context
+    *   The context the frame should be produced in, including the time, input state, a dice instance, the state of the
+    *   inputs, and a read only reference to your start up data.
+    * @param model
+    *   The latest version of the model to read from.
+    * @param viewModel
+    *   The latest version of the view model to read from.
+    * @return
+    *   A function that maps GlobalEvent's to the next version of your view model, and encapsuates failures or resulting
+    *   events within the Outcome wrapper.
     */
-  def updateViewModel(context: FrameContext[StartUpData], model: Model, viewModel: ViewModel): GlobalEvent => Outcome[ViewModel]
+  def updateViewModel(
+      context: FrameContext[StartUpData],
+      model: Model,
+      viewModel: ViewModel
+  ): GlobalEvent => Outcome[ViewModel]
 
-  /**
-    * A pure function for presenting your game. The result is a side effect
-    * free declaration of what you intend to be presented to the player next.
+  /** A pure function for presenting your game. The result is a side effect free declaration of what you intend to be
+    * presented to the player next.
     *
-    * @param context The context the frame should be produced in, including the time,
-    *                input state, a dice instance, the state of the inputs, and a
-    *                read only reference to your start up data.
-    * @param model The latest version of the model to read from.
-    * @param viewModel The latest version of the view model to read from.
-    * @return A function that produces a description of what to present next,
-    *         and encapsuates failures or resulting events within the Outcome
-    *         wrapper.
+    * @param context
+    *   The context the frame should be produced in, including the time, input state, a dice instance, the state of the
+    *   inputs, and a read only reference to your start up data.
+    * @param model
+    *   The latest version of the model to read from.
+    * @param viewModel
+    *   The latest version of the view model to read from.
+    * @return
+    *   A function that produces a description of what to present next, and encapsuates failures or resulting events
+    *   within the Outcome wrapper.
     */
   def present(context: FrameContext[StartUpData], model: Model, viewModel: ViewModel): Outcome[SceneUpdateFragment]
 
@@ -141,8 +149,8 @@ trait IndigoDemo[BootData, StartUpData, Model, ViewModel] extends GameLauncher {
   }
 
   @SuppressWarnings(Array("scalafix:DisableSyntax.throw"))
-  final protected def ready(parentElementId: String, flags: Map[String, String]): Unit =
-    boot(flags) match {
+  final protected def ready(parentElementId: String, flags: Map[String, String]): GameEngine[StartUpData, Model, ViewModel] =
+    boot(flags) match
       case oe @ Outcome.Error(e, _) =>
         IndigoLogger.error("Error during boot - Halting")
         IndigoLogger.error(oe.reportCrash)
@@ -150,6 +158,5 @@ trait IndigoDemo[BootData, StartUpData, Model, ViewModel] extends GameLauncher {
 
       case Outcome.Result(b, evts) =>
         indigoGame(b).start(parentElementId, b.gameConfig, Future(None), b.assets, Future(Set()), evts)
-    }
 
 }

--- a/indigo/indigo/src/main/scala/indigo/IndigoGame.scala
+++ b/indigo/indigo/src/main/scala/indigo/IndigoGame.scala
@@ -12,100 +12,113 @@ import scala.concurrent.Future
 
 /** A trait representing a game with scene management baked in
   *
-  * @example `object MyGame extends IndigoGame[BootData, StartUpData, Model, ViewModel]`
+  * @example
+  *   `object MyGame extends IndigoGame[BootData, StartUpData, Model, ViewModel]`
   *
-  * @tparam BootData The class type representing you a successful game boot up
-  * @tparam StartUpData The class type representing your successful startup data
-  * @tparam Model The class type representing your game's model
-  * @tparam ViewModel The class type representing your game's view model
+  * @tparam BootData
+  *   The class type representing you a successful game boot up
+  * @tparam StartUpData
+  *   The class type representing your successful startup data
+  * @tparam Model
+  *   The class type representing your game's model
+  * @tparam ViewModel
+  *   The class type representing your game's view model
   */
-trait IndigoGame[BootData, StartUpData, Model, ViewModel] extends GameLauncher {
+trait IndigoGame[BootData, StartUpData, Model, ViewModel] extends GameLauncher[StartUpData, Model, ViewModel] {
 
   /** A non-empty ordered list of scenes
     *
-    * @param bootData Data created during initial game boot.
-    * @return A list of scenes that ensures at least one scene exists.
+    * @param bootData
+    *   Data created during initial game boot.
+    * @return
+    *   A list of scenes that ensures at least one scene exists.
     */
   def scenes(bootData: BootData): NonEmptyList[Scene[StartUpData, Model, ViewModel]]
 
-  /** Optional name of the first scene. If None is provided
-    * then the first scene is the head of the scenes list.
+  /** Optional name of the first scene. If None is provided then the first scene is the head of the scenes list.
     *
-    * @param bootData Data created during initial game boot.
-    * @return Optionally return the scene to start the game on,
-    *         otherwise the first scene is used.
+    * @param bootData
+    *   Data created during initial game boot.
+    * @return
+    *   Optionally return the scene to start the game on, otherwise the first scene is used.
     */
   def initialScene(bootData: BootData): Option[SceneName]
 
-  /** Event filters represent a mapping from events to possible events,
-    * and act like a firewall to prevent unnecessary event processing
-    * by the model or view model.
+  /** Event filters represent a mapping from events to possible events, and act like a firewall to prevent unnecessary
+    * event processing by the model or view model.
     */
   def eventFilters: EventFilters
 
-  /** `boot` provides the initial boot up function for your game, accepting
-    * commandline-like arguments and allowing you to declare pre-requist
-    * assets assets and data that must be in place for your game to get going.
+  /** `boot` provides the initial boot up function for your game, accepting commandline-like arguments and allowing you
+    * to declare pre-requist assets assets and data that must be in place for your game to get going.
     *
-    * @param flags A simply key-value object/map passed in during initial boot.
-    * @return Bootup data consisting of a custom data type, animations,
-    *         subsytems, assets, fonts, and the game's config.
+    * @param flags
+    *   A simply key-value object/map passed in during initial boot.
+    * @return
+    *   Bootup data consisting of a custom data type, animations, subsytems, assets, fonts, and the game's config.
     */
   def boot(flags: Map[String, String]): Outcome[BootResult[BootData]]
 
-  /** The `setup` function is your only opportunity to do an initial work
-    * to set up your game. For example, perhaps one of your assets was a
-    * JSON description of a map or an animation sequence, you could process
-    * that now, which is why you have access to the `AssetCollection` object.
-    * `setup` is typically only called when new assets are loaded. In a simple
-    * game this may only be once, but if assets are dynamically loaded, set up
-    * will be called again.
+  /** The `setup` function is your only opportunity to do an initial work to set up your game. For example, perhaps one
+    * of your assets was a JSON description of a map or an animation sequence, you could process that now, which is why
+    * you have access to the `AssetCollection` object. `setup` is typically only called when new assets are loaded. In a
+    * simple game this may only be once, but if assets are dynamically loaded, set up will be called again.
     *
-    * @param bootData Data created during initial game boot.
-    * @param assetCollection Access to the Asset collection in order to,
-    *                        for example, parse text files.
-    * @param dice Psuedorandom number generator
-    * @return Return start up data, which can include animations and fonts
-    *         that could not be declared at boot time.
+    * @param bootData
+    *   Data created during initial game boot.
+    * @param assetCollection
+    *   Access to the Asset collection in order to, for example, parse text files.
+    * @param dice
+    *   Psuedorandom number generator
+    * @return
+    *   Return start up data, which can include animations and fonts that could not be declared at boot time.
     */
   def setup(bootData: BootData, assetCollection: AssetCollection, dice: Dice): Outcome[Startup[StartUpData]]
 
   /** Set up of your initial model state
     *
-    * @param startupData Access to Startup data in case you need it for the model
-    * @return An instance of your game model
+    * @param startupData
+    *   Access to Startup data in case you need it for the model
+    * @return
+    *   An instance of your game model
     */
   def initialModel(startupData: StartUpData): Outcome[Model]
 
   /** Set up of your initial view model state
     *
-    * @param startupData Access to Startup data in case you need it for the view model
-    * @return An instance of your game's view model
+    * @param startupData
+    *   Access to Startup data in case you need it for the view model
+    * @return
+    *   An instance of your game's view model
     */
   def initialViewModel(startupData: StartUpData, model: Model): Outcome[ViewModel]
 
-  /** A pure function for updating your game's model in the context of the
-    * running frame and the events acting upon it.
+  /** A pure function for updating your game's model in the context of the running frame and the events acting upon it.
     *
-    *  @param context The context the frame should be produced in, including the time,
-    *                input state, a dice instance, the state of the inputs, and a
-    *                read only reference to your start up data.
-    * @param model The latest version of the model to read from.
-    * @return A function that maps GlobalEvent's to the next version of your model,
-    *         and encapsuates failures or resulting events within the Outcome wrapper.
+    * @param context
+    *   The context the frame should be produced in, including the time, input state, a dice instance, the state of the
+    *   inputs, and a read only reference to your start up data.
+    * @param model
+    *   The latest version of the model to read from.
+    * @return
+    *   A function that maps GlobalEvent's to the next version of your model, and encapsuates failures or resulting
+    *   events within the Outcome wrapper.
     */
   def updateModel(context: FrameContext[StartUpData], model: Model): GlobalEvent => Outcome[Model]
 
-  /** A pure function for updating your game's view model in the context of the
-    * running frame and the events acting upon it.
+  /** A pure function for updating your game's view model in the context of the running frame and the events acting upon
+    * it.
     *
-    * @param context The context the frame should be produced in, including the time,
-    *                input state, a dice instance, the state of the inputs, and a
-    *                read only reference to your start up data.
-    * @param model The latest version of the model to read from.
-    * @param viewModel The latest version of the view model to read from.
-    * @return A function that maps GlobalEvent's to the next version of your view model,
-    *         and encapsuates failures or resulting events within the Outcome wrapper.
+    * @param context
+    *   The context the frame should be produced in, including the time, input state, a dice instance, the state of the
+    *   inputs, and a read only reference to your start up data.
+    * @param model
+    *   The latest version of the model to read from.
+    * @param viewModel
+    *   The latest version of the view model to read from.
+    * @return
+    *   A function that maps GlobalEvent's to the next version of your view model, and encapsuates failures or resulting
+    *   events within the Outcome wrapper.
     */
   def updateViewModel(
       context: FrameContext[StartUpData],
@@ -113,17 +126,19 @@ trait IndigoGame[BootData, StartUpData, Model, ViewModel] extends GameLauncher {
       viewModel: ViewModel
   ): GlobalEvent => Outcome[ViewModel]
 
-  /** A pure function for presenting your game. The result is a side effect
-    * free declaration of what you intend to be presented to the player next.
+  /** A pure function for presenting your game. The result is a side effect free declaration of what you intend to be
+    * presented to the player next.
     *
-    * @param context The context the frame should be produced in, including the time,
-    *                input state, a dice instance, the state of the inputs, and a
-    *                read only reference to your start up data.
-    * @param model The latest version of the model to read from.
-    * @param viewModel The latest version of the view model to read from.
-    * @return A function that produces a description of what to present next,
-    *         and encapsuates failures or resulting events within the Outcome
-    *         wrapper.
+    * @param context
+    *   The context the frame should be produced in, including the time, input state, a dice instance, the state of the
+    *   inputs, and a read only reference to your start up data.
+    * @param model
+    *   The latest version of the model to read from.
+    * @param viewModel
+    *   The latest version of the view model to read from.
+    * @return
+    *   A function that produces a description of what to present next, and encapsuates failures or resulting events
+    *   within the Outcome wrapper.
     */
   def present(context: FrameContext[StartUpData], model: Model, viewModel: ViewModel): Outcome[SceneUpdateFragment]
 
@@ -169,8 +184,8 @@ trait IndigoGame[BootData, StartUpData, Model, ViewModel] extends GameLauncher {
   }
 
   @SuppressWarnings(Array("scalafix:DisableSyntax.throw"))
-  final protected def ready(parentElementId: String, flags: Map[String, String]): Unit =
-    boot(flags) match {
+  final protected def ready(parentElementId: String, flags: Map[String, String]): GameEngine[StartUpData, Model, ViewModel] =
+    boot(flags) match
       case oe @ Outcome.Error(e, _) =>
         IndigoLogger.error("Error during boot - Halting")
         IndigoLogger.error(oe.reportCrash)
@@ -178,6 +193,5 @@ trait IndigoGame[BootData, StartUpData, Model, ViewModel] extends GameLauncher {
 
       case Outcome.Result(b, evts) =>
         indigoGame(b).start(parentElementId, b.gameConfig, Future(None), b.assets, Future(Set()), evts)
-    }
 
 }

--- a/indigo/indigo/src/main/scala/indigo/IndigoSandbox.scala
+++ b/indigo/indigo/src/main/scala/indigo/IndigoSandbox.scala
@@ -8,91 +8,87 @@ import org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits._
 
 import scala.concurrent.Future
 
-/**
-  * A trait representing a minimal set of functions to get your game running
+/** A trait representing a minimal set of functions to get your game running
   *
-  * @example `object MyGame extends IndigoSandbox[StartUpData, Model]`
+  * @example
+  *   `object MyGame extends IndigoSandbox[StartUpData, Model]`
   *
-  * @tparam StartUpData The class type representing your successful startup data
-  * @tparam Model The class type representing your game's model
+  * @tparam StartUpData
+  *   The class type representing your successful startup data
+  * @tparam Model
+  *   The class type representing your game's model
   */
-trait IndigoSandbox[StartUpData, Model] extends GameLauncher {
+trait IndigoSandbox[StartUpData, Model] extends GameLauncher[StartUpData, Model, Unit] {
 
-  /**
-    * Your game's configuration settings.
+  /** Your game's configuration settings.
     */
   val config: GameConfig
 
-  /**
-    * A fixed set of assets that will be loaded before the game starts
+  /** A fixed set of assets that will be loaded before the game starts
     */
   val assets: Set[AssetType]
 
-  /**
-    * A fixed set of fonts that your game will be able to render
+  /** A fixed set of fonts that your game will be able to render
     */
   val fonts: Set[FontInfo]
 
-  /**
-    * A fixed set of animations your game will be able to play
+  /** A fixed set of animations your game will be able to play
     */
   val animations: Set[Animation]
 
-  /**
-    * A fixed set of custom shaders you will be able to render with
+  /** A fixed set of custom shaders you will be able to render with
     */
   val shaders: Set[Shader]
 
-  /**
-    * The `setup` function is your only opportunity to do an initial work
-    * to set up your game. For example, perhaps one of your assets was a
-    * JSON description of a map or an animation sequence, you could process
-    * that now, which is why you have access to the `AssetCollection` object.
-    * `setup` is typically only called when new assets are loaded. In a simple
-    * game this may only be once, but if assets are dynamically loaded, set up
-    * will be called again.
+  /** The `setup` function is your only opportunity to do an initial work to set up your game. For example, perhaps one
+    * of your assets was a JSON description of a map or an animation sequence, you could process that now, which is why
+    * you have access to the `AssetCollection` object. `setup` is typically only called when new assets are loaded. In a
+    * simple game this may only be once, but if assets are dynamically loaded, set up will be called again.
     *
-    * @param assetCollection Access to the Asset collection in order to,
-    *                        for example, parse text files.
-    * @param dice Psuedorandom number generator
-    * @return Return start up data, which can include animations and fonts
-    *         that could not be declared statically declared.
+    * @param assetCollection
+    *   Access to the Asset collection in order to, for example, parse text files.
+    * @param dice
+    *   Psuedorandom number generator
+    * @return
+    *   Return start up data, which can include animations and fonts that could not be declared statically declared.
     */
   def setup(assetCollection: AssetCollection, dice: Dice): Outcome[Startup[StartUpData]]
 
-  /**
-    * Set up of your initial model state
+  /** Set up of your initial model state
     *
-    * @param startupData Access to Startup data in case you need it for the model
-    * @return An instance of your game model
+    * @param startupData
+    *   Access to Startup data in case you need it for the model
+    * @return
+    *   An instance of your game model
     */
   def initialModel(startupData: StartUpData): Outcome[Model]
 
-  /**
-    * A pure function for updating your game's model in the context of the
-    * running frame and the events acting upon it.
+  /** A pure function for updating your game's model in the context of the running frame and the events acting upon it.
     *
-    * @param context The context the frame should be produced in, including the time,
-    *                input state, a dice instance, the state of the inputs, and a
-    *                read only reference to your start up data.
-    * @param model The latest version of the model to read from.
-    * @return A function that maps GlobalEvent's to the next version of your model,
-    *         and encapsuates failures or resulting events within the Outcome wrapper.
+    * @param context
+    *   The context the frame should be produced in, including the time, input state, a dice instance, the state of the
+    *   inputs, and a read only reference to your start up data.
+    * @param model
+    *   The latest version of the model to read from.
+    * @return
+    *   A function that maps GlobalEvent's to the next version of your model, and encapsuates failures or resulting
+    *   events within the Outcome wrapper.
     */
   def updateModel(context: FrameContext[StartUpData], model: Model): GlobalEvent => Outcome[Model]
 
-  /**
-    * A pure function for presenting your game. The result is a side effect
-    * free declaration of what you intend to be presented to the player next.
+  /** A pure function for presenting your game. The result is a side effect free declaration of what you intend to be
+    * presented to the player next.
     *
-    * @param context The context the frame should be produced in, including the time,
-    *                input state, a dice instance, the state of the inputs, and a
-    *                read only reference to your start up data.
-    * @param model The latest version of the model to read from.
-    * @param viewModel The latest version of the view model to read from.
-    * @return A function that produces a description of what to present next,
-    *         and encapsuates failures or resulting events within the Outcome
-    *         wrapper.
+    * @param context
+    *   The context the frame should be produced in, including the time, input state, a dice instance, the state of the
+    *   inputs, and a read only reference to your start up data.
+    * @param model
+    *   The latest version of the model to read from.
+    * @param viewModel
+    *   The latest version of the view model to read from.
+    * @return
+    *   A function that produces a description of what to present next, and encapsuates failures or resulting events
+    *   within the Outcome wrapper.
     */
   def present(context: FrameContext[StartUpData], model: Model): Outcome[SceneUpdateFragment]
 
@@ -128,7 +124,7 @@ trait IndigoSandbox[StartUpData, Model] extends GameLauncher {
     )
   }
 
-  final protected def ready(parentElementId: String, flags: Map[String, String]): Unit =
+  final protected def ready(parentElementId: String, flags: Map[String, String]): GameEngine[StartUpData, Model, Unit] =
     indigoGame.start(parentElementId, config, Future(None), assets, Future(Set()), Nil)
 
 }

--- a/indigo/indigo/src/main/scala/indigo/gameengine/GameEngine.scala
+++ b/indigo/indigo/src/main/scala/indigo/gameengine/GameEngine.scala
@@ -85,6 +85,31 @@ final class GameEngine[StartUpData, GameModel, ViewModel](
   var platform: Platform = null
 
   @SuppressWarnings(Array("scalafix:DisableSyntax.null"))
+  def kill(): Unit =
+    platform.kill()
+    gameLoopInstance.kill()
+    animationsRegister.kill()
+    fontRegister.kill()
+    shaderRegister.kill()
+    shaderRegister.kill()
+    boundaryLocator.purgeCache()
+    sceneProcessor.purgeCaches()
+    audioPlayer.kill()
+    globalEventStream.kill()
+
+    gameConfig = null
+    storage = null
+    globalEventStream = null
+    gamepadInputCapture = null
+    gameLoopInstance = null
+    accumulatedAssetCollection = null
+    assetMapping = null
+    renderer = null
+    startUpData = null.asInstanceOf[StartUpData]
+    platform = null
+    ()
+
+  @SuppressWarnings(Array("scalafix:DisableSyntax.null"))
   def start(
       parentElementId: String,
       config: GameConfig,
@@ -92,7 +117,7 @@ final class GameEngine[StartUpData, GameModel, ViewModel](
       assets: Set[AssetType],
       assetsAsync: Future[Set[AssetType]],
       bootEvents: List[GlobalEvent]
-  ): Unit = {
+  ): GameEngine[StartUpData, GameModel, ViewModel] = {
 
     IndigoLogger.info("Starting Indigo")
 
@@ -131,6 +156,8 @@ final class GameEngine[StartUpData, GameModel, ViewModel](
       }
 
     }
+
+    this
   }
 
   @SuppressWarnings(Array("scalafix:DisableSyntax.throw"))
@@ -164,7 +191,11 @@ final class GameEngine[StartUpData, GameModel, ViewModel](
 
           GameEngine.registerAnimations(animationsRegister, animations ++ startupData.additionalAnimations)
           GameEngine.registerFonts(fontRegister, fonts ++ startupData.additionalFonts)
-          GameEngine.registerShaders(shaderRegister, shaders ++ startupData.additionalShaders, accumulatedAssetCollection)
+          GameEngine.registerShaders(
+            shaderRegister,
+            shaders ++ startupData.additionalShaders,
+            accumulatedAssetCollection
+          )
 
           def modelToUse(startUpSuccessData: => StartUpData): Outcome[GameModel] =
             if (firstRun) initialModel(startUpSuccessData)

--- a/indigo/indigo/src/main/scala/indigo/gameengine/GameLoop.scala
+++ b/indigo/indigo/src/main/scala/indigo/gameengine/GameLoop.scala
@@ -34,6 +34,8 @@ final class GameLoop[StartUpData, GameModel, ViewModel](
   private var _runningTimeReference: Long = 0
   @SuppressWarnings(Array("scalafix:DisableSyntax.var"))
   private var _inputState: InputState = InputState.default
+  @SuppressWarnings(Array("scalafix:DisableSyntax.var"))
+  private var _running: Boolean = true
 
   def gameModelState: GameModel  = _gameModelState
   def viewModelState: ViewModel  = _viewModelState
@@ -53,10 +55,19 @@ final class GameLoop[StartUpData, GameModel, ViewModel](
             gameEngine.platform.tick(gameEngine.gameLoop(time))
           else gameEngine.platform.tick(loop(lastUpdateTime))
 
+  @SuppressWarnings(Array("scalafix:DisableSyntax.null"))
+  def kill(): Unit =
+    _running = false
+    _gameModelState = null.asInstanceOf[GameModel]
+    _viewModelState = null.asInstanceOf[ViewModel]
+    _runningTimeReference = 0
+    _inputState = null
+    ()
+
   def loop(lastUpdateTime: Long): Long => Unit = { time =>
     _runningTimeReference = time
     val timeDelta: Long = time - lastUpdateTime
-    runner(time, timeDelta, lastUpdateTime)
+    if _running then runner(time, timeDelta, lastUpdateTime)
   }
 
   @SuppressWarnings(Array("scalafix:DisableSyntax.throw"))

--- a/indigo/indigo/src/main/scala/indigo/platform/audio/AudioPlayer.scala
+++ b/indigo/indigo/src/main/scala/indigo/platform/audio/AudioPlayer.scala
@@ -176,6 +176,14 @@ final class AudioPlayer(context: AudioContextProxy) {
         }
       }
 
+  @SuppressWarnings(Array("scalafix:DisableSyntax.null"))
+  def kill(): Unit =
+    soundAssets = Nil
+    sourceA = null
+    sourceB = null
+    sourceC = null
+    ()
+
   private class AudioSourceState(val bindingKey: BindingKey, val audioNodes: Option[AudioNodes])
   private class AudioNodes(val audioBufferSourceNode: AudioBufferSourceNode, val gainNode: GainNode)
 

--- a/indigo/indigo/src/main/scala/indigo/platform/events/GlobalEventStream.scala
+++ b/indigo/indigo/src/main/scala/indigo/platform/events/GlobalEventStream.scala
@@ -30,6 +30,10 @@ final class GlobalEventStream(
   private val eventQueue: mutable.Queue[GlobalEvent] =
     new mutable.Queue[GlobalEvent]()
 
+  def kill(): Unit =
+    eventQueue.clear()
+    ()
+
   val pushGlobalEvent: GlobalEvent => Unit = {
     // Networking
     case httpRequest: HttpRequest =>

--- a/indigo/indigo/src/main/scala/indigo/platform/events/WorldEvents.scala
+++ b/indigo/indigo/src/main/scala/indigo/platform/events/WorldEvents.scala
@@ -10,7 +10,7 @@ import org.scalajs.dom.document
 import org.scalajs.dom.html
 import org.scalajs.dom.window
 
-object WorldEvents {
+final class WorldEvents:
 
   def absoluteCoordsX(relativeX: Double): Int = {
     val offset: Double =
@@ -118,4 +118,14 @@ object WorldEvents {
 
   }
 
-}
+  def kill(canvas: html.Canvas): Unit = {
+    canvas.removeEventListener("click", (e: dom.MouseEvent) => ())
+    canvas.removeEventListener("wheel", (e: dom.WheelEvent) => ())
+    canvas.removeEventListener("mousemove", (e: dom.MouseEvent) => ())
+    canvas.removeEventListener("mousedown", (e: dom.MouseEvent) => ())
+    canvas.removeEventListener("mouseup", (e: dom.MouseEvent) => ())
+    document.removeEventListener("keydown", (e: dom.KeyboardEvent) => ())
+    document.removeEventListener("keyup", (e: dom.KeyboardEvent) => ())
+  }
+
+end WorldEvents

--- a/indigo/indigo/src/main/scala/indigo/shared/AnimationsRegister.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/AnimationsRegister.scala
@@ -10,8 +10,13 @@ import indigo.shared.time.GameTime
 
 final class AnimationsRegister:
 
-  private val animationRegistry: scalajs.js.Dictionary[AnimationRef] = scalajs.js.Dictionary.empty
+  private val animationRegistry: scalajs.js.Dictionary[AnimationRef]   = scalajs.js.Dictionary.empty
   private val animationStates: scalajs.js.Dictionary[AnimationMemento] = scalajs.js.Dictionary.empty
+
+  def kill(): Unit =
+    animationRegistry.clear()
+    animationStates.clear()
+    ()
 
   def register(animation: Animation): Unit = {
     animationRegistry.put(animation.animationKey.toString, AnimationRef.fromAnimation(animation))

--- a/indigo/indigo/src/main/scala/indigo/shared/FontRegister.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/FontRegister.scala
@@ -7,6 +7,9 @@ final class FontRegister {
 
   implicit private val cache: QuickCache[FontInfo] = QuickCache.empty
 
+  def kill(): Unit =
+    clearRegister()
+
   def register(fontInfo: FontInfo): Unit = {
     QuickCache(fontInfo.fontKey.toString)(fontInfo)
     ()

--- a/indigo/indigo/src/main/scala/indigo/shared/shader/ShaderRegister.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/shader/ShaderRegister.scala
@@ -7,6 +7,9 @@ final class ShaderRegister {
 
   implicit private val cache: QuickCache[RawShaderCode] = QuickCache.empty
 
+  def kill(): Unit =
+    clearRegister()
+
   def register(shader: Shader): Unit =
     shader match {
       case s: EntityShader.Source =>


### PR DESCRIPTION
This PR adds the ability to call `IndigoGame.halt()` either from JavaScript or from Scala.

If you're running more than one game on a page you would need to have stored the game instances somewhere, but that's an implementation detail.

When you call halt, the engine prevents any further tick calls or requests for animation frames. If also attempts to clean itself up and release memory. I don't _think_ we can do a perfect job here, but it has a good go.