### PR TITLE
Override Key.hashCode to be compatible with equals.

### DIFF
--- a/indigo/indigo/src/main/scala/indigo/shared/constants/Key.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/constants/Key.scala
@@ -20,6 +20,7 @@ final case class Key(code: Int, key: String) derives CanEqual {
       case _ => false
     }
 
+  override def hashCode: Int = code
 }
 
 object Key {

--- a/indigo/indigo/src/test/scala/indigo/shared/constants/Key.scala
+++ b/indigo/indigo/src/test/scala/indigo/shared/constants/Key.scala
@@ -1,0 +1,14 @@
+package indigo.shared.constants
+
+class KeyTests extends munit.FunSuite {
+  private val upperJ = Key(74, "J")
+  private val lowerJ = Key(74, "j")
+
+  test("Key.equals is case-insensitive") {
+    assertEquals(upperJ, lowerJ)
+  }
+
+  test("Key.hashCode is case-insensitive") {
+    assertEquals(upperJ.hashCode, lowerJ.hashCode)
+  }
+}


### PR DESCRIPTION
fixes #347