### PR TITLE
Small rectangles now overlap correctly

### DIFF
--- a/indigo/indigo/src/main/scala/indigo/shared/datatypes/Rectangle.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/datatypes/Rectangle.scala
@@ -23,8 +23,8 @@ final case class Rectangle(position: Point, size: Size) derives CanEqual:
   lazy val center: Point      = Point(horizontalCenter, verticalCenter)
   lazy val halfSize: Size     = (size / 2).abs
 
-  lazy private val halfWidth: Double = (size.width / 2.0).abs
-  lazy private val halfHeight: Double = (size.height / 2.0).abs
+  lazy private val halfWidth: Double = (size.width * 0.5).abs
+  lazy private val halfHeight: Double = (size.height * 0.5).abs
 
   lazy val corners: List[Point] =
     List(topLeft, topRight, bottomRight, bottomLeft)

--- a/indigo/indigo/src/main/scala/indigo/shared/datatypes/Rectangle.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/datatypes/Rectangle.scala
@@ -23,6 +23,9 @@ final case class Rectangle(position: Point, size: Size) derives CanEqual:
   lazy val center: Point      = Point(horizontalCenter, verticalCenter)
   lazy val halfSize: Size     = (size / 2).abs
 
+  lazy private val halfWidth: Double = (size.width / 2.0).abs
+  lazy private val halfHeight: Double = (size.height / 2.0).abs
+
   lazy val corners: List[Point] =
     List(topLeft, topRight, bottomRight, bottomLeft)
 
@@ -171,5 +174,5 @@ object Rectangle:
     b.x >= a.x && b.y >= a.y && (b.width + (b.x - a.x)) <= a.width && (b.height + (b.y - a.y)) <= a.height
 
   def overlapping(a: Rectangle, b: Rectangle): Boolean =
-    Math.abs(a.center.x - b.center.x) < a.halfSize.width + b.halfSize.width &&
-      Math.abs(a.center.y - b.center.y) < a.halfSize.height + b.halfSize.height
+    Math.abs(a.center.x - b.center.x) < a.halfWidth + b.halfWidth &&
+      Math.abs(a.center.y - b.center.y) < a.halfHeight + b.halfHeight

--- a/indigo/indigo/src/test/scala/indigo/shared/datatypes/RectangleTests.scala
+++ b/indigo/indigo/src/test/scala/indigo/shared/datatypes/RectangleTests.scala
@@ -175,6 +175,13 @@ class RectangleTests extends munit.FunSuite {
     assert(!Rectangle.overlapping(a, b))
   }
 
+  test("overlapping rectangles.should return true when A is more than 1 in height, but B is 1 in height.") {
+    val a = Rectangle(3, 5, 2, 2)
+    val b = Rectangle(4, 5, 2, 1)
+
+    assert(Rectangle.overlapping(a, b))
+  }
+
   test("Expand should be able to expand in size by a given amount") {
     val a = Rectangle(10, 10, 20, 20)
     val b = Rectangle(0, 10, 100, 5)


### PR DESCRIPTION
Previously small rectangles would sometimes report that they weren't overlapping, when in fat they were. This PR fixes that by making use of half sizes that are doubles rather than ints