### PR TITLE
Fixed #359: Option to use non-global Electron

### DIFF
--- a/demos/pirate/build.sbt
+++ b/demos/pirate/build.sbt
@@ -1,3 +1,7 @@
+import indigoplugin.ElectronInstall
+
+Global / onChangedBuildSource := ReloadOnSourceChanges
+
 //-----------------------------------
 // The essentials.
 //-----------------------------------
@@ -31,6 +35,7 @@ lazy val pirate =
       windowStartWidth      := 1280,
       windowStartHeight     := 720,
       disableFrameRateLimit := false,
+      electronInstall       := ElectronInstall.Global,
       libraryDependencies ++= Seq(
         "io.indigoengine" %%% "indigo-json-circe" % IndigoVersion.getVersion, // Needed for Aseprite & Tiled support
         "io.indigoengine" %%% "indigo"            % IndigoVersion.getVersion, // Important! :-)

--- a/demos/snake/build.sc
+++ b/demos/snake/build.sc
@@ -13,12 +13,13 @@ object snake extends ScalaJSModule with MillIndigo {
   def scalaVersion   = "3.1.2"
   def scalaJSVersion = "1.10.0"
 
-  val gameAssetsDirectory: os.Path   = os.pwd / "assets"
-  val showCursor: Boolean            = true
-  val title: String                  = "Snake - Made with Indigo"
-  val windowStartWidth: Int          = 720
-  val windowStartHeight: Int         = 516
-  val disableFrameRateLimit: Boolean = false
+  val gameAssetsDirectory: os.Path     = os.pwd / "assets"
+  val showCursor: Boolean              = true
+  val title: String                    = "Snake - Made with Indigo"
+  val windowStartWidth: Int            = 720
+  val windowStartHeight: Int           = 516
+  val disableFrameRateLimit: Boolean   = false
+  val electronInstall: ElectronInstall = ElectronInstall.Global
 
   def buildGame() = T.command {
     T {

--- a/indigo-plugin/indigo-plugin/src/indigoplugin/ElectronInstall.scala
+++ b/indigo-plugin/indigo-plugin/src/indigoplugin/ElectronInstall.scala
@@ -1,0 +1,33 @@
+package indigoplugin
+
+sealed trait ElectronInstall {
+  def executable: String =
+    this match {
+      case ElectronInstall.Global                 => "electron"
+      case ElectronInstall.Version(_)             => "npx electron"
+      case ElectronInstall.Latest                 => "npx electron"
+      case ElectronInstall.PathToExecutable(path) => path
+    }
+
+  def devDependencies: String =
+    this match {
+      case ElectronInstall.Global                 => ""
+      case ElectronInstall.Version(version)       => s""""electron": "${version}""""
+      case ElectronInstall.Latest                 => ""
+      case ElectronInstall.PathToExecutable(path) => path
+    }
+
+  def requiresInstall: Boolean =
+    this match {
+      case ElectronInstall.Global              => false
+      case ElectronInstall.Version(_)          => true
+      case ElectronInstall.Latest              => true
+      case ElectronInstall.PathToExecutable(_) => false
+    }
+}
+object ElectronInstall {
+  case object Global                              extends ElectronInstall
+  final case class Version(version: String)       extends ElectronInstall
+  case object Latest                              extends ElectronInstall
+  final case class PathToExecutable(path: String) extends ElectronInstall
+}

--- a/indigo-plugin/indigo-plugin/src/indigoplugin/templates/ElectronTemplates.scala
+++ b/indigo-plugin/indigo-plugin/src/indigoplugin/templates/ElectronTemplates.scala
@@ -1,5 +1,7 @@
 package indigoplugin.templates
 
+import indigoplugin.ElectronInstall
+
 object ElectronTemplates {
 
   def mainFileTemplate(windowWidth: Int, windowHeight: Int): String =
@@ -51,18 +53,21 @@ app.on('window-all-closed', function () {
 // code. You can also put them in separate files and require them here.
     """
 
-  def packageFileTemplate(disableFrameRateLimit: Boolean): String =
+  def packageFileTemplate(disableFrameRateLimit: Boolean, electronInstall: ElectronInstall): String =
     s"""{
   "name": "indigo-runner",
   "version": "1.0.0",
   "description": "Indigo Runner",
   "main": "main.js",
   "scripts": {
-    "start": "electron${if(disableFrameRateLimit) " --disable-frame-rate-limit" else ""} ."
+    "start": "${electronInstall.executable}${if (disableFrameRateLimit) " --disable-frame-rate-limit" else ""} ."
   },
   "repository": "",
   "author": "Purple Kingdom Games",
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    ${electronInstall.devDependencies}
+  }
 }
     """
 

--- a/mill-indigo/mill-indigo/src/millindigo/MillIndigo.scala
+++ b/mill-indigo/mill-indigo/src/millindigo/MillIndigo.scala
@@ -35,6 +35,11 @@ trait MillIndigo extends mill.Module {
     */
   val disableFrameRateLimit: Boolean
 
+  /** How should electron be run? ElectronInstall.Global | ElectronInstall.Version(version: String) |
+    * ElectronInstall.Latest | ElectronInstall.PathToExecutable(path: String)
+    */
+  val electronInstall: ElectronInstall
+
   def indigoBuild(): Command[Path] =
     T.command {
       val scriptPathBase: Path = {
@@ -105,7 +110,7 @@ trait MillIndigo extends mill.Module {
       val outputDir: Path = T.dest
       val buildDir: Path  = indigoBuild()()
 
-      IndigoRun.run(outputDir, buildDir, title, windowStartWidth, windowStartHeight, disableFrameRateLimit)
+      IndigoRun.run(outputDir, buildDir, title, windowStartWidth, windowStartHeight, disableFrameRateLimit, electronInstall)
     }
 
   def indigoRunFull(): Command[Unit] =
@@ -113,7 +118,7 @@ trait MillIndigo extends mill.Module {
       val outputDir: Path = T.dest
       val buildDir: Path  = indigoBuildFull()()
 
-      IndigoRun.run(outputDir, buildDir, title, windowStartWidth, windowStartHeight, disableFrameRateLimit)
+      IndigoRun.run(outputDir, buildDir, title, windowStartWidth, windowStartHeight, disableFrameRateLimit, electronInstall)
     }
 
   def indigoCordovaBuild(): Command[Unit] =

--- a/mill-indigo/mill-indigo/src/millindigo/package.scala
+++ b/mill-indigo/mill-indigo/src/millindigo/package.scala
@@ -1,0 +1,6 @@
+package object millindigo {
+
+  type ElectronInstall = indigoplugin.ElectronInstall
+  val ElectronInstall: indigoplugin.ElectronInstall.type = indigoplugin.ElectronInstall
+
+}

--- a/sbt-indigo/.scalafmt.conf
+++ b/sbt-indigo/.scalafmt.conf
@@ -1,4 +1,5 @@
 version = 3.3.0
+runner.dialect = scala212
 style = defaultWithAlign
 maxColumn = 120
 rewrite.rules = [RedundantBraces,RedundantParens,PreferCurlyFors]

--- a/sbt-indigo/src/main/scala/sbtindigo/SbtIndigo.scala
+++ b/sbt-indigo/src/main/scala/sbtindigo/SbtIndigo.scala
@@ -12,40 +12,46 @@ object SbtIndigo extends sbt.AutoPlugin {
   override def trigger: PluginTrigger   = allRequirements
 
   object autoImport {
-    val indigoBuild: TaskKey[Unit]            = taskKey[Unit]("Build an Indigo game.")
-    val indigoBuildFull: TaskKey[Unit]        = taskKey[Unit]("Build an Indigo game using full compression.")
-    val indigoRun: TaskKey[Unit]              = taskKey[Unit]("Run an Indigo game.")
-    val indigoRunFull: TaskKey[Unit]          = taskKey[Unit]("Run an Indigo game that has been compressed.")
-    val indigoCordovaBuild: TaskKey[Unit]     = taskKey[Unit]("Build an Indigo game Cordova template.")
-    val indigoCordovaBuildFull: TaskKey[Unit] = taskKey[Unit]("Build an Indigo game Cordova template that has been compressed.")
+    val indigoBuild: TaskKey[Unit]        = taskKey[Unit]("Build an Indigo game.")
+    val indigoBuildFull: TaskKey[Unit]    = taskKey[Unit]("Build an Indigo game using full compression.")
+    val indigoRun: TaskKey[Unit]          = taskKey[Unit]("Run an Indigo game.")
+    val indigoRunFull: TaskKey[Unit]      = taskKey[Unit]("Run an Indigo game that has been compressed.")
+    val indigoCordovaBuild: TaskKey[Unit] = taskKey[Unit]("Build an Indigo game Cordova template.")
+    val indigoCordovaBuildFull: TaskKey[Unit] =
+      taskKey[Unit]("Build an Indigo game Cordova template that has been compressed.")
     val gameAssetsDirectory: SettingKey[String] =
       settingKey[String]("Project relative path to a directory that contains all of the assets the game needs to load.")
     val showCursor: SettingKey[Boolean]    = settingKey[Boolean]("Show the cursor? True by default.")
     val title: SettingKey[String]          = settingKey[String]("Title of your game. Defaults to 'Made with Indigo'.")
     val windowStartWidth: SettingKey[Int]  = settingKey[Int]("Initial window width. Defaults to 550 pixels.")
     val windowStartHeight: SettingKey[Int] = settingKey[Int]("Initial window height. Defaults to 400 pixels.")
-    val disableFrameRateLimit: SettingKey[Boolean] = settingKey[Boolean]("If possible, disables the runtime's frame rate limit. Defaults to false.")
+    val disableFrameRateLimit: SettingKey[Boolean] =
+      settingKey[Boolean]("If possible, disables the runtime's frame rate limit. Defaults to false.")
+    val electronInstall: SettingKey[ElectronInstall] = settingKey[ElectronInstall](
+      "How should electron be run? `ElectronInstall.Global | ElectronInstall.Version(version: String) | ElectronInstall.Latest | ElectronInstall.PathToExecutable(path: String)`. Defaults to ElectronInstall.Global."
+    )
   }
 
   import autoImport._
 
   override lazy val projectSettings = Seq(
-    indigoBuild := { indigoBuildTask.value; () },
-    indigoBuildFull := { indigoBuildFullTask.value; () },
-    indigoRun := indigoRunTask.value,
-    indigoRunFull := indigoRunFullTask.value,
-    indigoCordovaBuild := indigoCordovaBuildTask.value,
+    indigoBuild            := { indigoBuildTask.value; () },
+    indigoBuildFull        := { indigoBuildFullTask.value; () },
+    indigoRun              := indigoRunTask.value,
+    indigoRunFull          := indigoRunFullTask.value,
+    indigoCordovaBuild     := indigoCordovaBuildTask.value,
     indigoCordovaBuildFull := indigoCordovaBuildFullTask.value,
-    showCursor := true,
-    title := "Made with Indigo",
-    gameAssetsDirectory := ".",
-    windowStartWidth := 550,
-    windowStartHeight := 400,
-    disableFrameRateLimit := false
+    showCursor             := true,
+    title                  := "Made with Indigo",
+    gameAssetsDirectory    := ".",
+    windowStartWidth       := 550,
+    windowStartHeight      := 400,
+    disableFrameRateLimit  := false,
+    electronInstall        := indigoplugin.ElectronInstall.Global
   )
 
   def giveScriptBasePath(baseDir: String, scalaVersion: String): String =
-    if(scalaVersion.startsWith("2"))
+    if (scalaVersion.startsWith("2"))
       s"$baseDir/target/scala-${scalaVersion.split('.').reverse.tail.reverse.mkString(".")}"
     else
       s"$baseDir/target/scala-${scalaVersion}"
@@ -126,7 +132,8 @@ object SbtIndigo extends sbt.AutoPlugin {
         title = title.value,
         windowWidth = windowStartWidth.value,
         windowHeight = windowStartHeight.value,
-        disableFrameRateLimit = disableFrameRateLimit.value
+        disableFrameRateLimit = disableFrameRateLimit.value,
+        electronInstall = electronInstall.value
       )
     }
 
@@ -142,7 +149,8 @@ object SbtIndigo extends sbt.AutoPlugin {
         title = title.value,
         windowWidth = windowStartWidth.value,
         windowHeight = windowStartHeight.value,
-        disableFrameRateLimit = disableFrameRateLimit.value
+        disableFrameRateLimit = disableFrameRateLimit.value,
+        electronInstall = electronInstall.value
       )
     }
 

--- a/sbt-indigo/src/main/scala/sbtindigo/package.scala
+++ b/sbt-indigo/src/main/scala/sbtindigo/package.scala
@@ -1,0 +1,6 @@
+package object sbtindigo {
+
+  type ElectronInstall = indigoplugin.ElectronInstall
+  val ElectronInstall: indigoplugin.ElectronInstall.type = indigoplugin.ElectronInstall
+
+}


### PR DESCRIPTION
This PR adds a new configuration option to the Indigo plugin (both Mill and sbt) to change how Electron is installed and invoked, like this (Mill shown here):

```scala
// (Pick one...) 
val electronInstall = ElectronInstall.Latest // will install and use version 18.0.0+
val electronInstall = ElectronInstall.Version("^17.0.0") // will install and use 17.0.0+
val electronInstall = ElectronInstall.Global // will use the globally installed version
val electronInstall = ElectronInstall.PathToExecutable(path) // Assumes you know what you're doing...
```

Defaults to global for two reasons:

1. Doesn't break existing experience
2. Local installs are slower and rather inefficient

Regarding the inefficiency, there might be a future piece of work to make all this significantly more performant, but I decided not to do that yet - if anyone wants it I'm sure an issue can be raised. Essentially if we build the npm deps as part of the build DAG then it can be cached and reused.