### PR TITLE
Fixed #379: Do no reinstall local electron

### DIFF
--- a/indigo-plugin/indigo-plugin/src/indigoplugin/ElectronInstall.scala
+++ b/indigo-plugin/indigo-plugin/src/indigoplugin/ElectronInstall.scala
@@ -1,11 +1,12 @@
 package indigoplugin
 
 sealed trait ElectronInstall {
+
   def executable: String =
     this match {
       case ElectronInstall.Global                 => "electron"
-      case ElectronInstall.Version(_)             => "npx electron"
-      case ElectronInstall.Latest                 => "npx electron"
+      case ElectronInstall.Version(_)             => "npx --no-install electron"
+      case ElectronInstall.Latest                 => "npx --no-install electron"
       case ElectronInstall.PathToExecutable(path) => path
     }
 
@@ -17,13 +18,6 @@ sealed trait ElectronInstall {
       case ElectronInstall.PathToExecutable(path) => path
     }
 
-  def requiresInstall: Boolean =
-    this match {
-      case ElectronInstall.Global              => false
-      case ElectronInstall.Version(_)          => true
-      case ElectronInstall.Latest              => true
-      case ElectronInstall.PathToExecutable(_) => false
-    }
 }
 object ElectronInstall {
   case object Global                              extends ElectronInstall

--- a/indigo-plugin/indigo-plugin/src/indigoplugin/IndigoRun.scala
+++ b/indigo-plugin/indigo-plugin/src/indigoplugin/IndigoRun.scala
@@ -8,6 +8,12 @@ import indigoplugin.templates.SupportScriptTemplate
 
 object IndigoRun {
 
+  private val installingNPMDepsMessage: String =
+    " > Installing NPM dependencies"
+
+  private val usingInstalledNPMDepsMessage: String =
+    " > Using already installed NPM dependencies"
+
   def run(
       outputDir: Path,
       buildDir: Path,
@@ -18,7 +24,6 @@ object IndigoRun {
       electronInstall: ElectronInstall
   ): Unit = {
 
-    os.remove.all(outputDir)
     os.makeDir.all(outputDir)
 
     filesToWrite(windowWidth, windowHeight, disableFrameRateLimit, electronInstall).foreach { f =>
@@ -26,7 +31,7 @@ object IndigoRun {
     }
 
     os.list(buildDir).foreach { file =>
-      CustomOSLibCopy.copyInto(file, outputDir, true, true, true, true, false)
+      CustomOSLibCopy.copyInto(file, outputDir, true, true, true, true, true)
     }
 
     // Write support js script
@@ -44,12 +49,22 @@ object IndigoRun {
             IndigoProc.Windows.npmStart(outputDir)
 
           case ElectronInstall.Version(_) =>
-            IndigoProc.Windows.npmInstall(outputDir)
+            if (!os.exists(outputDir / "node_modules" / "electron")) {
+              println(installingNPMDepsMessage)
+              IndigoProc.Windows.npmInstall(outputDir)
+            } else {
+              println(usingInstalledNPMDepsMessage)
+            }
             IndigoProc.Windows.npmStart(outputDir)
 
           case ElectronInstall.Latest =>
-            IndigoProc.Windows.installLatestElectron(outputDir)
-            IndigoProc.Windows.npmInstall(outputDir)
+            if (!os.exists(outputDir / "node_modules" / "electron")) {
+              println(installingNPMDepsMessage)
+              IndigoProc.Windows.installLatestElectron(outputDir)
+              IndigoProc.Windows.npmInstall(outputDir)
+            } else {
+              println(usingInstalledNPMDepsMessage)
+            }
             IndigoProc.Windows.npmStart(outputDir)
 
           case ElectronInstall.PathToExecutable(path) =>
@@ -62,12 +77,22 @@ object IndigoRun {
             IndigoProc.Nix.npmStart(outputDir)
 
           case ElectronInstall.Version(_) =>
-            IndigoProc.Nix.npmInstall(outputDir)
+            if (!os.exists(outputDir / "node_modules" / "electron")) {
+              println(installingNPMDepsMessage)
+              IndigoProc.Nix.npmInstall(outputDir)
+            } else {
+              println(usingInstalledNPMDepsMessage)
+            }
             IndigoProc.Nix.npmStart(outputDir)
 
           case ElectronInstall.Latest =>
-            IndigoProc.Nix.installLatestElectron(outputDir)
-            IndigoProc.Nix.npmInstall(outputDir)
+            if (!os.exists(outputDir / "node_modules" / "electron")) {
+              println(installingNPMDepsMessage)
+              IndigoProc.Nix.installLatestElectron(outputDir)
+              IndigoProc.Nix.npmInstall(outputDir)
+            } else {
+              println(usingInstalledNPMDepsMessage)
+            }
             IndigoProc.Nix.npmStart(outputDir)
 
           case ElectronInstall.PathToExecutable(path) =>


### PR DESCRIPTION
Fixes: https://github.com/PurpleKingdomGames/indigo/issues/379

Makes using a locally installed version of Electron as fast as a globally installed. Local installs work much better on some systems, anecdotally Windows, but for example I'm on Linux installing the global electron with Nix, and that version is very slow for reasons I do not understand. :grin: 