### PR TITLE
Bugfix aseprite json

### DIFF
--- a/indigo/docs/platform/importers.md
+++ b/indigo/docs/platform/importers.md
@@ -21,7 +21,7 @@ Graphics can be exported as any web compatible file format. One thing to be awar
 
 Animations can also be exported as a spritesheet with accompanying JSON data, here is an example of the export window.
 
-**PLEASE NOTE:** The export is done as a "hash", Indigo does not support the other "array" option.
+**PLEASE NOTE:** The export is done as an "array", Indigo does not support the other "hash" option.
 
 ![Aseprite export dialogue window](/img/aseprite_export.png "Aseprite export dialogue window")
 

--- a/indigo/indigo-json-circe/src/main/scala/indigo/json/core/CirceJsonEncodersAndDecoders.scala
+++ b/indigo/indigo-json-circe/src/main/scala/indigo/json/core/CirceJsonEncodersAndDecoders.scala
@@ -47,12 +47,11 @@ object CirceJsonEncodersAndDecoders {
         for {
           app       <- c.downField("app").as[String]
           version   <- c.downField("version").as[String]
-          image     <- c.downField("image").as[String]
           format    <- c.downField("format").as[String]
           size      <- c.downField("size").as[AsepriteSize]
           scale     <- c.downField("scale").as[String]
           frameTags <- c.downField("frameTags").as[List[AsepriteFrameTag]]
-        } yield AsepriteMeta(app, version, image, format, size, scale, frameTags)
+        } yield AsepriteMeta(app, version, format, size, scale, frameTags)
     }
 
   implicit val decodeAsepriteSize: Decoder[AsepriteSize] =

--- a/indigo/indigo-json-circe/src/test/scala/indigo/json/JsonTests.scala
+++ b/indigo/indigo-json-circe/src/test/scala/indigo/json/JsonTests.scala
@@ -173,7 +173,6 @@ object AsepriteSampleData {
       meta = AsepriteMeta(
         app = "http://www.aseprite.org/",
         version = "1.1.13",
-        image = "/Users/dave/repos/indigo/sandbox/trafficlights.png",
         format = "RGBA8888",
         size = AsepriteSize(128, 128),
         scale = "1",

--- a/indigo/indigo/src/main/scala/indigo/shared/formats/Aseprite.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/formats/Aseprite.scala
@@ -52,7 +52,6 @@ final case class AsepriteRectangle(x: Int, y: Int, w: Int, h: Int) derives CanEq
 final case class AsepriteMeta(
     app: String,
     version: String,
-    image: String,
     format: String,
     size: AsepriteSize,
     scale: String,

--- a/indigo/indigo/src/test/scala/indigo/shared/formats/AsepriteTests.scala
+++ b/indigo/indigo/src/test/scala/indigo/shared/formats/AsepriteTests.scala
@@ -139,7 +139,6 @@ object AsepriteSampleData {
       meta = AsepriteMeta(
         app = "http://www.aseprite.org/",
         version = "1.1.13",
-        image = "/Users/dave/repos/indigo/sandbox/trafficlights.png",
         format = "RGBA8888",
         size = AsepriteSize(128, 128),
         scale = "1",


### PR DESCRIPTION
I encountered a couple problems with the aseprite importer. firstly, when I exported my sprite sheet's JSON, it lacked a field for `AsepriteMeta.image`, which caused the decoding process to fail. it appears that that field is [optional,](https://github.com/aseprite/aseprite/blob/e6c90334f96f9553288c8b1bea2e654238e8816a/src/app/doc_exporter.cpp#L1297) though I don't actually know exactly what triggers it. at any rate, indigo doesn't seem to use that field, so I propose removing it.

secondly, the documentation mentions that only the aseprite's hash format is supported, however the required `AsepriteFrame.filename` field seems to be only present in the array export format (that field's value is used as the key in hash exports). this leads me to  strongly suspect this was a simple typo, as importing the array JSON works fine, so I fixed the relevant documentation as well.