### PR TITLE
Reset lastFrameAdvance after an AnimationAction.jumpTo

### DIFF
--- a/indigo/indigo/src/main/scala/indigo/shared/animation/AnimationRef.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/animation/AnimationRef.scala
@@ -118,13 +118,13 @@ final case class CycleRef(
           cycle // No op, done at animation level.
 
         case JumpToFirstFrame =>
-          updatePlayheadAndLastAdvance(0, lastFrameAdvance)
+          updatePlayheadAndLastAdvance(0, gameTime.running.toMillis)
 
         case JumpToLastFrame =>
-          updatePlayheadAndLastAdvance(frameCount - 1, lastFrameAdvance)
+          updatePlayheadAndLastAdvance(frameCount - 1, gameTime.running.toMillis)
 
         case JumpToFrame(number) =>
-          updatePlayheadAndLastAdvance(if (number > frameCount - 1) frameCount - 1 else number, lastFrameAdvance)
+          updatePlayheadAndLastAdvance(if (number > frameCount - 1) frameCount - 1 else number, gameTime.running.toMillis)
 
       }
     }

--- a/indigo/indigo/src/test/scala/indigo/shared/animation/AnimationRefTests.scala
+++ b/indigo/indigo/src/test/scala/indigo/shared/animation/AnimationRefTests.scala
@@ -2,6 +2,7 @@ package indigo.shared.animation
 
 import indigo.shared.collections.Batch
 import indigo.shared.datatypes._
+import indigo.shared.time.GameTime
 import indigo.shared.time.Millis
 
 class AnimationRefTests extends munit.FunSuite {
@@ -82,6 +83,28 @@ class AnimationRefTests extends munit.FunSuite {
     assertEquals(updated.currentCycle.lastFrameAdvance, Millis(300))
 
     assertEquals(expected == actual, true)
+
+  }
+
+  test("AnimationAction.JumpToFrame resets cycle timing") {
+
+    //convenience class to cut down on syntax noise
+    final case class Tick(a: AnimationRef, t: GameTime):
+      extension (g: GameTime) def in(d: Millis) = GameTime.withDelta(g.running + d.toSeconds, d.toSeconds)
+      def play(m: Millis) = Tick(a, t.in(m)).run(AnimationAction.Play)
+      def run(aa: AnimationAction) = Tick(a.runActions(Batch(aa), t), t)
+      val playhead = a.currentCycle.playheadPosition
+
+    val tick0 = Tick(animation, GameTime.zero)
+
+    val tick1 = tick0.play(frame1.duration / 2)
+    assertEquals(tick1.playhead, 0)
+
+    val tick2 = tick1.play(frame1.duration / 2)
+    assertEquals(tick2.playhead, 1)
+
+    val tick2alt = tick1.run(AnimationAction.JumpToFrame(0)).play(frame1.duration / 2)
+    assertEquals(tick2alt.playhead, 0)
 
   }
 


### PR DESCRIPTION
I noticed that the frame some of my animations started on seemed somewhat random, even after calling `Sprite.jumpToFirstFrame`. after doing some digging, I believe this code is the culprit. it seems the way animations in indigo work is that a timestamp is saved each time a frame advances, and when the time since that timestamp is greater than the current frame's designated duration, it flips to the next frame

if so, reusing the `lastFrameAdvance` value here seems incorrect. for example, if you call `Sprite.jumpToFirstFrame` midway through frame n, it will effectively jump to midway through frame 0 rather than the beginning, which I don't think is the expected effect. using the current time instead seems to fix the issue I was having, but it's possible there's an intentional design choice I'm not aware of, so feel free to use your discretion here