### PR TITLE
example mill template in docs is incomplete

### DIFF
--- a/indigo/docs/quickstart/setup-and-configuration.md
+++ b/indigo/docs/quickstart/setup-and-configuration.md
@@ -62,11 +62,13 @@ object mygame extends ScalaJSModule with MillIndigo {
   def scalaVersion   = "@SCALA_VERSION@"
   def scalaJSVersion = "@SCALAJS_VERSION@"
 
-  val gameAssetsDirectory: os.Path = os.pwd / "assets"
-  val showCursor: Boolean          = true
-  val title: String                = "My Game"
-  val windowStartWidth: Int        = 720 // Width of Electron window, used with `indigoRun`.
-  val windowStartHeight: Int       = 480 // Height of Electron window, used with `indigoRun`.
+  val gameAssetsDirectory: os.Path   = os.pwd / "assets"
+  val showCursor: Boolean            = true
+  val title: String                  = "My Game"
+  val windowStartWidth: Int          = 720 // Width of Electron window, used with `indigoRun`.
+  val windowStartHeight: Int         = 480 // Height of Electron window, used with `indigoRun`.
+  val disableFrameRateLimit: Boolean = false
+  val electronInstall                = indigoplugin.ElectronInstall.Global
 
   def ivyDeps = Agg(
     ivy"io.indigoengine::indigo::@VERSION@",
@@ -173,11 +175,13 @@ object mygame extends ScalaJSModule with MillIndigo {
   def scalaVersion   = "@SCALA_VERSION@"
   def scalaJSVersion = "@SCALAJS_VERSION@"
 
-  val gameAssetsDirectory: os.Path = os.pwd / "assets"
-  val showCursor: Boolean          = true
-  val title: String                = "My Game"
-  val windowStartWidth: Int        = 720 // Width of Electron window, used with `indigoRun`.
-  val windowStartHeight: Int       = 480 // Height of Electron window, used with `indigoRun`.
+  val gameAssetsDirectory: os.Path   = os.pwd / "assets"
+  val showCursor: Boolean            = true
+  val title: String                  = "My Game"
+  val windowStartWidth: Int          = 720 // Width of Electron window, used with `indigoRun`.
+  val windowStartHeight: Int         = 480 // Height of Electron window, used with `indigoRun`.
+  val disableFrameRateLimit: Boolean = false
+  val electronInstall                = indigoplugin.ElectronInstall.Global
 
   def ivyDeps = Agg(
     ivy"io.indigoengine::indigo::@VERSION@",


### PR DESCRIPTION
the "minimal build.sc" mentioned in the docs won't actually compile (even when actual version numbers are substituted in, that is) as it is missing values for two members. the solution was to copy the two missing lines from [here](https://github.com/PurpleKingdomGames/blank-indigo-mill/blob/f4aa935fe88e8f6455bcc8f4390c41c40fecfc97/build.sc). if these are not sensible defaults feel free to say so,  but I felt it was worth bringing to attention as it seems unintentional