### PR TITLE
simplification: replace SceneAudio.None with Option types

### DIFF
--- a/indigo/docs/presentation/audio.md
+++ b/indigo/docs/presentation/audio.md
@@ -52,4 +52,4 @@ SceneUpdateFragment.empty
   )
 ```
 
-A `SceneAudio` can describe up to three music channels at once, called `SceneAudioSource`s. A `SceneAudioSource` specifics a `BindingKey` to keep track of what is being played and it's progression state, and a playback pattern which at the moment can only be either `PlaybackPattern.SingleTrackLoop` or `Silent`. `SingleTrackLoop` takes a `Track` which is very similar to the `PlaySound` type above, taking an `AssetName` to tell it what to play, and optionally a `Volume`.
+A `SceneAudio` can describe up to three music channels at once, called `SceneAudioSource`s. A `SceneAudioSource` specifics a `BindingKey` to keep track of what is being played and it's progression state, and a playback pattern which at the moment can only be `PlaybackPattern.SingleTrackLoop`. `SingleTrackLoop` takes a `Track` which is very similar to the `PlaySound` type above, taking an `AssetName` to tell it what to play, and optionally a `Volume`.

--- a/indigo/indigo-extras/src/test/scala/indigoextras/jobs/JobMarketTests.scala
+++ b/indigo/indigo-extras/src/test/scala/indigoextras/jobs/JobMarketTests.scala
@@ -80,7 +80,7 @@ class JobMarketTests extends munit.FunSuite {
 
     assertEquals(market.present(context, List(job)).unsafeGet.layers.flatMap(_.nodes).isEmpty, true)
     assertEquals(market.present(context, List(job)).unsafeGlobalEvents.isEmpty, true)
-    assertEquals(market.present(context, List(job)).unsafeGet.audio, SceneAudio.None)
+    assertEquals(market.present(context, List(job)).unsafeGet.audio, None)
   }
 
   test("The job market.should have an empty subsystem representation") {

--- a/indigo/indigo/src/main/scala/indigo/shared/scenegraph/PlaybackPattern.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/scenegraph/PlaybackPattern.scala
@@ -5,5 +5,4 @@ import indigo.shared.audio.Track
 /** Scene audio can either be played on a loop, or be silenced.
   */
 enum PlaybackPattern derives CanEqual:
-  case Silent extends PlaybackPattern
   case SingleTrackLoop(track: Track) extends PlaybackPattern

--- a/indigo/indigo/src/main/scala/indigo/shared/scenegraph/SceneAudio.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/scenegraph/SceneAudio.scala
@@ -9,6 +9,8 @@ final case class SceneAudio(sourceA: Option[SceneAudioSource], sourceB: Option[S
 }
 object SceneAudio {
 
+  val Mute = SceneAudio(None, None, None)
+
   def apply(sourceA: SceneAudioSource): SceneAudio =
     SceneAudio(Some(sourceA), None, None)
 

--- a/indigo/indigo/src/main/scala/indigo/shared/scenegraph/SceneAudio.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/scenegraph/SceneAudio.scala
@@ -2,7 +2,7 @@ package indigo.shared.scenegraph
 
 /** Describes what audio is currently being played by the scene as part of a `SceneUpdateFragment`. Can play up to three audio sources at once.
  */
-final case class SceneAudio(sourceA: SceneAudioSource, sourceB: SceneAudioSource, sourceC: SceneAudioSource)
+final case class SceneAudio(sourceA: Option[SceneAudioSource], sourceB: Option[SceneAudioSource], sourceC: Option[SceneAudioSource])
     derives CanEqual {
   def |+|(other: SceneAudio): SceneAudio =
     SceneAudio.combine(this, other)
@@ -10,15 +10,12 @@ final case class SceneAudio(sourceA: SceneAudioSource, sourceB: SceneAudioSource
 object SceneAudio {
 
   def apply(sourceA: SceneAudioSource): SceneAudio =
-    SceneAudio(sourceA, SceneAudioSource.None, SceneAudioSource.None)
+    SceneAudio(Some(sourceA), None, None)
 
   def apply(sourceA: SceneAudioSource, sourceB: SceneAudioSource): SceneAudio =
-    SceneAudio(sourceA, sourceB, SceneAudioSource.None)
-
-  val None: SceneAudio =
-    SceneAudio(SceneAudioSource.None, SceneAudioSource.None, SceneAudioSource.None)
+    SceneAudio(Some(sourceA), Some(sourceB), None)
 
   def combine(a: SceneAudio, b: SceneAudio): SceneAudio =
-    SceneAudio(a.sourceA |+| b.sourceA, a.sourceB |+| b.sourceB, a.sourceC |+| b.sourceC)
+    SceneAudio(b.sourceA.orElse(a.sourceA), b.sourceB.orElse(a.sourceB), b.sourceC.orElse(a.sourceC))
 
 }

--- a/indigo/indigo/src/main/scala/indigo/shared/scenegraph/SceneAudioSource.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/scenegraph/SceneAudioSource.scala
@@ -6,28 +6,11 @@ import indigo.shared.datatypes.BindingKey
 /** Represents a single audio source, how it is being played, and at what volume. You could implement a cross fade
   * between two audio sources.
   */
-final case class SceneAudioSource(bindingKey: BindingKey, playbackPattern: PlaybackPattern, masterVolume: Volume)
-    derives CanEqual {
-  def |+|(other: SceneAudioSource): SceneAudioSource =
-    SceneAudioSource.combine(this, other)
-}
+final case class SceneAudioSource(bindingKey: BindingKey, playbackPattern: PlaybackPattern, masterVolume: Volume) derives CanEqual
+
 object SceneAudioSource {
 
   def apply(bindingKey: BindingKey, playbackPattern: PlaybackPattern): SceneAudioSource =
     SceneAudioSource(bindingKey, playbackPattern, Volume.Max)
 
-  val None: SceneAudioSource =
-    SceneAudioSource(BindingKey("none"), PlaybackPattern.Silent, Volume.Min)
-
-  def combine(a: SceneAudioSource, b: SceneAudioSource): SceneAudioSource =
-    (a, b) match {
-      case (None, y) =>
-        y
-
-      case (x, None) =>
-        x
-
-      case (_, y) =>
-        y
-    }
 }

--- a/indigo/indigo/src/main/scala/indigo/shared/scenegraph/SceneUpdateFragment.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/scenegraph/SceneUpdateFragment.scala
@@ -29,7 +29,7 @@ import annotation.targetName
 final case class SceneUpdateFragment(
     layers: Batch[Layer],
     lights: Batch[Light],
-    audio: SceneAudio,
+    audio: Option[SceneAudio],
     blendMaterial: Option[BlendMaterial],
     cloneBlanks: Batch[CloneBlank],
     camera: Option[Camera]
@@ -68,7 +68,7 @@ final case class SceneUpdateFragment(
     withLights(lights ++ newLights)
 
   def withAudio(sceneAudio: SceneAudio): SceneUpdateFragment =
-    this.copy(audio = sceneAudio)
+    this.copy(audio = Some(sceneAudio))
 
   def addCloneBlanks(blanks: CloneBlank*): SceneUpdateFragment =
     addCloneBlanks(blanks.toBatch)
@@ -100,23 +100,23 @@ object SceneUpdateFragment:
     SceneUpdateFragment(nodes.toBatch)
 
   def apply(nodes: Batch[SceneNode]): SceneUpdateFragment =
-    SceneUpdateFragment(Batch(Layer(nodes)), Batch.empty, SceneAudio.None, None, Batch.empty, None)
+    SceneUpdateFragment(Batch(Layer(nodes)), Batch.empty, None, None, Batch.empty, None)
 
   def apply(layer: Layer): SceneUpdateFragment =
-    SceneUpdateFragment(Batch(layer), Batch.empty, SceneAudio.None, None, Batch.empty, None)
+    SceneUpdateFragment(Batch(layer), Batch.empty, None, None, Batch.empty, None)
 
   @targetName("suf-apply-many-layers")
   def apply(layers: Layer*): SceneUpdateFragment =
-    SceneUpdateFragment(layers.toBatch, Batch.empty, SceneAudio.None, None, Batch.empty, None)
+    SceneUpdateFragment(layers.toBatch, Batch.empty, None, None, Batch.empty, None)
 
   val empty: SceneUpdateFragment =
-    SceneUpdateFragment(Batch.empty, Batch.empty, SceneAudio.None, None, Batch.empty, None)
+    SceneUpdateFragment(Batch.empty, Batch.empty, None, None, Batch.empty, None)
 
   def append(a: SceneUpdateFragment, b: SceneUpdateFragment): SceneUpdateFragment =
     SceneUpdateFragment(
       b.layers.foldLeft(a.layers) { case (als, bl) => addLayer(als, bl) },
       a.lights ++ b.lights,
-      a.audio |+| b.audio,
+      b.audio.orElse(a.audio),
       b.blendMaterial.orElse(a.blendMaterial),
       a.cloneBlanks ++ b.cloneBlanks,
       b.camera.orElse(a.camera)


### PR DESCRIPTION
this PR is the result of a rabbit hole I went down after trying to mute a `SceneUpdateFragment` by `|+|`-ing it with a `SceneUpdateFragment(myLayer).withAudio(SceneAudio.None)` and being surprised when music kept playing. I ended up figuring out that `SceneAudioSource.None` is a special value that represents both silence _and_ the absence of a value, that is to say, it plays no sound, but also any other `SceneAudioSource` will override it when combined.

this seems slightly more complex than just using `Option` types to represent sound and lack thereof, so I'm suggesting a few changes. to summarize:

* `SceneAudioSource.None` is gone, as all `SceneAudioSource` values now represent some sort of audible sound.
* `SceneAudio`'s three `SceneAudioSource` members are now of type `Option[SceneAudioSource]`.
  * `SceneAudio.Mute` has been added, which is simply `SceneAudio(None, None, None)`.
* `PlaybackPattern.Silent` has been removed, as silence is now represented by a `None` in a `SceneAudio`
* `SceneUpdateFragment.audio` is now an `Option[SceneAudio]`, which makes the empty-value semantics more obvious.
  *  while `SceneAudio.Mute` is not special in any way, it is the fallback used by `AudioPlayer` if the final `SceneUpdateFragment.audio` value passed to it ends up being a `None`.
 * for consistency, the three `AudioSourceState` vars in `AudioPlayer` are now `Option[AudioSourceState]`.
   * this eliminates the need for the `nodes` field to be an `Option`, so that was changed as well.
 
 to recap, the advantages of these changes are:
 * no more magic `SceneAudioSource(BindingKey("none"), PlaybackPattern.Silent, Volume.Min)` value.
   * silence cannot interrupt silence, so silent values probably do not need `BindingKey`s anyway?
 * using a regular old `Option` in the API leads to fewer surprises for the end user.
 * `SceneAudio.Mute` can be used both as a noun (the audio is mute) and a verb (a fragment with it will mute the left-hand-side fragment when `|+|`'d).
 * this is basically just a syntax change, the semantics are intended to be more or less identical.
 * no increase in codebase size.

feel free to give feedback or ask for tests/changes, if you don't feel this PR is a good fit, I'll understand that too. consider this just something that I thought of and decided to share in case it might be helpful! 