### PR TITLE
Scenes use `SceneContext` in place of `FrameContext`

### DIFF
--- a/demos/pirate/src/main/scala/pirate/scenes/level/LevelScene.scala
+++ b/demos/pirate/src/main/scala/pirate/scenes/level/LevelScene.scala
@@ -41,7 +41,7 @@ final case class LevelScene(screenWidth: Int) extends Scene[StartupData, Model, 
     )
 
   def updateModel(
-      context: FrameContext[StartupData],
+      context: SceneContext[StartupData],
       model: LevelModel
   ): GlobalEvent => Outcome[LevelModel] = {
     case FrameTick if model.notReady =>
@@ -66,7 +66,7 @@ final case class LevelScene(screenWidth: Int) extends Scene[StartupData, Model, 
   }
 
   def updateViewModel(
-      context: FrameContext[StartupData],
+      context: SceneContext[StartupData],
       model: LevelModel,
       viewModel: LevelViewModel
   ): GlobalEvent => Outcome[LevelViewModel] = {
@@ -96,7 +96,7 @@ final case class LevelScene(screenWidth: Int) extends Scene[StartupData, Model, 
   }
 
   def present(
-      context: FrameContext[StartupData],
+      context: SceneContext[StartupData],
       model: LevelModel,
       viewModel: SceneViewModel
   ): Outcome[SceneUpdateFragment] =

--- a/demos/pirate/src/main/scala/pirate/scenes/loading/LoadingScene.scala
+++ b/demos/pirate/src/main/scala/pirate/scenes/loading/LoadingScene.scala
@@ -48,7 +48,7 @@ final case class LoadingScene(assetPath: String, screenDimensions: Rectangle)
     Set(AssetBundleLoader)
 
   def updateModel(
-      context: FrameContext[StartupData],
+      context: SceneContext[StartupData],
       loadingState: LoadingState
   ): GlobalEvent => Outcome[LoadingState] = {
     case FrameTick =>
@@ -78,14 +78,14 @@ final case class LoadingScene(assetPath: String, screenDimensions: Rectangle)
   }
 
   def updateViewModel(
-      context: FrameContext[StartupData],
+      context: SceneContext[StartupData],
       loadingState: LoadingState,
       viewModel: Unit
   ): GlobalEvent => Outcome[Unit] =
     _ => Outcome(viewModel)
 
   def present(
-      context: FrameContext[StartupData],
+      context: SceneContext[StartupData],
       loadingState: LoadingState,
       viewModel: Unit
   ): Outcome[SceneUpdateFragment] =

--- a/demos/snake/snake/src/snake/scenes/ControlsScene.scala
+++ b/demos/snake/snake/src/snake/scenes/ControlsScene.scala
@@ -27,7 +27,7 @@ object ControlsScene extends Scene[StartupData, GameModel, ViewModel] {
     Set()
 
   def updateModel(
-      context: FrameContext[StartupData],
+      context: SceneContext[StartupData],
       controlScheme: ControlScheme
   ): GlobalEvent => Outcome[ControlScheme] = {
     case KeyboardEvent.KeyUp(Key.SPACE) =>
@@ -42,14 +42,14 @@ object ControlsScene extends Scene[StartupData, GameModel, ViewModel] {
   }
 
   def updateViewModel(
-      context: FrameContext[StartupData],
+      context: SceneContext[StartupData],
       controlScheme: ControlScheme,
       sceneViewModel: Unit
   ): GlobalEvent => Outcome[Unit] =
     _ => Outcome(sceneViewModel)
 
   def present(
-      context: FrameContext[StartupData],
+      context: SceneContext[StartupData],
       sceneModel: ControlScheme,
       sceneViewModel: Unit
   ): Outcome[SceneUpdateFragment] =
@@ -76,13 +76,27 @@ object ControlsScene extends Scene[StartupData, GameModel, ViewModel] {
         case ControlScheme.Turning(_, _) =>
           Batch(
             Text("[_] direction (all arrow keys)", center, middle - 5, 1, GameAssets.fontKey, GameAssets.fontMaterial).alignLeft,
-            Text("[x] turn (left and right arrows)", center, middle + 10, 1, GameAssets.fontKey, GameAssets.fontMaterial).alignLeft
+            Text(
+              "[x] turn (left and right arrows)",
+              center,
+              middle + 10,
+              1,
+              GameAssets.fontKey,
+              GameAssets.fontMaterial
+            ).alignLeft
           )
 
         case ControlScheme.Directed(_, _, _, _) =>
           Batch(
             Text("[x] direction (all arrow keys)", center, middle - 5, 1, GameAssets.fontKey, GameAssets.fontMaterial).alignLeft,
-            Text("[_] turn (left and right arrows)", center, middle + 10, 1, GameAssets.fontKey, GameAssets.fontMaterial).alignLeft
+            Text(
+              "[_] turn (left and right arrows)",
+              center,
+              middle + 10,
+              1,
+              GameAssets.fontKey,
+              GameAssets.fontMaterial
+            ).alignLeft
           )
       }
     }

--- a/demos/snake/snake/src/snake/scenes/GameOverScene.scala
+++ b/demos/snake/snake/src/snake/scenes/GameOverScene.scala
@@ -26,7 +26,7 @@ object GameOverScene extends Scene[StartupData, GameModel, ViewModel] {
   val subSystems: Set[SubSystem] =
     Set()
 
-  def updateModel(context: FrameContext[StartupData], pointsScored: Int): GlobalEvent => Outcome[Int] = {
+  def updateModel(context: SceneContext[StartupData], pointsScored: Int): GlobalEvent => Outcome[Int] = {
     case KeyboardEvent.KeyUp(Key.SPACE) =>
       Outcome(pointsScored)
         .addGlobalEvents(SceneEvent.JumpTo(StartScene.name))
@@ -36,14 +36,14 @@ object GameOverScene extends Scene[StartupData, GameModel, ViewModel] {
   }
 
   def updateViewModel(
-      context: FrameContext[StartupData],
+      context: SceneContext[StartupData],
       pointsScored: Int,
       sceneViewModel: Unit
   ): GlobalEvent => Outcome[Unit] =
     _ => Outcome(sceneViewModel)
 
   def present(
-      context: FrameContext[StartupData],
+      context: SceneContext[StartupData],
       pointsScored: Int,
       sceneViewModel: Unit
   ): Outcome[SceneUpdateFragment] =
@@ -56,7 +56,14 @@ object GameOverScene extends Scene[StartupData, GameModel, ViewModel] {
           Layer(
             BindingKey("ui"),
             Text("Game Over!", horizontalCenter, verticalMiddle - 20, 1, GameAssets.fontKey, GameAssets.fontMaterial).alignCenter,
-            Text(s"You scored: ${pointsScored.toString()} pts!", horizontalCenter, verticalMiddle - 5, 1, GameAssets.fontKey, GameAssets.fontMaterial).alignCenter,
+            Text(
+              s"You scored: ${pointsScored.toString()} pts!",
+              horizontalCenter,
+              verticalMiddle - 5,
+              1,
+              GameAssets.fontKey,
+              GameAssets.fontMaterial
+            ).alignCenter,
             Text("(hit space to restart)", horizontalCenter, 220, 1, GameAssets.fontKey, GameAssets.fontMaterial).alignCenter
           )
         )

--- a/demos/snake/snake/src/snake/scenes/GameScene.scala
+++ b/demos/snake/snake/src/snake/scenes/GameScene.scala
@@ -27,18 +27,18 @@ object GameScene extends Scene[StartupData, GameModel, ViewModel] {
   val subSystems: Set[SubSystem] =
     Set(Score.automataSubSystem(GameModel.ScoreIncrement.toString(), GameAssets.fontKey))
 
-  def updateModel(context: FrameContext[StartupData], gameModel: GameModel): GlobalEvent => Outcome[GameModel] =
+  def updateModel(context: SceneContext[StartupData], gameModel: GameModel): GlobalEvent => Outcome[GameModel] =
     gameModel.update(context.gameTime, context.dice, context.startUpData.viewConfig.gridSquareSize)
 
   def updateViewModel(
-      context: FrameContext[StartupData],
+      context: SceneContext[StartupData],
       gameModel: GameModel,
       walls: Group
   ): GlobalEvent => Outcome[Group] =
     _ => Outcome(walls)
 
   def present(
-      context: FrameContext[StartupData],
+      context: SceneContext[StartupData],
       gameModel: GameModel,
       walls: Group
   ): Outcome[SceneUpdateFragment] =

--- a/demos/snake/snake/src/snake/scenes/StartScene.scala
+++ b/demos/snake/snake/src/snake/scenes/StartScene.scala
@@ -30,7 +30,7 @@ object StartScene extends Scene[StartupData, GameModel, ViewModel] {
     Set()
 
   def updateModel(
-      context: FrameContext[StartupData],
+      context: SceneContext[StartupData],
       snakeGameModel: Unit
   ): GlobalEvent => Outcome[Unit] = {
     case KeyboardEvent.KeyUp(Key.SPACE) =>
@@ -45,14 +45,14 @@ object StartScene extends Scene[StartupData, GameModel, ViewModel] {
   }
 
   def updateViewModel(
-      context: FrameContext[StartupData],
+      context: SceneContext[StartupData],
       snakeGameModel: Unit,
       snakeViewModel: Unit
   ): GlobalEvent => Outcome[Unit] =
     _ => Outcome(snakeViewModel)
 
   def present(
-      context: FrameContext[StartupData],
+      context: SceneContext[StartupData],
       snakeGameModel: Unit,
       snakeViewModel: Unit
   ): Outcome[SceneUpdateFragment] =

--- a/examples/scenes-setup/src/main/scala/indigoexamples/SceneA.scala
+++ b/examples/scenes-setup/src/main/scala/indigoexamples/SceneA.scala
@@ -1,7 +1,7 @@
 package indigoexamples
 
-import indigo._
-import indigo.scenes._
+import indigo.*
+import indigo.scenes.*
 
 // There is no relevant entry in the ViewModel for either scene, so we've just left it as Unit.
 object SceneA extends Scene[StartUpData, GameModel, Unit] {
@@ -27,7 +27,7 @@ object SceneA extends Scene[StartUpData, GameModel, Unit] {
       HelloSubSystem("Scene SubSystem A", FontStuff.fontKey)
     )
 
-  def updateModel(context: FrameContext[StartUpData], sceneModel: MessageA): GlobalEvent => Outcome[MessageA] = {
+  def updateModel(context: SceneContext[StartUpData], sceneModel: MessageA): GlobalEvent => Outcome[MessageA] = {
     case SceneEvent.SceneChange(from, to, at) =>
       println(s"A: Changed scene from '${from}' to '${to}' at running time: ${at}")
       Outcome(sceneModel)
@@ -37,12 +37,12 @@ object SceneA extends Scene[StartUpData, GameModel, Unit] {
   }
 
   // Nothing to do
-  def updateViewModel(context: FrameContext[StartUpData], sceneModel: MessageA, sceneViewModel: Unit): GlobalEvent => Outcome[Unit] =
+  def updateViewModel(context: SceneContext[StartUpData], sceneModel: MessageA, sceneViewModel: Unit): GlobalEvent => Outcome[Unit] =
     _ => Outcome(())
 
   // Show some text
   // When the user clicks anywhere in the screen, trigger an event to jump to the other scene.
-  def present(context: FrameContext[StartUpData], sceneModel: MessageA, sceneViewModel: Unit): Outcome[SceneUpdateFragment] = {
+  def present(context: SceneContext[StartUpData], sceneModel: MessageA, sceneViewModel: Unit): Outcome[SceneUpdateFragment] = {
     val events: Batch[GlobalEvent] =
       if (context.inputState.mouse.wasMouseClickedWithin(Rectangle(0, 0, 550, 400))) Batch(SceneEvent.JumpTo(SceneB.name))
       else Batch.empty

--- a/examples/scenes-setup/src/main/scala/indigoexamples/SceneB.scala
+++ b/examples/scenes-setup/src/main/scala/indigoexamples/SceneB.scala
@@ -1,7 +1,7 @@
 package indigoexamples
 
-import indigo._
-import indigo.scenes._
+import indigo.*
+import indigo.scenes.*
 
 // There is no relevant entry in the ViewModel for either scene, so we've just left it as Unit.
 object SceneB extends Scene[StartUpData, GameModel, Unit] {
@@ -28,7 +28,7 @@ object SceneB extends Scene[StartUpData, GameModel, Unit] {
     )
 
   // Nothing to do
-  def updateModel(context: FrameContext[StartUpData], sceneModel: MessageB): GlobalEvent => Outcome[MessageB] = {
+  def updateModel(context: SceneContext[StartUpData], sceneModel: MessageB): GlobalEvent => Outcome[MessageB] = {
     case SceneEvent.SceneChange(from, to, at) =>
       println(s"B: Changed scene from '${from}' to '${to}' at running time: ${at}")
       Outcome(sceneModel)
@@ -38,12 +38,12 @@ object SceneB extends Scene[StartUpData, GameModel, Unit] {
   }
 
   // Nothing to do
-  def updateViewModel(context: FrameContext[StartUpData], sceneModel: MessageB, sceneViewModel: Unit): GlobalEvent => Outcome[Unit] =
+  def updateViewModel(context: SceneContext[StartUpData], sceneModel: MessageB, sceneViewModel: Unit): GlobalEvent => Outcome[Unit] =
     _ => Outcome(())
 
   // Show some text
   // When the user clicks anywhere in the screen, trigger an event to jump to the other scene.
-  def present(context: FrameContext[StartUpData], sceneModel: MessageB, sceneViewModel: Unit): Outcome[SceneUpdateFragment] = {
+  def present(context: SceneContext[StartUpData], sceneModel: MessageB, sceneViewModel: Unit): Outcome[SceneUpdateFragment] = {
     val events: Batch[GlobalEvent] =
       if (context.inputState.mouse.wasMouseClickedWithin(Rectangle(0, 0, 550, 400))) Batch(SceneEvent.JumpTo(SceneA.name))
       else Batch.empty

--- a/indigo/indigo/src/main/scala/indigo/scenes/Scene.scala
+++ b/indigo/indigo/src/main/scala/indigo/scenes/Scene.scala
@@ -1,7 +1,6 @@
 package indigo.scenes
 
 import indigo.*
-import indigo.shared.FrameContext
 import indigo.shared.Outcome
 import indigo.shared.collections.Batch
 import indigo.shared.events.EventFilters
@@ -21,14 +20,14 @@ trait Scene[StartUpData, GameModel, ViewModel] derives CanEqual {
   def eventFilters: EventFilters
   def subSystems: Set[SubSystem]
 
-  def updateModel(context: FrameContext[StartUpData], model: SceneModel): GlobalEvent => Outcome[SceneModel]
+  def updateModel(context: SceneContext[StartUpData], model: SceneModel): GlobalEvent => Outcome[SceneModel]
   def updateViewModel(
-      context: FrameContext[StartUpData],
+      context: SceneContext[StartUpData],
       model: SceneModel,
       viewModel: SceneViewModel
   ): GlobalEvent => Outcome[SceneViewModel]
   def present(
-      context: FrameContext[StartUpData],
+      context: SceneContext[StartUpData],
       model: SceneModel,
       viewModel: SceneViewModel
   ): Outcome[SceneUpdateFragment]
@@ -37,7 +36,7 @@ object Scene {
 
   def updateModel[SD, GM, VM](
       scene: Scene[SD, GM, VM],
-      context: FrameContext[SD],
+      context: SceneContext[SD],
       gameModel: GM
   ): GlobalEvent => Outcome[GM] =
     e =>
@@ -47,7 +46,7 @@ object Scene {
 
   def updateViewModel[SD, GM, VM](
       scene: Scene[SD, GM, VM],
-      context: FrameContext[SD],
+      context: SceneContext[SD],
       model: GM,
       viewModel: VM
   ): GlobalEvent => Outcome[VM] =
@@ -58,7 +57,7 @@ object Scene {
 
   def updateView[SD, GM, VM](
       scene: Scene[SD, GM, VM],
-      context: FrameContext[SD],
+      context: SceneContext[SD],
       model: GM,
       viewModel: VM
   ): Outcome[SceneUpdateFragment] =
@@ -90,20 +89,20 @@ object Scene {
         Set()
 
       def updateModel(
-          context: FrameContext[SD],
+          context: SceneContext[SD],
           model: Unit
       ): GlobalEvent => Outcome[Unit] =
         _ => modelOutcome
 
       def updateViewModel(
-          context: FrameContext[SD],
+          context: SceneContext[SD],
           model: Unit,
           viewModel: Unit
       ): GlobalEvent => Outcome[Unit] =
         _ => modelOutcome
 
       def present(
-          context: FrameContext[SD],
+          context: SceneContext[SD],
           model: Unit,
           viewModel: Unit
       ): Outcome[SceneUpdateFragment] = sceneFragment

--- a/indigo/indigo/src/main/scala/indigo/scenes/SceneContext.scala
+++ b/indigo/indigo/src/main/scala/indigo/scenes/SceneContext.scala
@@ -27,20 +27,15 @@ final class SceneContext[StartUpData](
     val sceneTime: Seconds,
     val frameContext: FrameContext[StartUpData]
 ):
-
-  lazy val gameTime: GameTime               = frameContext.gameTime
-  lazy val dice: Dice                       = frameContext.dice
-  lazy val inputState: InputState           = frameContext.inputState
-  lazy val boundaryLocator: BoundaryLocator = frameContext.boundaryLocator
-  lazy val startUpData: StartUpData         = frameContext.startUpData
-  lazy val running: Seconds                 = frameContext.gameTime.running
-  lazy val delta: Seconds                   = frameContext.gameTime.delta
-  lazy val mouse: Mouse                     = frameContext.inputState.mouse
-  lazy val keyboard: Keyboard               = frameContext.inputState.keyboard
-  lazy val gamepad: Gamepad                 = frameContext.inputState.gamepad
-
-  def findBounds(sceneNode: SceneNode): Option[Rectangle] =
-    frameContext.findBounds(sceneNode)
-
-  def bounds(sceneGraphNode: SceneNode): Rectangle =
-    frameContext.bounds(sceneGraphNode)
+  export frameContext.gameTime
+  export frameContext.dice
+  export frameContext.inputState
+  export frameContext.boundaryLocator
+  export frameContext.startUpData
+  export frameContext.gameTime.running
+  export frameContext.gameTime.delta
+  export frameContext.inputState.mouse
+  export frameContext.inputState.keyboard
+  export frameContext.inputState.gamepad
+  export frameContext.findBounds
+  export frameContext.bounds

--- a/indigo/indigo/src/main/scala/indigo/scenes/SceneContext.scala
+++ b/indigo/indigo/src/main/scala/indigo/scenes/SceneContext.scala
@@ -40,7 +40,7 @@ final class SceneContext[StartUpData](
   lazy val gamepad: Gamepad                 = frameContext.inputState.gamepad
 
   def findBounds(sceneNode: SceneNode): Option[Rectangle] =
-    boundaryLocator.findBounds(sceneNode)
+    frameContext.findBounds(sceneNode)
 
   def bounds(sceneGraphNode: SceneNode): Rectangle =
-    boundaryLocator.bounds(sceneGraphNode)
+    frameContext.bounds(sceneGraphNode)

--- a/indigo/indigo/src/main/scala/indigo/scenes/SceneContext.scala
+++ b/indigo/indigo/src/main/scala/indigo/scenes/SceneContext.scala
@@ -1,0 +1,46 @@
+package indigo.scenes
+
+import indigo.shared.BoundaryLocator
+import indigo.shared.FrameContext
+import indigo.shared.datatypes.Rectangle
+import indigo.shared.dice.Dice
+import indigo.shared.events.InputState
+import indigo.shared.input.Gamepad
+import indigo.shared.input.Keyboard
+import indigo.shared.input.Mouse
+import indigo.shared.scenegraph.SceneNode
+import indigo.shared.time.GameTime
+import indigo.shared.time.Seconds
+
+/** SceneContext is a Scene specific equivalent of `FrameContext`, and exposes all of the fields and methods or a normal
+  * `FrameContext` object. It adds information about the scene currently running.
+  *
+  * @param sceneName
+  *   The name of the current scene.
+  * @param sceneTime
+  *   The running time of the current scene calculated as the time the scene was entered minus game running time.
+  * @param frameContext
+  *   The normal frame context object that all other fields delegate to.
+  */
+final class SceneContext[StartUpData](
+    val sceneName: SceneName,
+    val sceneTime: Seconds,
+    val frameContext: FrameContext[StartUpData]
+):
+
+  lazy val gameTime: GameTime               = frameContext.gameTime
+  lazy val dice: Dice                       = frameContext.dice
+  lazy val inputState: InputState           = frameContext.inputState
+  lazy val boundaryLocator: BoundaryLocator = frameContext.boundaryLocator
+  lazy val startUpData: StartUpData         = frameContext.startUpData
+  lazy val running: Seconds                 = frameContext.gameTime.running
+  lazy val delta: Seconds                   = frameContext.gameTime.delta
+  lazy val mouse: Mouse                     = frameContext.inputState.mouse
+  lazy val keyboard: Keyboard               = frameContext.inputState.keyboard
+  lazy val gamepad: Gamepad                 = frameContext.inputState.gamepad
+
+  def findBounds(sceneNode: SceneNode): Option[Rectangle] =
+    boundaryLocator.findBounds(sceneNode)
+
+  def bounds(sceneGraphNode: SceneNode): Rectangle =
+    boundaryLocator.bounds(sceneGraphNode)

--- a/indigo/indigo/src/main/scala/indigo/shared/FrameContext.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/FrameContext.scala
@@ -33,15 +33,11 @@ final class FrameContext[StartUpData](
 ):
 
   lazy val startUpData = _startUpData
-  val running: Seconds = gameTime.running
-  val delta: Seconds   = gameTime.delta
 
-  val mouse: Mouse       = inputState.mouse
-  val keyboard: Keyboard = inputState.keyboard
-  val gamepad: Gamepad   = inputState.gamepad
-
-  def findBounds(sceneNode: SceneNode): Option[Rectangle] =
-    boundaryLocator.findBounds(sceneNode)
-
-  def bounds(sceneGraphNode: SceneNode): Rectangle =
-    boundaryLocator.bounds(sceneGraphNode)
+  export gameTime.running
+  export gameTime.delta
+  export inputState.mouse
+  export inputState.keyboard
+  export inputState.gamepad
+  export boundaryLocator.findBounds
+  export boundaryLocator.bounds

--- a/indigo/indigo/src/test/scala/indigo/scenes/SceneManagerTests.scala
+++ b/indigo/indigo/src/test/scala/indigo/scenes/SceneManagerTests.scala
@@ -112,7 +112,6 @@ class SceneManagerTests extends munit.FunSuite {
     val actual = runModel(events, gameModel, sceneManager)
 
     assertEquals(actual, expected)
-
   }
 
   private def runModel(events: Batch[GlobalEvent], model: TestGameModel, sceneManager: SceneManager[Unit, TestGameModel, TestViewModel]): Outcome[TestGameModel] =

--- a/indigo/indigo/src/test/scala/indigo/scenes/TestScenes.scala
+++ b/indigo/indigo/src/test/scala/indigo/scenes/TestScenes.scala
@@ -61,18 +61,18 @@ final case class TestSceneA() extends Scene[Unit, TestGameModel, TestViewModel] 
 
   val subSystems: Set[SubSystem] = Set()
 
-  def updateModel(context: FrameContext[Unit], sceneModel: TestSceneModelA): GlobalEvent => Outcome[TestSceneModelA] =
+  def updateModel(context: SceneContext[Unit], sceneModel: TestSceneModelA): GlobalEvent => Outcome[TestSceneModelA] =
     _ => Outcome(sceneModel.copy(count = sceneModel.count + 1))
 
   def updateViewModel(
-      context: FrameContext[Unit],
+      context: SceneContext[Unit],
       sceneModel: TestSceneModelA,
       sceneViewModel: TestSceneViewModelA
   ): GlobalEvent => Outcome[TestSceneViewModelA] =
     _ => Outcome(TestSceneViewModelA())
 
   def present(
-      context: FrameContext[Unit],
+      context: SceneContext[Unit],
       sceneModel: TestSceneModelA,
       sceneViewModel: TestSceneViewModelA
   ): Outcome[SceneUpdateFragment] =
@@ -124,18 +124,18 @@ final case class TestSceneB() extends Scene[Unit, TestGameModel, TestViewModel] 
 
   val subSystems: Set[SubSystem] = Set()
 
-  def updateModel(context: FrameContext[Unit], sceneModel: TestSceneModelB): GlobalEvent => Outcome[TestSceneModelB] =
+  def updateModel(context: SceneContext[Unit], sceneModel: TestSceneModelB): GlobalEvent => Outcome[TestSceneModelB] =
     _ => Outcome(sceneModel.copy(count = sceneModel.count + 10))
 
   def updateViewModel(
-      context: FrameContext[Unit],
+      context: SceneContext[Unit],
       sceneModel: TestSceneModelB,
       sceneViewModel: TestSceneViewModelB
   ): GlobalEvent => Outcome[TestSceneViewModelB] =
     _ => Outcome(TestSceneViewModelB())
 
   def present(
-      context: FrameContext[Unit],
+      context: SceneContext[Unit],
       sceneModel: TestSceneModelB,
       sceneViewModel: TestSceneViewModelB
   ): Outcome[SceneUpdateFragment] =

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/BoundsScene.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/BoundsScene.scala
@@ -29,20 +29,20 @@ object BoundsScene extends Scene[SandboxStartupData, SandboxGameModel, SandboxVi
     Set()
 
   def updateModel(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: SandboxGameModel
   ): GlobalEvent => Outcome[SandboxGameModel] =
     _ => Outcome(model)
 
   def updateViewModel(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: SandboxGameModel,
       viewModel: SandboxViewModel
   ): GlobalEvent => Outcome[SandboxViewModel] =
     _ => Outcome(viewModel)
 
   def present(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: SandboxGameModel,
       viewModel: SandboxViewModel
   ): Outcome[SceneUpdateFragment] =

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/BoxesScene.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/BoxesScene.scala
@@ -27,13 +27,13 @@ object BoxesScene extends Scene[SandboxStartupData, SandboxGameModel, SandboxVie
     Set()
 
   def updateModel(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: SandboxGameModel
   ): GlobalEvent => Outcome[SandboxGameModel] =
     _ => Outcome(model)
 
   def updateViewModel(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: SandboxGameModel,
       viewModel: SandboxViewModel
   ): GlobalEvent => Outcome[SandboxViewModel] =
@@ -69,7 +69,7 @@ object BoxesScene extends Scene[SandboxStartupData, SandboxGameModel, SandboxVie
     )
 
   def present(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: SandboxGameModel,
       viewModel: SandboxViewModel
   ): Outcome[SceneUpdateFragment] =

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/CameraScene.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/CameraScene.scala
@@ -28,13 +28,13 @@ object CameraScene extends Scene[SandboxStartupData, SandboxGameModel, SandboxVi
     Set()
 
   def updateModel(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: SandboxGameModel
   ): GlobalEvent => Outcome[SandboxGameModel] =
     _ => Outcome(model)
 
   def updateViewModel(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: SandboxGameModel,
       viewModel: SandboxViewModel
   ): GlobalEvent => Outcome[SandboxViewModel] =
@@ -49,7 +49,7 @@ object CameraScene extends Scene[SandboxStartupData, SandboxGameModel, SandboxVi
     Signal.Orbit(Point.zero, 100.0d).map(_.toPoint)
 
   def present(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: SandboxGameModel,
       viewModel: SandboxViewModel
   ): Outcome[SceneUpdateFragment] = {

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/ClipScene.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/ClipScene.scala
@@ -29,13 +29,13 @@ object ClipScene extends Scene[SandboxStartupData, SandboxGameModel, SandboxView
     Set()
 
   def updateModel(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: SandboxGameModel
   ): GlobalEvent => Outcome[SandboxGameModel] =
     _ => Outcome(model)
 
   def updateViewModel(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: SandboxGameModel,
       viewModel: SandboxViewModel
   ): GlobalEvent => Outcome[SandboxViewModel] =
@@ -48,7 +48,7 @@ object ClipScene extends Scene[SandboxStartupData, SandboxGameModel, SandboxView
       .withFontFamily(FontFamily.uiMonospace)
 
   def present(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: SandboxGameModel,
       viewModel: SandboxViewModel
   ): Outcome[SceneUpdateFragment] =

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/ConfettiScene.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/ConfettiScene.scala
@@ -39,7 +39,7 @@ object ConfettiScene extends Scene[SandboxStartupData, SandboxGameModel, Sandbox
     Set()
 
   def updateModel(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: ConfettiModel
   ): GlobalEvent => Outcome[ConfettiModel] =
 
@@ -60,7 +60,7 @@ object ConfettiScene extends Scene[SandboxStartupData, SandboxGameModel, Sandbox
       Outcome(model)
 
   def updateViewModel(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: ConfettiModel,
       viewModel: Unit
   ): GlobalEvent => Outcome[Unit] =
@@ -94,7 +94,7 @@ object ConfettiScene extends Scene[SandboxStartupData, SandboxGameModel, Sandbox
     )
 
   def present(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: ConfettiModel,
       viewModel: Unit
   ): Outcome[SceneUpdateFragment] =

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/CratesScene.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/CratesScene.scala
@@ -28,13 +28,13 @@ object CratesScene extends Scene[SandboxStartupData, SandboxGameModel, SandboxVi
     Set()
 
   def updateModel(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: Unit
   ): GlobalEvent => Outcome[Unit] =
     _ => Outcome(model)
 
   def updateViewModel(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: Unit,
       viewModel: Unit
   ): GlobalEvent => Outcome[Unit] =
@@ -58,7 +58,7 @@ object CratesScene extends Scene[SandboxStartupData, SandboxGameModel, SandboxVi
     )
 
   def present(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: Unit,
       viewModel: Unit
   ): Outcome[SceneUpdateFragment] =

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/LegacyEffectsScene.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/LegacyEffectsScene.scala
@@ -32,13 +32,13 @@ object LegacyEffectsScene extends Scene[SandboxStartupData, SandboxGameModel, Sa
     Set()
 
   def updateModel(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: SandboxGameModel
   ): GlobalEvent => Outcome[SandboxGameModel] =
     _ => Outcome(model)
 
   def updateViewModel(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: SandboxGameModel,
       viewModel: SandboxViewModel
   ): GlobalEvent => Outcome[SandboxViewModel] =
@@ -49,7 +49,7 @@ object LegacyEffectsScene extends Scene[SandboxStartupData, SandboxGameModel, Sa
       .withRef(20, 20)
 
   def present(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: SandboxGameModel,
       viewModel: SandboxViewModel
   ): Outcome[SceneUpdateFragment] = {

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/LightsScene.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/LightsScene.scala
@@ -28,13 +28,13 @@ object LightsScene extends Scene[SandboxStartupData, SandboxGameModel, SandboxVi
     Set()
 
   def updateModel(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: SandboxGameModel
   ): GlobalEvent => Outcome[SandboxGameModel] =
     _ => Outcome(model)
 
   def updateViewModel(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: SandboxGameModel,
       viewModel: SandboxViewModel
   ): GlobalEvent => Outcome[SandboxViewModel] =
@@ -69,7 +69,7 @@ object LightsScene extends Scene[SandboxStartupData, SandboxGameModel, SandboxVi
       .withLighting(LightingModel.Lit.flat)
 
   def present(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: SandboxGameModel,
       viewModel: SandboxViewModel
   ): Outcome[SceneUpdateFragment] =

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/ManyEventHandlers.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/ManyEventHandlers.scala
@@ -29,13 +29,13 @@ object ManyEventHandlers extends Scene[SandboxStartupData, SandboxGameModel, San
     Set()
 
   def updateModel(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: SandboxGameModel
   ): GlobalEvent => Outcome[SandboxGameModel] =
     _ => Outcome(model)
 
   def updateViewModel(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: SandboxGameModel,
       viewModel: SandboxViewModel
   ): GlobalEvent => Outcome[SandboxViewModel] =
@@ -70,7 +70,7 @@ object ManyEventHandlers extends Scene[SandboxStartupData, SandboxGameModel, San
     coords.map(pt => dude.moveTo(pt))
 
   def present(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: SandboxGameModel,
       viewModel: SandboxViewModel
   ): Outcome[SceneUpdateFragment] =

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/MutantsScene.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/MutantsScene.scala
@@ -33,13 +33,13 @@ object MutantsScene extends Scene[SandboxStartupData, SandboxGameModel, SandboxV
     Set()
 
   def updateModel(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: SandboxGameModel
   ): GlobalEvent => Outcome[SandboxGameModel] =
     _ => Outcome(model)
 
   def updateViewModel(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: SandboxGameModel,
       viewModel: SandboxViewModel
   ): GlobalEvent => Outcome[SandboxViewModel] =
@@ -86,7 +86,7 @@ object MutantsScene extends Scene[SandboxStartupData, SandboxGameModel, SandboxV
     )
 
   def present(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: SandboxGameModel,
       viewModel: SandboxViewModel
   ): Outcome[SceneUpdateFragment] =

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/OriginalScene.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/OriginalScene.scala
@@ -30,20 +30,20 @@ object OriginalScene extends Scene[SandboxStartupData, SandboxGameModel, Sandbox
     Set()
 
   def updateModel(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: SandboxGameModel
   ): GlobalEvent => Outcome[SandboxGameModel] =
     _ => Outcome(model)
 
   def updateViewModel(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: SandboxGameModel,
       viewModel: SandboxViewModel
   ): GlobalEvent => Outcome[SandboxViewModel] =
     _ => Outcome(viewModel)
 
   def present(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: SandboxGameModel,
       viewModel: SandboxViewModel
   ): Outcome[SceneUpdateFragment] = {

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/RefractionScene.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/RefractionScene.scala
@@ -30,13 +30,13 @@ object RefractionScene extends Scene[SandboxStartupData, SandboxGameModel, Sandb
     Set()
 
   def updateModel(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: SandboxGameModel
   ): GlobalEvent => Outcome[SandboxGameModel] =
     _ => Outcome(model)
 
   def updateViewModel(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: SandboxGameModel,
       viewModel: SandboxViewModel
   ): GlobalEvent => Outcome[SandboxViewModel] =
@@ -64,7 +64,7 @@ object RefractionScene extends Scene[SandboxStartupData, SandboxGameModel, Sandb
     }
 
   def present(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: SandboxGameModel,
       viewModel: SandboxViewModel
   ): Outcome[SceneUpdateFragment] = {

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/ShapesScene.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/ShapesScene.scala
@@ -27,20 +27,20 @@ object ShapesScene extends Scene[SandboxStartupData, SandboxGameModel, SandboxVi
     Set()
 
   def updateModel(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: SandboxGameModel
   ): GlobalEvent => Outcome[SandboxGameModel] =
     _ => Outcome(model)
 
   def updateViewModel(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: SandboxGameModel,
       viewModel: SandboxViewModel
   ): GlobalEvent => Outcome[SandboxViewModel] =
     _ => Outcome(viewModel)
 
   def present(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: SandboxGameModel,
       viewModel: SandboxViewModel
   ): Outcome[SceneUpdateFragment] = {

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/TextBoxScene.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/TextBoxScene.scala
@@ -28,13 +28,13 @@ object TextBoxScene extends Scene[SandboxStartupData, SandboxGameModel, SandboxV
     Set()
 
   def updateModel(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: SandboxGameModel
   ): GlobalEvent => Outcome[SandboxGameModel] =
     _ => Outcome(model)
 
   def updateViewModel(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: SandboxGameModel,
       viewModel: SandboxViewModel
   ): GlobalEvent => Outcome[SandboxViewModel] =
@@ -45,7 +45,7 @@ object TextBoxScene extends Scene[SandboxStartupData, SandboxGameModel, SandboxV
       .modifyStyle(_.withColor(RGBA.Magenta).modifyStroke(_.withWidth(Pixels(3)).withColor(RGBA.Cyan)))
 
   def present(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: SandboxGameModel,
       viewModel: SandboxViewModel
   ): Outcome[SceneUpdateFragment] =

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/TextScene.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/TextScene.scala
@@ -29,13 +29,13 @@ object TextScene extends Scene[SandboxStartupData, SandboxGameModel, SandboxView
     Set()
 
   def updateModel(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: SandboxGameModel
   ): GlobalEvent => Outcome[SandboxGameModel] =
     _ => Outcome(model)
 
   def updateViewModel(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: SandboxGameModel,
       viewModel: SandboxViewModel
   ): GlobalEvent => Outcome[SandboxViewModel] =
@@ -44,7 +44,7 @@ object TextScene extends Scene[SandboxStartupData, SandboxGameModel, SandboxView
   val textMaterial = SandboxAssets.fontMaterial.toBitmap
 
   def present(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: SandboxGameModel,
       viewModel: SandboxViewModel
   ): Outcome[SceneUpdateFragment] =

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/TextureTileScene.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/TextureTileScene.scala
@@ -29,13 +29,13 @@ object TextureTileScene extends Scene[SandboxStartupData, SandboxGameModel, Sand
     Set()
 
   def updateModel(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: SandboxGameModel
   ): GlobalEvent => Outcome[SandboxGameModel] =
     _ => Outcome(model)
 
   def updateViewModel(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: SandboxGameModel,
       viewModel: SandboxViewModel
   ): GlobalEvent => Outcome[SandboxViewModel] =
@@ -45,7 +45,7 @@ object TextureTileScene extends Scene[SandboxStartupData, SandboxGameModel, Sand
     Vector2(Math.max(screenSize.x / originalSize.x, screenSize.y / originalSize.y))
 
   def present(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: SandboxGameModel,
       viewModel: SandboxViewModel
   ): Outcome[SceneUpdateFragment] = {

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/TimelineScene.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/TimelineScene.scala
@@ -30,13 +30,13 @@ object TimelineScene extends Scene[SandboxStartupData, SandboxGameModel, Sandbox
     Set()
 
   def updateModel(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: Unit
   ): GlobalEvent => Outcome[Unit] =
     _ => Outcome(model)
 
   def updateViewModel(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: Unit,
       viewModel: Unit
   ): GlobalEvent => Outcome[Unit] =
@@ -99,7 +99,7 @@ object TimelineScene extends Scene[SandboxStartupData, SandboxGameModel, Sandbox
       .moveTo(50, 0)
 
   def present(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: Unit,
       viewModel: Unit
   ): Outcome[SceneUpdateFragment] =

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/UiScene.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/UiScene.scala
@@ -31,13 +31,13 @@ object UiScene extends Scene[SandboxStartupData, SandboxGameModel, SandboxViewMo
     Set()
 
   def updateModel(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: SandboxGameModel
   ): GlobalEvent => Outcome[SandboxGameModel] =
     _ => Outcome(model)
 
   def updateViewModel(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: SandboxGameModel,
       viewModel: SandboxViewModel
   ): GlobalEvent => Outcome[SandboxViewModel] =
@@ -60,7 +60,7 @@ object UiScene extends Scene[SandboxStartupData, SandboxGameModel, SandboxViewMo
     )
 
   def present(
-      context: FrameContext[SandboxStartupData],
+      context: SceneContext[SandboxStartupData],
       model: SandboxGameModel,
       viewModel: SandboxViewModel
   ): Outcome[SceneUpdateFragment] =


### PR DESCRIPTION
A request from @hobnob as a result of working on the Roguelike demo.

The standard scene functions now provide a `SceneContext` in place of a `FrameContext`. This provides all of the same functionality as a normal `FrameContext` (and in fact just delegates to the normal context), but also provides the scene running time (`sceneTime`) and the current `sceneName`.

The purposes of this is primarily to make it easier to play animations from the time the scene started.

While the `Scene`s themselves now take the new `SceneContext`, the standard functions on the outer game still expect a `FrameContext`. I'm slightly torn by that decision. Not being able to get the scene context at the outer level arguably makes the `sceneName` parameter redundant. On the other hand making the scene context available at the game level would have been a more serious change, so I've decided to leave it here and see how it goes!

Below is a quick screen grab of some logging I temporarily added to some of the sandbox scenes. 

![scene-context](https://user-images.githubusercontent.com/908709/190853946-e5a5c9e5-9933-400b-b3c6-68ae957e9ec4.png)
