### PR TITLE
Improve uniform syntax and API experience

### DIFF
--- a/indigo/indigo-extras/src/main/scala/indigoextras/effectmaterials/LegacyEffects.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/effectmaterials/LegacyEffects.scala
@@ -15,6 +15,7 @@ import indigo.shared.shader.ShaderPrimitive.rawJSArray
 import indigo.shared.shader.UltravioletShader
 import indigo.shared.shader.Uniform
 import indigo.shared.shader.UniformBlock
+import indigo.shared.shader.UniformBlockName
 import indigo.shared.shader.library.IndigoUV.VertexEnv
 import indigo.shared.shader.library.NoOp
 import indigoextras.effectmaterials.shaders.LegacyEffectsShaders
@@ -78,7 +79,7 @@ final case class LegacyEffects(
       LegacyEffects.entityShader.id,
       Batch(
         UniformBlock(
-          "IndigoLegacyEffectsData",
+          UniformBlockName("IndigoLegacyEffectsData"),
           Batch(
             // ALPHA_SATURATION_OVERLAYTYPE_FILLTYPE (vec4), TINT (vec4)
             Uniform("LegacyEffects_DATA") -> rawJSArray(

--- a/indigo/indigo-extras/src/main/scala/indigoextras/effectmaterials/Refraction.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/effectmaterials/Refraction.scala
@@ -18,6 +18,7 @@ import indigo.shared.shader.ShaderPrimitive.float
 import indigo.shared.shader.UltravioletShader
 import indigo.shared.shader.Uniform
 import indigo.shared.shader.UniformBlock
+import indigo.shared.shader.UniformBlockName
 import indigo.shared.shader.library.NoOp
 import indigoextras.effectmaterials.shaders.RefractionShaders
 
@@ -82,7 +83,7 @@ final case class RefractionEntity(diffuse: AssetName, fillType: FillType) extend
 
     val uniformBlock: UniformBlock =
       UniformBlock(
-        "IndigoBitmapData",
+        UniformBlockName("IndigoBitmapData"),
         Batch(
           Uniform("FILLTYPE") -> float(imageFillType)
         )
@@ -108,7 +109,7 @@ final case class RefractionBlend(multiplier: Double) extends BlendMaterial deriv
       Refraction.blendShader.id,
       Batch(
         UniformBlock(
-          "IndigoRefractionBlendData",
+          UniformBlockName("IndigoRefractionBlendData"),
           Batch(
             Uniform("REFRACTION_AMOUNT") -> float(multiplier)
           )

--- a/indigo/indigo/src/main/scala/indigo/package.scala
+++ b/indigo/indigo/src/main/scala/indigo/package.scala
@@ -223,6 +223,9 @@ val array: shared.shader.ShaderPrimitive.array.type = shared.shader.ShaderPrimit
 type rawArray = shared.shader.ShaderPrimitive.rawArray
 val rawArray: shared.shader.ShaderPrimitive.rawArray.type = shared.shader.ShaderPrimitive.rawArray
 
+type rawJSArray = shared.shader.ShaderPrimitive.rawJSArray
+val rawJSArray: shared.shader.ShaderPrimitive.rawJSArray.type = shared.shader.ShaderPrimitive.rawJSArray
+
 val StandardShaders: shared.shader.StandardShaders.type = shared.shader.StandardShaders
 
 type Outcome[T] = shared.Outcome[T]

--- a/indigo/indigo/src/main/scala/indigo/package.scala
+++ b/indigo/indigo/src/main/scala/indigo/package.scala
@@ -1,5 +1,7 @@
 package indigo
 
+import scala.annotation.targetName
+
 object syntax:
 
   extension (d: Double)
@@ -112,6 +114,44 @@ object syntax:
     export SignalFunction.smoothPulse
     export SignalFunction.multiply
   end animations
+
+  // Shaders
+  object shaders:
+
+    extension (c: RGBA) def asVec4: vec4 = vec4.fromRGBA(c)
+    extension (c: RGB)
+      def asVec4: vec4 = vec4.fromRGB(c)
+      def asVec3: vec3 = vec3.fromRGB(c)
+    extension (p: Point) def asVec2: vec2     = vec2.fromPoint(p)
+    extension (s: Size) def asVec2: vec2      = vec2.fromSize(s)
+    extension (v: Vector2) def asVec2: vec2   = vec2.fromVector2(v)
+    extension (v: Vector3) def asVec3: vec3   = vec3.fromVector3(v)
+    extension (v: Vector4) def asVec4: vec4   = vec4.fromVector4(v)
+    extension (r: Rectangle) def asVec4: vec4 = vec4.fromRectangle(r)
+    extension (m: Matrix4) def asMat4: mat4   = mat4.fromMatrix4(m)
+    extension (d: Depth) def asFloat: float   = float.fromDepth(d)
+    extension (m: Millis) def asFloat: float  = float.fromMillis(m)
+    extension (r: Radians) def asFloat: float = float.fromRadians(r)
+    extension (s: Seconds)
+      @targetName("ext_Seconds_asFloat")
+      def asFloat: float = float.fromSeconds(s)
+    extension (d: Double)
+      @targetName("ext_Double_asFloat")
+      def asFloat: float = float(d)
+    extension (i: Int)
+      @targetName("ext_Int_asFloat")
+      def asFloat: float = float(i)
+    extension (l: Long)
+      @targetName("ext_Long_asFloat")
+      def asFloat: float = float(l)
+    extension (a: Array[Float])
+      def asMat4: mat4         = mat4(a)
+      def asRawArray: rawArray = rawArray(a)
+    extension (a: scalajs.js.Array[Float])
+      def asMat4: mat4           = mat4(a.toArray)
+      def asRawArray: rawJSArray = rawJSArray(a)
+
+  end shaders
 
 end syntax
 

--- a/indigo/indigo/src/main/scala/indigo/package.scala
+++ b/indigo/indigo/src/main/scala/indigo/package.scala
@@ -19,18 +19,19 @@ object syntax:
   extension (l: Long) def millis: Millis = Millis(l)
 
   extension (s: String)
-    def animationKey: AnimationKey = AnimationKey(s)
-    def assetName: AssetName       = AssetName(s)
-    def assetPath: AssetPath       = AssetPath(s)
-    def assetTag: AssetTag         = AssetTag(s)
-    def cloneId: CloneId           = CloneId(s)
-    def cycleLabel: CycleLabel     = CycleLabel(s)
-    def fontKey: FontKey           = FontKey(s)
-    def fontFamily: FontFamily     = FontFamily(s)
-    def bindingKey: BindingKey     = BindingKey(s)
-    def scene: scenes.SceneName    = scenes.SceneName(s)
-    def shaderId: ShaderId         = ShaderId(s)
-    def uniform: Uniform           = Uniform(s)
+    def animationKey: AnimationKey         = AnimationKey(s)
+    def assetName: AssetName               = AssetName(s)
+    def assetPath: AssetPath               = AssetPath(s)
+    def assetTag: AssetTag                 = AssetTag(s)
+    def cloneId: CloneId                   = CloneId(s)
+    def cycleLabel: CycleLabel             = CycleLabel(s)
+    def fontKey: FontKey                   = FontKey(s)
+    def fontFamily: FontFamily             = FontFamily(s)
+    def bindingKey: BindingKey             = BindingKey(s)
+    def scene: scenes.SceneName            = scenes.SceneName(s)
+    def shaderId: ShaderId                 = ShaderId(s)
+    def uniform: Uniform                   = Uniform(s)
+    def uniformBlockName: UniformBlockName = UniformBlockName(s)
 
   extension (t: (Double, Double)) def vector2: Vector2 = Vector2(t._1, t._2)
 
@@ -235,6 +236,9 @@ val ShaderId: shared.shader.ShaderId.type = shared.shader.ShaderId
 
 type Uniform = shared.shader.Uniform
 val Uniform: shared.shader.Uniform.type = shared.shader.Uniform
+
+type UniformBlockName = shared.shader.UniformBlockName
+val UniformBlockName: shared.shader.UniformBlockName.type = shared.shader.UniformBlockName
 
 type UniformBlock = shared.shader.UniformBlock
 val UniformBlock: shared.shader.UniformBlock.type = shared.shader.UniformBlock

--- a/indigo/indigo/src/main/scala/indigo/shared/materials/BlendMaterial.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/materials/BlendMaterial.scala
@@ -9,6 +9,7 @@ import indigo.shared.shader.ShaderPrimitive.rawJSArray
 import indigo.shared.shader.StandardShaders
 import indigo.shared.shader.Uniform
 import indigo.shared.shader.UniformBlock
+import indigo.shared.shader.UniformBlockName
 
 trait BlendMaterial:
   def toShaderData: BlendShaderData
@@ -29,7 +30,7 @@ object BlendMaterial {
         StandardShaders.LightingBlend.id,
         Batch(
           UniformBlock(
-            "IndigoLightingBlendData",
+            UniformBlockName("IndigoLightingBlendData"),
             Batch(
               Uniform("AMBIENT_LIGHT_COLOR") -> rawJSArray(
                 ambient.r.toFloat,
@@ -85,7 +86,7 @@ object BlendMaterial {
         StandardShaders.BlendEffects.id,
         Batch(
           UniformBlock(
-            "IndigoBlendEffectsData",
+            UniformBlockName("IndigoBlendEffectsData"),
             Batch(
               // ALPHA_SATURATION_OVERLAYTYPE_BG (vec4), TINT (vec4)
               Uniform("BlendEffects_DATA") -> rawJSArray(

--- a/indigo/indigo/src/main/scala/indigo/shared/materials/LightingModel.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/materials/LightingModel.scala
@@ -6,6 +6,7 @@ import indigo.shared.shader.ShaderId
 import indigo.shared.shader.ShaderPrimitive.vec2
 import indigo.shared.shader.Uniform
 import indigo.shared.shader.UniformBlock
+import indigo.shared.shader.UniformBlockName
 
 sealed trait LightingModel:
   def enableLighting: LightingModel
@@ -71,7 +72,7 @@ object LightingModel {
         shaderId,
         Batch(
           UniformBlock(
-            "IndigoMaterialLightingData",
+            UniformBlockName("IndigoMaterialLightingData"),
             Batch(
               Uniform("LIGHT_EMISSIVE") -> vec2(
                 emissive.map(_ => 1.0).getOrElse(-1.0),

--- a/indigo/indigo/src/main/scala/indigo/shared/materials/Material.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/materials/Material.scala
@@ -13,6 +13,7 @@ import indigo.shared.shader.ShaderPrimitive.rawJSArray
 import indigo.shared.shader.StandardShaders
 import indigo.shared.shader.Uniform
 import indigo.shared.shader.UniformBlock
+import indigo.shared.shader.UniformBlockName
 
 trait Material {
   def toShaderData: ShaderData
@@ -70,7 +71,7 @@ object Material {
 
       val uniformBlock: UniformBlock =
         UniformBlock(
-          "IndigoBitmapData",
+          UniformBlockName("IndigoBitmapData"),
           Batch(
             Uniform("Bitmap_FILLTYPE") -> rawJSArray(scalajs.js.Array(imageFillType))
           )
@@ -172,7 +173,7 @@ object Material {
       // ALPHA_SATURATION_OVERLAYTYPE_FILLTYPE (vec4), TINT (vec4)
       val effectsUniformBlock: UniformBlock =
         UniformBlock(
-          "IndigoImageEffectsData",
+          UniformBlockName("IndigoImageEffectsData"),
           Batch(
             Uniform("ImageEffects_DATA") -> rawJSArray(
               scalajs.js.Array(

--- a/indigo/indigo/src/main/scala/indigo/shared/platform/DisplayObjectConversions.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/platform/DisplayObjectConversions.scala
@@ -142,7 +142,7 @@ final class DisplayObjectConversions(
       uniformBlocks.toJSArray.map { ub =>
         DisplayObjectUniformData(
           uniformHash = ub.uniformHash,
-          blockName = ub.blockName,
+          blockName = ub.blockName.toString,
           data = DisplayObjectConversions.packUBO(ub.uniforms, ub.uniformHash, false)
         )
       }
@@ -440,7 +440,7 @@ final class DisplayObjectConversions(
       shader.uniformBlocks.toJSArray.map { ub =>
         DisplayObjectUniformData(
           uniformHash = ub.uniformHash,
-          blockName = ub.blockName,
+          blockName = ub.blockName.toString,
           data = DisplayObjectConversions.packUBO(ub.uniforms, ub.uniformHash, false)
         )
       }
@@ -508,7 +508,7 @@ final class DisplayObjectConversions(
       shader.uniformBlocks.toJSArray.map { ub =>
         DisplayObjectUniformData(
           uniformHash = ub.uniformHash,
-          blockName = ub.blockName,
+          blockName = ub.blockName.toString,
           data = DisplayObjectConversions.packUBO(ub.uniforms, ub.uniformHash, false)
         )
       }
@@ -583,7 +583,7 @@ final class DisplayObjectConversions(
       shaderData.uniformBlocks.toJSArray.map { ub =>
         DisplayObjectUniformData(
           uniformHash = ub.uniformHash,
-          blockName = ub.blockName,
+          blockName = ub.blockName.toString,
           data = DisplayObjectConversions.packUBO(ub.uniforms, ub.uniformHash, false)
         )
       }
@@ -648,7 +648,7 @@ final class DisplayObjectConversions(
       shaderData.uniformBlocks.toJSArray.map { ub =>
         DisplayObjectUniformData(
           uniformHash = ub.uniformHash,
-          blockName = ub.blockName,
+          blockName = ub.blockName.toString,
           data = DisplayObjectConversions.packUBO(ub.uniforms, ub.uniformHash, false)
         )
       }
@@ -716,7 +716,7 @@ final class DisplayObjectConversions(
         shaderData.uniformBlocks.toJSArray.map { ub =>
           DisplayObjectUniformData(
             uniformHash = ub.uniformHash,
-            blockName = ub.blockName,
+            blockName = ub.blockName.toString,
             data = DisplayObjectConversions.packUBO(ub.uniforms, ub.uniformHash, false)
           )
         }
@@ -795,7 +795,7 @@ final class DisplayObjectConversions(
           shaderData.uniformBlocks.toJSArray.map { ub =>
             DisplayObjectUniformData(
               uniformHash = ub.uniformHash,
-              blockName = ub.blockName,
+              blockName = ub.blockName.toString,
               data = DisplayObjectConversions.packUBO(ub.uniforms, ub.uniformHash, false)
             )
           }

--- a/indigo/indigo/src/main/scala/indigo/shared/platform/SceneProcessor.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/platform/SceneProcessor.scala
@@ -312,7 +312,7 @@ object SceneProcessor {
     shaderData.uniformBlocks.toJSArray.map { ub =>
       DisplayObjectUniformData(
         uniformHash = ub.uniformHash,
-        blockName = ub.blockName,
+        blockName = ub.blockName.toString,
         data = DisplayObjectConversions.packUBO(ub.uniforms, ub.uniformHash, false)
       )
     }

--- a/indigo/indigo/src/main/scala/indigo/shared/scenegraph/Clip.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/scenegraph/Clip.scala
@@ -16,6 +16,7 @@ import indigo.shared.shader.ShaderPrimitive.float
 import indigo.shared.shader.StandardShaders
 import indigo.shared.shader.Uniform
 import indigo.shared.shader.UniformBlock
+import indigo.shared.shader.UniformBlockName
 import indigo.shared.time.FPS
 import indigo.shared.time.Seconds
 
@@ -158,7 +159,7 @@ final case class Clip[M <: Material](
       .withShaderId(StandardShaders.shaderIdToClipShaderId(data.shaderId))
       .addUniformBlock(
         UniformBlock(
-          "IndigoClipData",
+          UniformBlockName("IndigoClipData"),
           Batch(
             Uniform("CLIP_SHEET_FRAME_COUNT")    -> float(sheet.frameCount),
             Uniform("CLIP_SHEET_FRAME_DURATION") -> float.fromSeconds(sheet.frameDuration),

--- a/indigo/indigo/src/main/scala/indigo/shared/scenegraph/Shape.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/scenegraph/Shape.scala
@@ -22,6 +22,7 @@ import indigo.shared.shader.ShaderPrimitive._
 import indigo.shared.shader.StandardShaders
 import indigo.shared.shader.Uniform
 import indigo.shared.shader.UniformBlock
+import indigo.shared.shader.UniformBlockName
 
 /** Parent type for all Shapes, which are visible elements draw mathematically that require no textures. Shapes are
   * quite versitile and support different fills and stroke effects, even lighting. Due to the way strokes around shapes
@@ -684,7 +685,7 @@ object Shape:
 
         val shapeUniformBlock =
           UniformBlock(
-            "IndigoShapeData",
+            UniformBlockName("IndigoShapeData"),
             // ASPECT_RATIO (vec2), STROKE_WIDTH (float), FILL_TYPE (float), STROKE_COLOR (vec4)
             Batch(
               Uniform("Shape_DATA") -> rawJSArray(
@@ -716,7 +717,7 @@ object Shape:
       case s: Shape.Circle =>
         val shapeUniformBlock =
           UniformBlock(
-            "IndigoShapeData",
+            UniformBlockName("IndigoShapeData"),
             // STROKE_WIDTH (float), FILL_TYPE (float), STROKE_COLOR (vec4)
             Batch(
               Uniform("Shape_DATA") -> rawJSArray(
@@ -758,7 +759,7 @@ object Shape:
 
         val shapeUniformBlock =
           UniformBlock(
-            "IndigoShapeData",
+            UniformBlockName("IndigoShapeData"),
             // STROKE_WIDTH (float), STROKE_COLOR (vec4), START (vec2), END (vec2)
             Batch(
               Uniform("Shape_DATA") -> rawJSArray(
@@ -808,7 +809,7 @@ object Shape:
 
         val shapeUniformBlock =
           UniformBlock(
-            "IndigoShapeData",
+            UniformBlockName("IndigoShapeData"),
             // STROKE_WIDTH (float), FILL_TYPE (float), COUNT (float), STROKE_COLOR (vec4)
             Batch(
               Uniform("Shape_DATA") -> rawJSArray(

--- a/indigo/indigo/src/main/scala/indigo/shared/shader/UniformBlock.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/shader/UniformBlock.scala
@@ -2,6 +2,8 @@ package indigo.shared.shader
 
 import indigo.shared.collections.Batch
 
+import scala.annotation.targetName
+
 final case class UniformBlock(blockName: UniformBlockName, uniforms: Batch[(Uniform, ShaderPrimitive)])
     derives CanEqual:
 
@@ -20,6 +22,15 @@ final case class UniformBlock(blockName: UniformBlockName, uniforms: Batch[(Unif
     this.copy(uniforms = uniforms ++ newUniforms)
   def addUniforms(newUniforms: (Uniform, ShaderPrimitive)*): UniformBlock =
     addUniforms(Batch.fromSeq(newUniforms))
+
+object UniformBlock:
+
+  def apply(blockName: UniformBlockName, uniforms: (Uniform, ShaderPrimitive)*): UniformBlock =
+    UniformBlock(blockName, Batch.fromSeq(uniforms))
+
+  @targetName("UniformBlock_ValueOnly_apply")
+  def apply(blockName: UniformBlockName, uniformValues: ShaderPrimitive*): UniformBlock =
+    UniformBlock(blockName, Batch.fromSeq(uniformValues).map(v => Uniform("") -> v))
 
 opaque type UniformBlockName = String
 object UniformBlockName:

--- a/indigo/indigo/src/main/scala/indigo/shared/shader/UniformBlock.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/shader/UniformBlock.scala
@@ -6,7 +6,7 @@ final case class UniformBlock(blockName: UniformBlockName, uniforms: Batch[(Unif
     derives CanEqual:
 
   lazy val uniformHash: String =
-    uniforms.toList.map(p => p._1.toString + p._2.hash).mkString
+    blockName.toString + uniforms.map(_._2.hash).mkString
 
   def withUniformBlockName(newBlockName: UniformBlockName): UniformBlock =
     this.copy(blockName = newBlockName)

--- a/indigo/indigo/src/main/scala/indigo/shared/shader/UniformBlock.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/shader/UniformBlock.scala
@@ -2,12 +2,13 @@ package indigo.shared.shader
 
 import indigo.shared.collections.Batch
 
-final case class UniformBlock(blockName: String, uniforms: Batch[(Uniform, ShaderPrimitive)]) derives CanEqual:
+final case class UniformBlock(blockName: UniformBlockName, uniforms: Batch[(Uniform, ShaderPrimitive)])
+    derives CanEqual:
 
   lazy val uniformHash: String =
     uniforms.toList.map(p => p._1.toString + p._2.hash).mkString
 
-  def withUniformBlockName(newBlockName: String): UniformBlock =
+  def withUniformBlockName(newBlockName: UniformBlockName): UniformBlock =
     this.copy(blockName = newBlockName)
 
   def withUniforms(newUniforms: Batch[(Uniform, ShaderPrimitive)]): UniformBlock =
@@ -19,6 +20,12 @@ final case class UniformBlock(blockName: String, uniforms: Batch[(Uniform, Shade
     this.copy(uniforms = uniforms ++ newUniforms)
   def addUniforms(newUniforms: (Uniform, ShaderPrimitive)*): UniformBlock =
     addUniforms(Batch.fromSeq(newUniforms))
+
+opaque type UniformBlockName = String
+object UniformBlockName:
+  inline def apply(name: String): UniformBlockName = name
+
+  extension (ubn: UniformBlockName) def toString: String = ubn
 
 opaque type Uniform = String
 object Uniform:

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/MutantsScene.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/MutantsScene.scala
@@ -6,8 +6,9 @@ import com.example.sandbox.SandboxGame
 import com.example.sandbox.SandboxGameModel
 import com.example.sandbox.SandboxStartupData
 import com.example.sandbox.SandboxViewModel
-import indigo._
-import indigo.scenes._
+import indigo.*
+import indigo.scenes.*
+import indigo.syntax.shaders.*
 import indigoextras.geometry.Polygon
 import indigoextras.geometry.Vertex
 import indigoextras.ui.HitArea
@@ -141,9 +142,9 @@ object Archetype:
       UniformBlock(
         "MutantData",
         Batch(
-          Uniform("MOVE_TO")  -> vec2.fromPoint(position),
-          Uniform("SCALE_TO") -> vec2.fromVector2(scale),
-          Uniform("ALPHA")    -> float(alpha)
+          Uniform("MOVE_TO")  -> position.asVec2,
+          Uniform("SCALE_TO") -> scale.asVec2,
+          Uniform("ALPHA")    -> alpha.asFloat
         )
       )
     )

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/MutantsScene.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/MutantsScene.scala
@@ -143,10 +143,8 @@ object Archetype:
     Batch(
       UniformBlock(
         "MutantData".uniformBlockName,
-        Batch(
-          "MOVE_TO".uniform  -> position.asVec2,
-          "SCALE_TO".uniform -> scale.asVec2,
-          "ALPHA".uniform    -> alpha.asFloat
-        )
+        position.asVec2,
+        scale.asVec2,
+        alpha.asFloat
       )
     )

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/MutantsScene.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/MutantsScene.scala
@@ -9,6 +9,8 @@ import com.example.sandbox.SandboxViewModel
 import indigo.*
 import indigo.scenes.*
 import indigo.syntax.shaders.*
+import indigo.syntax.uniform
+import indigo.syntax.uniformBlockName
 import indigoextras.geometry.Polygon
 import indigoextras.geometry.Vertex
 import indigoextras.ui.HitArea
@@ -140,11 +142,11 @@ object Archetype:
   def makeUniformBlock(position: Point, scale: Vector2, alpha: Double): Batch[UniformBlock] =
     Batch(
       UniformBlock(
-        "MutantData",
+        "MutantData".uniformBlockName,
         Batch(
-          Uniform("MOVE_TO")  -> position.asVec2,
-          Uniform("SCALE_TO") -> scale.asVec2,
-          Uniform("ALPHA")    -> alpha.asFloat
+          "MOVE_TO".uniform  -> position.asVec2,
+          "SCALE_TO".uniform -> scale.asVec2,
+          "ALPHA".uniform    -> alpha.asFloat
         )
       )
     )

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/OriginalScene.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/OriginalScene.scala
@@ -82,7 +82,7 @@ object OriginalScene extends Scene[SandboxStartupData, SandboxGameModel, Sandbox
               ShaderData(
                 Shaders.externalId,
                 UniformBlock(
-                  "CustomData",
+                  UniformBlockName("CustomData"),
                   Batch(
                     Uniform("ALPHA")        -> float(0.75),
                     Uniform("BORDER_COLOR") -> vec3(1.0, 1.0, 0.0)
@@ -99,7 +99,7 @@ object OriginalScene extends Scene[SandboxStartupData, SandboxGameModel, Sandbox
               ShaderData(
                 Shaders.externalId,
                 UniformBlock(
-                  "CustomData",
+                  UniformBlockName("CustomData"),
                   Batch(
                     Uniform("ALPHA")        -> float(0.5),
                     Uniform("BORDER_COLOR") -> vec3(1.0, 0.0, 1.0)


### PR DESCRIPTION
Allows you to express:

```scala
    Batch(
      UniformBlock(
        "MutantData",
        Batch(
          Uniform("MOVE_TO")  -> vec2.fromPoint(position),
          Uniform("SCALE_TO") -> vec2.fromVector2(scale),
          Uniform("ALPHA")    -> float(alpha)
        )
      )
```

as (using `import indigo.syntax.shaders.*`):

```scala
      UniformBlock(
        "MutantData".uniformBlockName,
        position.asVec2,
        scale.asVec2,
        alpha.asFloat
      )
```

This won't always be desirable, sometimes you will want the `Uniform("MOVE_TO")` stuff as a reference point to help you align with your GLSL code.