### PR TITLE
Fixed #461: Best effort to match target framerate

### DIFF
--- a/indigo/indigo/src/main/scala/indigo/gameengine/GameEngine.scala
+++ b/indigo/indigo/src/main/scala/indigo/gameengine/GameEngine.scala
@@ -73,7 +73,7 @@ final class GameEngine[StartUpData, GameModel, ViewModel](
   @SuppressWarnings(Array("scalafix:DisableSyntax.var", "scalafix:DisableSyntax.null"))
   var gamepadInputCapture: GamepadInputCapture = null
   @SuppressWarnings(Array("scalafix:DisableSyntax.var", "scalafix:DisableSyntax.null"))
-  var gameLoop: Long => Long => Unit = null
+  var gameLoop: Double => Double => Unit = null
   @SuppressWarnings(Array("scalafix:DisableSyntax.var", "scalafix:DisableSyntax.null"))
   var gameLoopInstance: GameLoop[StartUpData, GameModel, ViewModel] = null
   @SuppressWarnings(Array("scalafix:DisableSyntax.var"))
@@ -156,7 +156,7 @@ final class GameEngine[StartUpData, GameModel, ViewModel](
         rebuildGameLoop(parentElement, true)(assetCollection)
 
         if (gameLoop != null)
-          platform.tick(gameLoop(0))
+          platform.tick(gameLoop(0.0d))
       }
 
     }
@@ -180,7 +180,7 @@ final class GameEngine[StartUpData, GameModel, ViewModel](
 
       platform = new Platform(parentElement, gameConfig, accumulatedAssetCollection, globalEventStream, dynamicText)
 
-      initialise(accumulatedAssetCollection)(Dice.fromSeed(time)) match {
+      initialise(accumulatedAssetCollection)(Dice.fromSeed(time.toLong)) match {
         case oe @ Outcome.Error(error, _) =>
           IndigoLogger.error(
             if (firstRun) "Error during first initialisation - Halting."
@@ -209,7 +209,7 @@ final class GameEngine[StartUpData, GameModel, ViewModel](
             if (firstRun) initialViewModel(startUpSuccessData)(m).map(vm => (_: GameModel) => vm)
             else Outcome((_: GameModel) => gameLoopInstance.viewModelState)
 
-          val loop: Outcome[Long => Long => Unit] =
+          val loop: Outcome[Double => Double => Unit] =
             for {
               rendererAndAssetMapping <- platform.initialise(shaderRegister.toSet)
               startUpSuccessData      <- GameEngine.initialisedGame(startupData)

--- a/indigo/indigo/src/main/scala/indigo/gameengine/GameLoop.scala
+++ b/indigo/indigo/src/main/scala/indigo/gameengine/GameLoop.scala
@@ -32,17 +32,19 @@ final class GameLoop[StartUpData, GameModel, ViewModel](
   @SuppressWarnings(Array("scalafix:DisableSyntax.var"))
   private var _viewModelState: ViewModel = initialViewModel
   @SuppressWarnings(Array("scalafix:DisableSyntax.var"))
-  private var _runningTimeReference: Long = 0
+  private var _runningTimeReference: Double = 0
   @SuppressWarnings(Array("scalafix:DisableSyntax.var"))
   private var _inputState: InputState = InputState.default
   @SuppressWarnings(Array("scalafix:DisableSyntax.var"))
   private var _running: Boolean = true
 
-  def gameModelState: GameModel  = _gameModelState
-  def viewModelState: ViewModel  = _viewModelState
-  def runningTimeReference: Long = _runningTimeReference
+  private val frameDeltaRecord: scala.scalajs.js.Array[Double] = scala.scalajs.js.Array(0.0d, 0.0d, 0.0d, 0.0d, 0.0d)
 
-  private val runner: (Long, Long, Long) => Unit =
+  def gameModelState: GameModel    = _gameModelState
+  def viewModelState: ViewModel    = _viewModelState
+  def runningTimeReference: Double = _runningTimeReference
+
+  private val runner: (Double, Double, Double) => Unit =
     gameConfig.frameRateLimit match
       case None =>
         (time, timeDelta, lastUpdateTime) =>
@@ -51,9 +53,26 @@ final class GameLoop[StartUpData, GameModel, ViewModel](
 
       case Some(fps) =>
         (time, timeDelta, lastUpdateTime) =>
-          if timeDelta >= gameConfig.frameRateDeltaMillis.toLong - 1 then
+          val d = timeDelta
+
+          frameDeltaRecord.shift()
+          frameDeltaRecord.push(d)
+
+          val mean   = frameDeltaRecord.sum / 5.0d // Same as number of inital entries
+          val target = gameConfig.frameRateDeltaMillis.toDouble
+
+          if d >= target then
             runFrame(time, timeDelta)
             gameEngine.platform.tick(gameEngine.gameLoop(time))
+          else if d + mean >= target then
+            val diff = d + mean - target
+            val t    = time + diff
+
+            gameEngine.platform.delay(
+              diff,
+              () => runFrame(t, timeDelta + diff)
+            )
+            gameEngine.platform.tick(gameEngine.gameLoop(t))
           else gameEngine.platform.tick(loop(lastUpdateTime))
 
   @SuppressWarnings(Array("scalafix:DisableSyntax.null"))
@@ -65,17 +84,18 @@ final class GameLoop[StartUpData, GameModel, ViewModel](
     _inputState = null
     ()
 
-  def loop(lastUpdateTime: Long): Long => Unit = { time =>
+  def loop(lastUpdateTime: Double): Double => Unit = { time =>
     _runningTimeReference = time
-    val timeDelta: Long = time - lastUpdateTime
+    val timeDelta: Double = time - lastUpdateTime
     if _running then runner(time, timeDelta, lastUpdateTime)
   }
 
   @SuppressWarnings(Array("scalafix:DisableSyntax.throw"))
-  private def runFrame(time: Long, timeDelta: Long): Unit =
+  private def runFrame(time: Double, timeDelta: Double): Unit =
 
-    val gameTime = new GameTime(Millis(time).toSeconds, Millis(timeDelta).toSeconds, gameConfig.frameRateLimit)
-    val events   = gameEngine.globalEventStream.collect ++ Batch(FrameTick)
+    val gameTime =
+      new GameTime(Millis(time.toLong).toSeconds, Millis(timeDelta.toLong).toSeconds, gameConfig.frameRateLimit)
+    val events = gameEngine.globalEventStream.collect ++ Batch(FrameTick)
 
     // Persist input state
     _inputState = InputState.calculateNext(

--- a/indigo/indigo/src/main/scala/indigo/gameengine/GameLoop.scala
+++ b/indigo/indigo/src/main/scala/indigo/gameengine/GameLoop.scala
@@ -53,19 +53,17 @@ final class GameLoop[StartUpData, GameModel, ViewModel](
 
       case Some(fps) =>
         (time, timeDelta, lastUpdateTime) =>
-          val d = timeDelta
-
           frameDeltaRecord.shift()
-          frameDeltaRecord.push(d)
+          frameDeltaRecord.push(timeDelta)
 
-          val mean   = frameDeltaRecord.sum / 5.0d // Same as number of inital entries
-          val target = gameConfig.frameRateDeltaMillis.toDouble
+          val meanDelta = frameDeltaRecord.sum / 5.0d     // Same as number of inital entries
+          val target    = gameConfig.frameRateDeltaMillis // E.g. 16.7ms for 60fps
 
-          if d >= target then
+          if timeDelta >= target then
             runFrame(time, timeDelta)
             gameEngine.platform.tick(gameEngine.gameLoop(time))
-          else if d + mean >= target then
-            val diff = d + mean - target
+          else if timeDelta + meanDelta >= target then
+            val diff = target - timeDelta
             val t    = time + diff
 
             gameEngine.platform.delay(

--- a/indigo/indigo/src/main/scala/indigo/platform/Platform.scala
+++ b/indigo/indigo/src/main/scala/indigo/platform/Platform.scala
@@ -61,10 +61,12 @@ class Platform(
       _ = _canvas = canvas
     } yield (renderer, assetMapping)
 
-  def tick(loop: Long => Unit): Unit = {
-    if _running then dom.window.requestAnimationFrame(t => loop(t.toLong))
+  def tick(loop: Double => Unit): Unit =
+    if _running then dom.window.requestAnimationFrame(loop)
     ()
-  }
+
+  def delay(amount: Double, thunk: () => Unit): Unit =
+    dom.window.setTimeout(thunk, amount)
 
   def kill(): Unit =
     _running = false

--- a/indigo/indigo/src/main/scala/indigo/shared/config/GameConfig.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/config/GameConfig.scala
@@ -31,7 +31,7 @@ final case class GameConfig(
     transparentBackground: Boolean,
     advanced: AdvancedGameConfig
 ) derives CanEqual:
-  lazy val frameRateDeltaMillis: Int = 1000 / frameRateLimit.map(_.toInt).getOrElse(FPS.Default.toInt)
+  lazy val frameRateDeltaMillis: Double = 1000.0d / frameRateLimit.map(_.toDouble).getOrElse(FPS.Default.toDouble)
 
   def screenDimensions: Rectangle =
     viewport.giveDimensions(magnification)

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/SandboxGame.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/SandboxGame.scala
@@ -90,7 +90,7 @@ object SandboxGame extends IndigoGame[SandboxBootData, SandboxStartupData, Sandb
           viewport = gameViewport,
           clearColor = RGBA(0.4, 0.2, 0.5, 1),
           magnification = magnificationLevel
-        ),
+        ).withFrameRateLimit(FPS.`60`),
         SandboxBootData(flags.getOrElse("key", "No entry for 'key'."), gameViewport)
       ).withAssets(
         SandboxAssets.assets ++


### PR DESCRIPTION
So [after all the back and forth](https://github.com/PurpleKingdomGames/indigo/issues/461), I seem to have a solution.

It isn't a perfect solution, but it appears to allow Indigo to more closely meet the desired framerate.

The advice to try [not to rely on this](https://github.com/PurpleKingdomGames/indigo/issues/472) remains. However rather than (on this machine) a frame rate of 144fps being asked to constrain to 60fps and actually being 48fps, it is now 64fps which is much more acceptable.

Essentially I'm tracking the mean frame delta and using that to guess if we're likely to overshoot on the next update, and taking corrective action. 

Will it work nicely across all platforms? Time will tell.