### PR TITLE
Fixed #451: Transparent backgrounds are transparent

### DIFF
--- a/indigo/build.sbt
+++ b/indigo/build.sbt
@@ -87,6 +87,7 @@ lazy val sandbox =
       title                 := "Sandbox",
       gameAssetsDirectory   := "assets",
       disableFrameRateLimit := false,
+      backgroundColor       := "black",
       electronInstall       := indigoplugin.ElectronInstall.Latest
     )
 

--- a/indigo/indigo/src/main/scala/indigo/platform/renderer/webgl2/RendererWebGL2.scala
+++ b/indigo/indigo/src/main/scala/indigo/platform/renderer/webgl2/RendererWebGL2.scala
@@ -141,7 +141,7 @@ final class RendererWebGL2(
   private var currentBlendFactors: (BlendFactor, BlendFactor) = (Blend.Normal.src, Blend.Normal.dst)
 
   private val transparentBlack: RGBA = RGBA.Black.makeTransparent
-  private val clearColor: RGBA = if config.transparentBackground then transparentBlack else config.clearColor
+  private val clearColor: RGBA       = if config.transparentBackground then transparentBlack else config.clearColor
 
   private given CanEqual[(BlendFactor, BlendFactor), (BlendFactor, BlendFactor)] = CanEqual.derived
 

--- a/indigo/indigo/src/main/scala/indigo/platform/renderer/webgl2/RendererWebGL2.scala
+++ b/indigo/indigo/src/main/scala/indigo/platform/renderer/webgl2/RendererWebGL2.scala
@@ -140,6 +140,9 @@ final class RendererWebGL2(
   @SuppressWarnings(Array("scalafix:DisableSyntax.var"))
   private var currentBlendFactors: (BlendFactor, BlendFactor) = (Blend.Normal.src, Blend.Normal.dst)
 
+  private val transparentBlack: RGBA = RGBA.Black.makeTransparent
+  private val clearColor: RGBA = if config.transparentBackground then transparentBlack else config.clearColor
+
   private given CanEqual[(BlendFactor, BlendFactor), (BlendFactor, BlendFactor)] = CanEqual.derived
 
   def init(shaders: Set[RawShaderCode]): Unit = {
@@ -308,7 +311,7 @@ final class RendererWebGL2(
         Some(scalingFrameBuffer),
         lastWidth,
         lastHeight,
-        RGBA.Black.makeTransparent,
+        transparentBlack,
         false,
         customShaders,
         StandardShaders.NormalBlend.id,
@@ -339,7 +342,7 @@ final class RendererWebGL2(
         None,
         lastWidth,
         lastHeight,
-        RGBA.Black.makeTransparent,
+        transparentBlack,
         false,
         customShaders,
         layer.shaderId,
@@ -356,7 +359,7 @@ final class RendererWebGL2(
       None,
       lastWidth,
       lastHeight,
-      config.clearColor,
+      clearColor,
       true,
       customShaders,
       sceneData.shaderId,


### PR DESCRIPTION
Fixes #451, as @hobnob rightly noted, this was to do with the clear colour. The fix was to decide _not_ to use the clear colour **at all** if the background is explicitly set to transparent in the config.

If you don't do that, you might have a clear colour with an alpha set to zero in your config, but the other colours are still multiplied against the browser background. I suspect this bug is due to pre-multiplied alpha and has probably arisen since that work was done ages ago, and no-one has noticed.

Once in a blue moon, it might be desirable to have Indigo affect the HTML elements under it too (e.g. I want to render the background in HTML but still have the whole thing flash based on a blend shader), but I don't think it's the expected behaviour in general. We could allow this if background transparency was modelled as a three state enum/ADT rather than a boolean, but as a boolean, I think it's either transparent or it isn't.

Horrifically ugly proof that is works:

![transparent_bg](https://user-images.githubusercontent.com/908709/219940139-6478c8b7-168c-4b43-8857-b9faeea36c55.png)

Yes I know, the 90s called and they want their background back. Anyway, that is a scene with a transparent background, HTML background-image on the body, and a blend shader tinting all the indigo bits (but only the indigo bits) red.
