### PR TITLE
Add basic Pointers state

### DIFF
--- a/indigo/indigo-extras/src/test/scala/indigoextras/ui/InputFieldTests.scala
+++ b/indigo/indigo-extras/src/test/scala/indigoextras/ui/InputFieldTests.scala
@@ -21,6 +21,7 @@ import indigo.shared.events.KeyboardEvent
 import indigo.shared.input.Gamepad
 import indigo.shared.input.Keyboard
 import indigo.shared.input.Mouse
+import indigo.shared.input.Pointers
 import indigo.shared.materials.Material
 import indigo.shared.scenegraph.Graphic
 import indigo.shared.scenegraph.Text
@@ -278,7 +279,7 @@ class InputFieldTests extends munit.FunSuite {
     new FrameContext[Unit](
       GameTime.zero,
       Dice.loaded(1),
-      new InputState(Mouse.default, new Keyboard(keysUp, Batch.empty, None), Gamepad.default),
+      new InputState(Mouse.default, new Keyboard(keysUp, Batch.empty, None), Gamepad.default, Pointers.default),
       new BoundaryLocator(new AnimationsRegister, new FontRegister, new DynamicText),
       ()
     )

--- a/indigo/indigo/src/main/scala/indigo/package.scala
+++ b/indigo/indigo/src/main/scala/indigo/package.scala
@@ -387,6 +387,9 @@ val MouseButton: shared.events.MouseButton.type = shared.events.MouseButton
 type MouseWheel = shared.events.MouseWheel
 val MouseWheel: shared.events.MouseWheel.type = shared.events.MouseWheel
 
+type Pointers = shared.input.Pointers
+val Pointers: shared.input.Pointers.type = shared.input.Pointers
+
 type PointerEvent = shared.events.PointerEvent
 val PointerEvent: shared.events.PointerEvent.type = shared.events.PointerEvent
 

--- a/indigo/indigo/src/main/scala/indigo/shared/events/InputState.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/events/InputState.scala
@@ -4,6 +4,7 @@ import indigo.shared.collections.Batch
 import indigo.shared.input.Gamepad
 import indigo.shared.input.Keyboard
 import indigo.shared.input.Mouse
+import indigo.shared.input.Pointers
 
 /** Holds a snapshot of the states of the various input types as they were entering this frame.
   *
@@ -14,7 +15,7 @@ import indigo.shared.input.Mouse
   * @param gamepad
   *   Current state of the gamepad
   */
-final class InputState(val mouse: Mouse, val keyboard: Keyboard, val gamepad: Gamepad) {
+final class InputState(val mouse: Mouse, val keyboard: Keyboard, val gamepad: Gamepad, val pointers: Pointers) {
 
   /** Given some input mappings, produce a guaranteed value A based on the current InputState.
     */
@@ -30,7 +31,7 @@ final class InputState(val mouse: Mouse, val keyboard: Keyboard, val gamepad: Ga
 
 object InputState {
   val default: InputState =
-    InputState(Mouse.default, Keyboard.default, Gamepad.default)
+    InputState(Mouse.default, Keyboard.default, Gamepad.default, Pointers.default)
 
   def calculateNext(
       previous: InputState,
@@ -40,6 +41,7 @@ object InputState {
     InputState(
       Mouse.calculateNext(previous.mouse, events.collect { case e: MouseEvent => e }),
       Keyboard.calculateNext(previous.keyboard, events.collect { case e: KeyboardEvent => e }),
-      gamepadState
+      gamepadState,
+      Pointers.calculateNext(previous.pointers, events.collect { case e: PointerEvent => e })
     )
 }

--- a/indigo/indigo/src/main/scala/indigo/shared/input/Pointers.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/input/Pointers.scala
@@ -1,0 +1,24 @@
+package indigo.shared.input
+
+import indigo.shared.collections.Batch
+import indigo.shared.datatypes.Point
+import indigo.shared.datatypes.Rectangle
+import indigo.shared.events.PointerEvent
+
+final class Pointers(
+    val pointerEvents: Batch[PointerEvent],
+    val position: Point
+)
+
+object Pointers:
+  val default: Pointers =
+    Pointers(Batch.empty, Point.zero)
+
+  def calculateNext(previous: Pointers, events: Batch[PointerEvent]) =
+    Pointers(
+      pointerEvents = events,
+      position = lastPointerPosition(previous.position, events)
+    )
+
+  private def lastPointerPosition(previous: Point, events: Batch[PointerEvent]): Point =
+    events.collect { case mp: PointerEvent.PointerMove => mp.position }.lastOption.fold(previous)(identity)

--- a/indigo/project/Misc.scala
+++ b/indigo/project/Misc.scala
@@ -27,7 +27,7 @@ object Misc {
     UsefulTask("", "sandboxRun", "Run the sandbox game (fastOptJS + Electron)"),
     UsefulTask("", "perfRun", "Run the perf game (fastOptJS + Electron)"),
     UsefulTask("", "shaderRun", "Run the shader game (fastOptJS + Electron)"),
-    UsefulTask("", "scalafmtCheckAll", "Launch VSCode"),
+    UsefulTask("", "scalafmtCheckAll", "Check formatting"),
     UsefulTask("", "code", "Launch VSCode")
   )
 


### PR DESCRIPTION
While [tinkering with gestures](https://github.com/grzegorz-bielski/pure-tetrio/blob/gesture-controls/frontend/src/main/scala/pureframes/tetrio/game/scenes/gameplay/viewmodel/TapGestureArea.scala) I discovered that I actually need access to sequence of pointer events from current frame. The easiest way to do it was to modify Indigo by adding barebones Pointers state.

While this doesn't resolve the https://github.com/PurpleKingdomGames/indigo/issues/476 or https://github.com/PurpleKingdomGames/indigo/issues/475 it could be a starting point that makes the experimentation a little bit easier.

I'd be nice to merge it before 0.15.0 😄 
