### PR TITLE
Circle Datatype

### DIFF
--- a/indigo/indigo-extras/src/main/scala/indigoextras/geometry/BoundingCircle.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/geometry/BoundingCircle.scala
@@ -66,6 +66,16 @@ final case class BoundingCircle(position: Vertex, radius: Double) derives CanEqu
 
   def resize(newRadius: Double): BoundingCircle =
     this.copy(radius = newRadius)
+  def resizeTo(newRadius: Double): BoundingCircle =
+    resize(newRadius)
+  def resizeBy(amount: Double): BoundingCircle =
+    expand(amount)
+  def withRadius(newRadius: Double): BoundingCircle =
+    resize(newRadius)
+  def expand(by: Double): BoundingCircle =
+    resize(radius + by)
+  def contract(by: Double): BoundingCircle =
+    resize(radius - by)
 
   def toCircle: Circle =
     Circle(position.toPoint, radius.toInt)

--- a/indigo/indigo-extras/src/main/scala/indigoextras/geometry/BoundingCircle.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/geometry/BoundingCircle.scala
@@ -14,6 +14,8 @@ final case class BoundingCircle(position: Vertex, radius: Double) derives CanEqu
   lazy val top: Double    = y - radius
   lazy val bottom: Double = y + radius
 
+  lazy val center: Vertex = position
+
   def toBoundingBox: BoundingBox =
     BoundingBox(Vertex(left, top), Vertex(diameter, diameter))
 

--- a/indigo/indigo-extras/src/main/scala/indigoextras/geometry/BoundingCircle.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/geometry/BoundingCircle.scala
@@ -2,6 +2,7 @@ package indigoextras.geometry
 
 import indigo.shared.collections.Batch
 import indigo.shared.datatypes.Vector2
+import indigo.shared.datatypes.Circle
 
 final case class BoundingCircle(position: Vertex, radius: Double) derives CanEqual:
   lazy val x: Double        = position.x
@@ -64,6 +65,9 @@ final case class BoundingCircle(position: Vertex, radius: Double) derives CanEqu
   def resize(newRadius: Double): BoundingCircle =
     this.copy(radius = newRadius)
 
+  def toCircle: Circle =
+    Circle(position.toPoint, radius.toInt)
+
   def lineIntersects(line: LineSegment): Boolean =
     BoundingCircle.lineIntersects(this, line)
 
@@ -87,6 +91,12 @@ object BoundingCircle:
 
   def fromVertexCloud(vertices: Batch[Vertex]): BoundingCircle =
     fromVertices(vertices)
+
+  def fromCircle(circle: Circle): BoundingCircle =
+    BoundingCircle(
+      Vertex.fromPoint(circle.position),
+      circle.radius.toDouble
+    )
 
   def fromBoundingBox(boundingBox: BoundingBox): BoundingCircle =
     BoundingCircle(boundingBox.center, Math.max(boundingBox.halfSize.x, boundingBox.halfSize.y))

--- a/indigo/indigo-extras/src/main/scala/indigoextras/geometry/BoundingCircle.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/geometry/BoundingCircle.scala
@@ -1,8 +1,8 @@
 package indigoextras.geometry
 
 import indigo.shared.collections.Batch
-import indigo.shared.datatypes.Vector2
 import indigo.shared.datatypes.Circle
+import indigo.shared.datatypes.Vector2
 
 final case class BoundingCircle(position: Vertex, radius: Double) derives CanEqual:
   lazy val x: Double        = position.x

--- a/indigo/indigo/src/main/scala/indigo/package.scala
+++ b/indigo/indigo/src/main/scala/indigo/package.scala
@@ -470,6 +470,9 @@ val TextAlignment: shared.datatypes.TextAlignment.type = shared.datatypes.TextAl
 type Rectangle = shared.datatypes.Rectangle
 val Rectangle: shared.datatypes.Rectangle.type = shared.datatypes.Rectangle
 
+type Circle = shared.datatypes.Circle
+val Circle: shared.datatypes.Circle.type = shared.datatypes.Circle
+
 type Point = shared.datatypes.Point
 val Point: shared.datatypes.Point.type = shared.datatypes.Point
 

--- a/indigo/indigo/src/main/scala/indigo/shared/BoundaryLocator.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/BoundaryLocator.scala
@@ -227,7 +227,7 @@ object BoundaryLocator:
       case s: Shape.Circle =>
         Rectangle(
           s.position,
-          Size(s.radius * 2) + s.stroke.width
+          Size(s.circle.radius * 2) + s.stroke.width
         )
 
       case s: Shape.Line =>

--- a/indigo/indigo/src/main/scala/indigo/shared/datatypes/Circle.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/datatypes/Circle.scala
@@ -1,0 +1,99 @@
+package indigo.shared.datatypes
+
+import indigo.shared.collections.Batch
+import indigo.shared.datatypes.Vector2
+
+final case class Circle(position: Point, radius: Int) derives CanEqual:
+  lazy val x: Int        = position.x
+  lazy val y: Int        = position.y
+  lazy val diameter: Int = radius * 2
+
+  lazy val left: Int   = x - radius
+  lazy val right: Int  = x + radius
+  lazy val top: Int    = y - radius
+  lazy val bottom: Int = y + radius
+
+  def toRectangle: Rectangle =
+    Rectangle(Point(left, top), Size(diameter, diameter))
+
+  def contains(vertex: Point): Boolean =
+    vertex.distanceTo(position) <= radius
+  def contains(x: Int, y: Int): Boolean =
+    contains(Point(x, y))
+  def contains(vector: Vector2): Boolean =
+    contains(vector.toPoint)
+
+  def +(d: Int): Circle = resize(radius + d)
+  def -(d: Int): Circle = resize(radius - d)
+  def *(d: Int): Circle = resize(radius * d)
+  def /(d: Int): Circle = resize(radius / d)
+
+  def sdf(vertex: Point): Int =
+    Circle.signedDistanceFunction(vertex - position, radius)
+  def sdf(vector: Vector2): Int =
+    sdf(vector.toPoint)
+
+  def distanceToBoundary(vertex: Point): Int =
+    sdf(vertex)
+  def distanceToBoundary(vector: Vector2): Int =
+    sdf(vector.toPoint)
+
+  def expandToInclude(other: Circle): Circle =
+    Circle.expandToInclude(this, other)
+
+  def encompasses(other: Circle): Boolean =
+    Circle.encompassing(this, other)
+
+  def overlaps(other: Circle): Boolean =
+    Circle.overlapping(this, other)
+
+  def moveBy(amount: Point): Circle =
+    this.copy(position = position + amount)
+  def moveBy(x: Int, y: Int): Circle =
+    moveBy(Point(x, y))
+  def moveBy(amount: Vector2): Circle =
+    moveBy(amount.toPoint)
+
+  def moveTo(newPosition: Point): Circle =
+    this.copy(position = newPosition)
+  def moveTo(x: Int, y: Int): Circle =
+    moveTo(Point(x, y))
+  def moveTo(newPosition: Vector2): Circle =
+    moveTo(newPosition.toPoint)
+
+  def resize(newRadius: Int): Circle =
+    this.copy(radius = newRadius)
+
+object Circle:
+
+  val zero: Circle =
+    Circle(Point.zero, 0)
+
+  def apply(x: Int, y: Int, radius: Int): Circle =
+    Circle(Point(x, y), radius)
+
+  def fromTwoPoints(center: Point, boundary: Point): Circle =
+    Circle(center, center.distanceTo(boundary).toInt)
+
+  def fromPoint(points: Batch[Point]): Circle =
+    val bb = Rectangle.fromPointCloud(points)
+    Circle(bb.center, bb.center.distanceTo(bb.topLeft).toInt)
+
+  def fromPointCloud(points: Batch[Point]): Circle =
+    fromPoint(points)
+
+  def fromRectangle(rectangle: Rectangle): Circle =
+    Circle(rectangle.center, Math.max(rectangle.halfSize.width, rectangle.halfSize.height))
+
+  def expandToInclude(a: Circle, b: Circle): Circle =
+    a.resize((a.position.distanceTo(b.position) + Math.abs(b.radius)).toInt)
+
+  def encompassing(a: Circle, b: Circle): Boolean =
+    a.position.distanceTo(b.position) <= Math.abs(a.radius) - Math.abs(b.radius)
+
+  def overlapping(a: Circle, b: Circle): Boolean =
+    a.position.distanceTo(b.position) < Math.abs(a.radius) + Math.abs(b.radius)
+
+  // Centered at the origin
+  def signedDistanceFunction(point: Point, radius: Int): Int =
+    (point.toVector.length - radius).toInt

--- a/indigo/indigo/src/main/scala/indigo/shared/datatypes/Circle.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/datatypes/Circle.scala
@@ -13,6 +13,8 @@ final case class Circle(position: Point, radius: Int) derives CanEqual:
   lazy val top: Int    = y - radius
   lazy val bottom: Int = y + radius
 
+  lazy val center: Point = position
+
   def toRectangle: Rectangle =
     Rectangle(Point(left, top), Size(diameter, diameter))
 
@@ -63,6 +65,16 @@ final case class Circle(position: Point, radius: Int) derives CanEqual:
 
   def resize(newRadius: Int): Circle =
     this.copy(radius = newRadius)
+  def resizeTo(newRadius: Int): Circle =
+    resize(newRadius)
+  def resizeBy(amount: Int): Circle =
+    expand(amount)
+  def withRadius(newRadius: Int): Circle =
+    resize(newRadius)
+  def expand(by: Int): Circle =
+    resize(radius + by)
+  def contract(by: Int): Circle =
+    resize(radius - by)
 
 object Circle:
 

--- a/indigo/indigo/src/main/scala/indigo/shared/scenegraph/Shape.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/scenegraph/Shape.scala
@@ -12,6 +12,7 @@ import indigo.shared.datatypes.Rectangle
 import indigo.shared.datatypes.Size
 import indigo.shared.datatypes.Stroke
 import indigo.shared.datatypes.Vector2
+import indigo.shared.datatypes.Circle as C
 import indigo.shared.events.GlobalEvent
 import indigo.shared.materials.LightingModel
 import indigo.shared.materials.LightingModel.Lit
@@ -205,8 +206,7 @@ object Shape:
   /** Draws a coloured circle from it's center outwards.
     */
   final case class Circle(
-      center: Point,
-      radius: Int,
+      circle: C,
       fill: Fill,
       stroke: Stroke,
       lighting: LightingModel,
@@ -221,9 +221,9 @@ object Shape:
   ) extends Shape[Circle] {
 
     lazy val position: Point =
-      center - radius - (stroke.width / 2)
+      circle.center - circle.radius - (stroke.width / 2)
     lazy val size: Size =
-      Size(radius * 2) + stroke.width
+      Size(circle.radius * 2) + stroke.width
 
     @deprecated("Use `withFill` instead")
     def withFillColor(newFill: Fill): Circle =
@@ -245,11 +245,11 @@ object Shape:
       this.copy(stroke = stroke.withWidth(newWidth))
 
     def withRadius(newRadius: Int): Circle =
-      this.copy(radius = newRadius)
+      this.copy(circle = circle.withRadius(newRadius))
     def resizeTo(newRadius: Int): Circle =
       withRadius(newRadius)
     def resizeBy(amount: Int): Circle =
-      withRadius(radius + amount)
+      withRadius(circle.radius + amount)
 
     def withLighting(newLighting: LightingModel): Circle =
       this.copy(lighting = newLighting)
@@ -257,14 +257,14 @@ object Shape:
       this.copy(lighting = modifier(lighting))
 
     def moveTo(pt: Point): Circle =
-      this.copy(center = pt)
+      this.copy(circle = circle.moveTo(pt))
     def moveTo(x: Int, y: Int): Circle =
       moveTo(Point(x, y))
     def withPosition(newPosition: Point): Circle =
       moveTo(newPosition)
 
     def moveBy(pt: Point): Circle =
-      this.copy(center = center + pt)
+      this.copy(circle = circle.moveBy(pt))
     def moveBy(x: Int, y: Int): Circle =
       moveBy(Point(x, y))
 
@@ -283,7 +283,7 @@ object Shape:
       this.copy(scale = newScale)
 
     def transformTo(newPosition: Point, newRotation: Radians, newScale: Vector2): Circle =
-      this.copy(center = newPosition, rotation = newRotation, scale = newScale)
+      this.copy(circle = circle.moveTo(newPosition), rotation = newRotation, scale = newScale)
 
     def transformBy(positionDiff: Point, rotationDiff: Radians, scaleDiff: Vector2): Circle =
       transformTo(position + positionDiff, rotation + rotationDiff, scale * scaleDiff)
@@ -320,8 +320,7 @@ object Shape:
 
     def apply(center: Point, radius: Int, fill: Fill): Circle =
       Circle(
-        center,
-        radius,
+        C(center, radius),
         fill,
         Stroke.None,
         LightingModel.Unlit,
@@ -337,8 +336,7 @@ object Shape:
 
     def apply(center: Point, radius: Int, fill: Fill, stroke: Stroke): Circle =
       Circle(
-        center,
-        radius,
+        C(center, radius),
         fill,
         stroke,
         LightingModel.Unlit,

--- a/indigo/indigo/src/test/scala/indigo/shared/datatypes/CircleTests.scala
+++ b/indigo/indigo/src/test/scala/indigo/shared/datatypes/CircleTests.scala
@@ -1,0 +1,108 @@
+package indigo.shared.datatypes
+
+import indigo.shared.collections.Batch
+
+class CircleTests extends munit.FunSuite {
+
+  test("contains") {
+    val c = Circle(Point(20, 20), 10)
+
+    assert(c.contains(Point(15, 15)))
+    assert(!c.contains(Point.zero))
+  }
+
+  test("expandToInclude") {
+    val c1 = Circle(Point(20, 20), 10)
+    val c2 = Circle(Point(40, 20), 5)
+    val c3 = Circle(Point(20, 20), 25)
+
+    assertEquals(c1.expandToInclude(c2), c3)
+  }
+
+  test("encompasses") {
+    val c1 = Circle(Point(20, 20), 10)
+    val c2 = Circle(Point(40, 20), 5)
+    val c3 = Circle(Point(20, 20), 25)
+
+    assert(c3.encompasses(c1))
+    assert(c3.encompasses(c2))
+    assert(!c1.encompasses(c2))
+  }
+
+  test("overlaps") {
+    val c1 = Circle(Point(20, 20), 10)
+    val c2 = Circle(Point(25, 25), 10)
+    val c3 = Circle(Point(10, 40), 10)
+
+    assert(c1 overlaps c2)
+    assert(!(c1 overlaps c3))
+  }
+
+  test("moveBy | moveTo") {
+    val c = Circle(Point(20, 20), 10)
+
+    assertEquals(c.moveBy(1, 2).position, Point(21, 22))
+    assertEquals(c.moveTo(1, 2).position, Point(1, 2))
+  }
+
+  test("resize") {
+    val c = Circle(Point(20, 20), 10)
+
+    assertEquals(c.resize(5).radius, 5)
+  }
+
+  test("Constructor - fromTwoVertices") {
+    val c = Circle.fromTwoPoints(Point(5, 10), Point(5, -10))
+
+    assertEquals(c.position, Point(5, 10))
+    assertEquals(c.radius, 20)
+  }
+
+  test("Constructor - fromVertices") {
+    val actual =
+      Circle.fromPointCloud(
+        Batch(
+          Point(10, 10), // tl
+          Point(20, 10), // tr
+          Point(20, 20), // br
+          Point(10, 20)  // bl
+        )
+      )
+
+    val expected =
+      Circle(Point(15, 15), Point(15, 15).distanceTo(Point(10, 10)).toInt)
+
+    assertEquals(actual.position, expected.position)
+    assert(doubleCloseEnough(actual.radius, expected.radius))
+  }
+
+  test("signed distance function") {
+    val c = Circle(Point(20, 20), 10)
+
+    // top
+    assertEquals(c.sdf(Point(20, 1)), 9)
+
+    // bottom
+    assertEquals(c.sdf(Point(20, 55)), 25)
+
+    // left
+    assertEquals(c.sdf(Point(-10, 20)), 20)
+
+    // right
+    assertEquals(c.sdf(Point(33, 20)), 3)
+
+    // edge
+    assertEquals(c.sdf(Point(10, 20)), 0)
+
+    // inside
+    assertEquals(c.sdf(Point(12, 20)), -2)
+
+    // Diagonal
+    assertEquals(c.sdf(Point.zero), 18)
+
+  }
+
+  def doubleCloseEnough(r1: Double, r2: Double): Boolean =
+    r1 - 0.001 < r2 && r1 + 0.001 > r2
+
+}


### PR DESCRIPTION
While chatting to @zetashift, I knocked up this first commit for a new Circle type.

However, I tried to incorporate it into `Shape.Circle` and two things happened:

1. I had a name collision `Shape.Circle` and `Circle` - yuk!
2. I realised that the complementary type to `Rectangle` is not `Circle`, but `Oval`. I may need an `Oval` and a `BoundingOval` type!