### PR TITLE
Fixed #539: BoundingBox lineIntersect fails at 0,0

### DIFF
--- a/indigo/indigo/src/main/scala/indigo/shared/geometry/BoundingBox.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/geometry/BoundingBox.scala
@@ -222,16 +222,15 @@ object BoundingBox:
   def lineIntersects(boundingBox: BoundingBox, line: LineSegment): Boolean =
     @tailrec
     def rec(remaining: List[LineSegment]): Boolean =
-      remaining match {
+      remaining match
         case Nil =>
           false
 
-        case x :: _ if x.intersectsAt(line).isDefined =>
+        case x :: _ if x.intersectsWith(line) =>
           true
 
         case _ :: xs =>
           rec(xs)
-      }
 
     val containsStart = boundingBox.contains(line.start)
     val containsEnd   = boundingBox.contains(line.end)

--- a/indigo/indigo/src/main/scala/indigo/shared/geometry/Line.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/geometry/Line.scala
@@ -11,10 +11,12 @@ sealed trait Line derives CanEqual:
 object Line:
   final case class Components(m: Double, b: Double) extends Line:
 
+    /** This is a slope comparison function. Any point on the line should have the same slope as the line, however, this
+      * fails in the case where the x position of the vertex is 0.
+      */
     def slopeComparison(vertex: Vertex, tolerance: Double): Boolean =
-      // This is a slope comparison.. Any point on the line should have the same slope as the line.
       val m2: Double =
-        if (vertex.x == 0) 0
+        if vertex.x == 0 then 0
         else (b - vertex.y) / (0 - vertex.x)
 
       val mDelta: Double =

--- a/indigo/indigo/src/main/scala/indigo/shared/geometry/LineSegment.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/geometry/LineSegment.scala
@@ -84,36 +84,18 @@ final case class LineSegment(start: Vertex, end: Vertex) derives CanEqual:
 
   def intersectsAt(other: LineSegment): Option[Vertex] =
     toLine.intersectsAt(other.toLine).flatMap { pt =>
-      if (contains(pt) && other.contains(pt)) Some(pt)
+      if contains(pt) && other.contains(pt) then Some(pt)
       else None
     }
 
   def intersectsWith(other: LineSegment): Boolean =
-    toLine
-      .intersectsAt(other.toLine)
-      .map(pt => contains(pt) && other.contains(pt))
-      .getOrElse(false)
-
-  @deprecated("use `intersectsWith` instead.")
-  def intersectsWithLine(other: LineSegment): Boolean =
-    intersectsWith(other)
+    intersectsAt(other).isDefined
 
   def contains(vertex: Vertex, tolerance: Double): Boolean =
-    if (vertex.x >= left && vertex.x <= right && vertex.y >= top && vertex.y <= bottom)
-      toLine match {
-        case Line.InvalidLine =>
-          false
-
-        case _: Line.ParallelToAxisY =>
-          true
-
-        case l: Line.Components =>
-          l.slopeComparison(vertex, tolerance)
-      }
-    else false
+    sdf(vertex) <= tolerance
 
   def contains(vertex: Vertex): Boolean =
-    contains(vertex, 0.5d)
+    contains(vertex, 0.001)
   def contains(vector: Vector2): Boolean =
     contains(Vertex.fromVector2(vector))
 

--- a/indigo/indigo/src/test/scala/indigo/shared/geometry/BoundingBoxTests.scala
+++ b/indigo/indigo/src/test/scala/indigo/shared/geometry/BoundingBoxTests.scala
@@ -169,6 +169,21 @@ class BoundingBoxTests extends munit.FunSuite {
     assert(!BoundingBox(5, 5, 4, 4).lineIntersects(LineSegment((0d, 0d), (3d, 3d))))
   }
 
+  test("intersecting lines.detecting a hit through zero coord") {
+
+    val l = LineSegment(Vertex(1), Vertex(-1))
+
+    // In the original test case,
+    // This worked...
+    assert(BoundingBox(Vertex(0.1), Vertex(2)).lineIntersects(l))
+    assertEquals(BoundingBox(Vertex(0.1), Vertex(2)).lineIntersectsAt(l), Some(Vertex(0.1)))
+
+    // But this didn't...
+    assert(BoundingBox(Vertex(0), Vertex(2)).lineIntersects(l))
+    assertEquals(BoundingBox(Vertex(0), Vertex(2)).lineIntersectsAt(l), Some(Vertex(0)))
+
+  }
+
   test("encompasing bounding box.should return true when A encompases B") {
     val a = BoundingBox(10, 10, 110, 110)
     val b = BoundingBox(20, 20, 10, 10)


### PR DESCRIPTION
The solution was to change approach. The old method used a slope comparison function which fails in the specific case where `x == 0`. Instead, we now do an SDF check.