### PR TITLE
Mouse and Pointer Events

### DIFF
--- a/examples/subsystems/src/main/scala/indigoexamples/SubSystemsExample.scala
+++ b/examples/subsystems/src/main/scala/indigoexamples/SubSystemsExample.scala
@@ -33,7 +33,7 @@ object SubSystemsExample extends IndigoDemo[Unit, Unit, Unit, Unit] {
     Outcome(())
 
   def updateModel(context: FrameContext[Unit], model: Unit): GlobalEvent => Outcome[Unit] = {
-    case e @ MouseEvent.Click(_, _, _, _, _, _, _, _) =>
+    case e: MouseEvent.Click =>
       Outcome(())
         .addGlobalEvents(
           PointsTrackerEvent.Add(10),

--- a/examples/subsystems/src/main/scala/indigoexamples/SubSystemsExample.scala
+++ b/examples/subsystems/src/main/scala/indigoexamples/SubSystemsExample.scala
@@ -33,7 +33,7 @@ object SubSystemsExample extends IndigoDemo[Unit, Unit, Unit, Unit] {
     Outcome(())
 
   def updateModel(context: FrameContext[Unit], model: Unit): GlobalEvent => Outcome[Unit] = {
-    case e @ MouseEvent.Click(_) =>
+    case e @ MouseEvent.Click(_, _, _, _, _, _, _, _) =>
       Outcome(())
         .addGlobalEvents(
           PointsTrackerEvent.Add(10),

--- a/examples/text/src/main/scala/indigoexamples/TextExample.scala
+++ b/examples/text/src/main/scala/indigoexamples/TextExample.scala
@@ -51,7 +51,7 @@ object TextExample extends IndigoSandbox[Unit, Model] {
           Material.ImageEffects(fontName).withTint(model.tint)
         ).alignRight
           .onEvent {
-            case (txt, MouseEvent.Click(pt)) if context.bounds(txt).contains(pt) =>
+            case (txt, MouseEvent.Click(pt, _, _, _, _, _, _, _)) if context.bounds(txt).contains(pt) =>
               ChangeColour
           }
       )

--- a/examples/text/src/main/scala/indigoexamples/TextExample.scala
+++ b/examples/text/src/main/scala/indigoexamples/TextExample.scala
@@ -51,7 +51,7 @@ object TextExample extends IndigoSandbox[Unit, Model] {
           Material.ImageEffects(fontName).withTint(model.tint)
         ).alignRight
           .onEvent {
-            case (txt, MouseEvent.Click(pt, _, _, _, _, _, _, _)) if context.bounds(txt).contains(pt) =>
+            case (txt, e: MouseEvent.Click) if context.bounds(txt).contains(e.position) =>
               ChangeColour
           }
       )

--- a/indigo/docs/gameloop/events.md
+++ b/indigo/docs/gameloop/events.md
@@ -77,17 +77,27 @@ Handling `InputEvent`s can be a bit tricky in some situations, so Indigo include
 
 What did the mouse do and at what location?
 
+A Mouse event consists of the following properties:
+
+- `position` - The location of the mouse
+- `buttons` - The buttons that were down at the time of the event
+- `isAltKeyDown` - Whether the `alt` key is held down
+- `isCtrlKeyDown` - Whether the `ctrl` key is held down
+- `isMetaKeyDown` - Whether the `windows` or `cmd` key was held down
+- `isShiftKeyDown` - Whether the `shift` key was held down
+- `movementPosition` - The difference between the position of this event, and the last mouse event
+
+For events (such as `Click`) where a button is pressed, an additional `button` property is provided.
+
 Up to five mouse buttons are supported, including the most common left, middle and right buttons.
 
-Convenience functions are provided for the left mouse button.
+The following events are available:
 
-- `Click(x, y)`
-- `MouseUp(x, y, button)`
-- `MouseDown(x, y, button)`
-- `Move(x, y)`
-- `Wheel(x, y, amount)`
-
-Notice however that the `Click` event is restricted to the left mouse button, and `Move` is independent of any button.
+- `Click(position, buttons, isAltKeyDown, isCtrlKeyDown, isMetaKeyDown, isShiftKeyDown, movementPosition, button)`
+- `MouseUp(position, buttons, isAltKeyDown, isCtrlKeyDown, isMetaKeyDown, isShiftKeyDown, movementPosition, button)`
+- `MouseDown(position, buttons, isAltKeyDown, isCtrlKeyDown, isMetaKeyDown, isShiftKeyDown, movementPosition, button)`
+- `Move(position, buttons, isAltKeyDown, isCtrlKeyDown, isMetaKeyDown, isShiftKeyDown, movementPosition)`
+- `Wheel(position, buttons, isAltKeyDown, isCtrlKeyDown, isMetaKeyDown, isShiftKeyDown, movementPosition, amount)`
 
 #### `KeyboardEvent`s
 

--- a/indigo/docs/quickstart/hello-indigo.md
+++ b/indigo/docs/quickstart/hello-indigo.md
@@ -377,7 +377,8 @@ def updateModel(
     context: FrameContext[Unit],
     model: Model
 ): GlobalEvent => Outcome[Model] = {
-  case MouseEvent.Click(clickPoint, _, _, _, _, _, _, _) =>
+  case e: MouseEvent.Click =>
+    val clickPoint       = e.position
     val adjustedPosition = clickPoint - model.center
 
     Outcome(

--- a/indigo/docs/quickstart/hello-indigo.md
+++ b/indigo/docs/quickstart/hello-indigo.md
@@ -86,7 +86,7 @@ import scala.scalajs.js.annotation.JSExportTopLevel
 @JSExportTopLevel("IndigoGame")
 ```
 
-Indigo games are Scala.js projects. We've worked hard to make Indigo feel as much like a normal Scala project as possible, however, we do need a hook for the page. If you're using the standard Indigo Mill or SBT plugins, you ***must name your game "IndigoGame" or it won't work***. Once you move to your own page embed you can call it whatever you like!
+Indigo games are Scala.js projects. We've worked hard to make Indigo feel as much like a normal Scala project as possible, however, we do need a hook for the page. If you're using the standard Indigo Mill or SBT plugins, you _**must name your game "IndigoGame" or it won't work**_. Once you move to your own page embed you can call it whatever you like!
 
 `IndigoSandbox` takes two type parameters that define your start up data type, and the type of your model. Later on we'll introduce a real model, but for now we're just using `Unit` to say "I'm not using these".
 
@@ -263,7 +263,7 @@ graphic.moveBy((d * 600).toInt, 0)
 
 That is, we say that we want a velocity of 600 pixels per second, but multiply that 600 by the fraction of a second since the last frame update. At 60 FPS, `600 * 0.01666 = 9.996` i.e near as makes no odds the 10 pixel movement we wanted, while at a dip to 55 FPS we get `600 * 0.01818 = 10.908`, meaning that you move a little further to make up for lost time.
 
-> This is known as ***frame independent movement***.
+> This is known as _**frame independent movement**_.
 
 ## It isn't a game, if you can't play with it
 
@@ -377,7 +377,7 @@ def updateModel(
     context: FrameContext[Unit],
     model: Model
 ): GlobalEvent => Outcome[Model] = {
-  case MouseEvent.Click(clickPoint) =>
+  case MouseEvent.Click(clickPoint, _, _, _, _, _, _, _) =>
     val adjustedPosition = clickPoint - model.center
 
     Outcome(
@@ -450,7 +450,7 @@ def drawDots(
   }
 
 SceneUpdateFragment(
-  Graphic(Rectangle(0, 0, 32, 32), 1, Material.Bitmap(assetName)) :: 
+  Graphic(Rectangle(0, 0, 32, 32), 1, Material.Bitmap(assetName)) ::
     drawDots(model.center, model.dots)
 )
 ```

--- a/indigo/indigo/src/main/scala/indigo/platform/events/WorldEvents.scala
+++ b/indigo/indigo/src/main/scala/indigo/platform/events/WorldEvents.scala
@@ -3,14 +3,11 @@ package indigo.platform.events
 import indigo.shared.collections.Batch
 import indigo.shared.constants.Key
 import indigo.shared.datatypes.Point
-<<<<<<< HEAD
+import indigo.shared.datatypes.Radians
 import indigo.shared.events.ApplicationGainedFocus
 import indigo.shared.events.ApplicationLostFocus
 import indigo.shared.events.CanvasGainedFocus
 import indigo.shared.events.CanvasLostFocus
-=======
-import indigo.shared.datatypes.Radians
->>>>>>> fe2d8f565 (Mouse and Pointer events now contain a more props)
 import indigo.shared.events.KeyboardEvent
 import indigo.shared.events.MouseButton
 import indigo.shared.events.MouseEvent

--- a/indigo/indigo/src/main/scala/indigo/platform/events/WorldEvents.scala
+++ b/indigo/indigo/src/main/scala/indigo/platform/events/WorldEvents.scala
@@ -138,6 +138,7 @@ final class WorldEvents:
         globalEventStream.pushGlobalEvent(
           PointerEnter(position, PointerId(e.pointerId), Buttons(e.buttons), e.isPrimary)
         )
+        globalEventStream.pushGlobalEvent(MouseEvent.Enter(position))
       },
       onPointerLeave = { e =>
         val position = e.position(magnification, canvas)
@@ -145,6 +146,7 @@ final class WorldEvents:
         globalEventStream.pushGlobalEvent(
           PointerLeave(position, PointerId(e.pointerId), Buttons(e.buttons), e.isPrimary)
         )
+        globalEventStream.pushGlobalEvent(MouseEvent.Leave(position))
       },
       onPointerDown = { e =>
         val position = e.position(magnification, canvas)

--- a/indigo/indigo/src/main/scala/indigo/platform/events/WorldEvents.scala
+++ b/indigo/indigo/src/main/scala/indigo/platform/events/WorldEvents.scala
@@ -448,6 +448,14 @@ final class WorldEvents:
     _handlers = None
   }
 
+  extension (e: dom.FocusEvent)
+    def isWindowTarget: Boolean =
+      val target = e.target
+      target match {
+        case e: dom.Element if e.tagName == "WINDOW" => true
+        case _                                       => false
+      }
+
   extension (e: dom.MouseEvent)
     /** @return
       *   position relative to magnification level

--- a/indigo/indigo/src/main/scala/indigo/platform/events/WorldEvents.scala
+++ b/indigo/indigo/src/main/scala/indigo/platform/events/WorldEvents.scala
@@ -1,11 +1,16 @@
 package indigo.platform.events
 
+import indigo.shared.collections.Batch
 import indigo.shared.constants.Key
 import indigo.shared.datatypes.Point
+<<<<<<< HEAD
 import indigo.shared.events.ApplicationGainedFocus
 import indigo.shared.events.ApplicationLostFocus
 import indigo.shared.events.CanvasGainedFocus
 import indigo.shared.events.CanvasLostFocus
+=======
+import indigo.shared.datatypes.Radians
+>>>>>>> fe2d8f565 (Mouse and Pointer events now contain a more props)
 import indigo.shared.events.KeyboardEvent
 import indigo.shared.events.MouseButton
 import indigo.shared.events.MouseEvent
@@ -13,6 +18,7 @@ import indigo.shared.events.NetworkEvent
 import indigo.shared.events.NetworkEvent.*
 import indigo.shared.events.PointerEvent
 import indigo.shared.events.PointerEvent.*
+import indigo.shared.events.PointerType
 import org.scalajs.dom
 import org.scalajs.dom.document
 import org.scalajs.dom.html
@@ -107,9 +113,23 @@ final class WorldEvents:
       canvas = canvas,
       // onClick only supports the left mouse button
       onClick = { e =>
-        globalEventStream.pushGlobalEvent(
-          MouseEvent.Click(e.position(magnification, canvas))
-        )
+        MouseButton.fromOrdinalOpt(e.button).foreach { button =>
+          val position         = e.position(magnification, canvas)
+          val buttons          = e.indigoButtons
+          val movementPosition = e.movementPosition(magnification)
+          globalEventStream.pushGlobalEvent(
+            MouseEvent.Click(
+              position,
+              buttons,
+              e.altKey,
+              e.ctrlKey,
+              e.metaKey,
+              e.shiftKey,
+              movementPosition,
+              button
+            )
+          )
+        }
       },
       /*
           Follows the most conventional, basic definition of wheel.
@@ -120,7 +140,19 @@ final class WorldEvents:
           More info: https://developer.mozilla.org/en-US/docs/Web/API/WheelEvent
        */
       onWheel = { e =>
-        val wheel = MouseEvent.Wheel(e.position(magnification, canvas), e.deltaY)
+        val position         = e.position(magnification, canvas)
+        val buttons          = e.indigoButtons
+        val movementPosition = e.movementPosition(magnification)
+        val wheel = MouseEvent.Wheel(
+          position,
+          buttons,
+          e.altKey,
+          e.ctrlKey,
+          e.metaKey,
+          e.shiftKey,
+          movementPosition,
+          e.deltaY
+        )
 
         globalEventStream.pushGlobalEvent(wheel)
       },
@@ -133,57 +165,252 @@ final class WorldEvents:
       // Prevent right mouse button from popping up the context menu
       onContextMenu = if disableContextMenu then Some((e: dom.MouseEvent) => e.preventDefault()) else None,
       onPointerEnter = { e =>
-        val position = e.position(magnification, canvas)
+        val position         = e.position(magnification, canvas)
+        val buttons          = e.indigoButtons
+        val movementPosition = e.movementPosition(magnification)
+        val pointerType      = e.indigoPointerType
 
         globalEventStream.pushGlobalEvent(
-          PointerEnter(position, PointerId(e.pointerId), Buttons(e.buttons), e.isPrimary)
+          PointerEnter(
+            position,
+            buttons,
+            e.altKey,
+            e.ctrlKey,
+            e.metaKey,
+            e.shiftKey,
+            movementPosition,
+            PointerId(e.pointerId),
+            e.width(magnification),
+            e.height(magnification),
+            e.pressure,
+            e.tangentialPressure,
+            Radians.fromDegrees(e.tiltX),
+            Radians.fromDegrees(e.tiltY),
+            Radians.fromDegrees(e.twist),
+            pointerType,
+            e.isPrimary
+          )
         )
-        globalEventStream.pushGlobalEvent(MouseEvent.Enter(position))
+
+        if pointerType == PointerType.Mouse then {
+          globalEventStream.pushGlobalEvent(
+            MouseEvent.Enter(
+              position,
+              buttons,
+              e.altKey,
+              e.ctrlKey,
+              e.metaKey,
+              e.shiftKey,
+              movementPosition
+            )
+          )
+        }
       },
       onPointerLeave = { e =>
-        val position = e.position(magnification, canvas)
+        val position         = e.position(magnification, canvas)
+        val buttons          = e.indigoButtons
+        val movementPosition = e.movementPosition(magnification)
+        val pointerType      = e.indigoPointerType
 
         globalEventStream.pushGlobalEvent(
-          PointerLeave(position, PointerId(e.pointerId), Buttons(e.buttons), e.isPrimary)
+          PointerLeave(
+            position,
+            buttons,
+            e.altKey,
+            e.ctrlKey,
+            e.metaKey,
+            e.shiftKey,
+            movementPosition,
+            PointerId(e.pointerId),
+            e.width(magnification),
+            e.height(magnification),
+            e.pressure,
+            e.tangentialPressure,
+            Radians.fromDegrees(e.tiltX),
+            Radians.fromDegrees(e.tiltY),
+            Radians.fromDegrees(e.twist),
+            pointerType,
+            e.isPrimary
+          )
         )
-        globalEventStream.pushGlobalEvent(MouseEvent.Leave(position))
+
+        if pointerType == PointerType.Mouse then {
+          globalEventStream.pushGlobalEvent(
+            MouseEvent.Leave(
+              position,
+              buttons,
+              e.altKey,
+              e.ctrlKey,
+              e.metaKey,
+              e.shiftKey,
+              movementPosition
+            )
+          )
+        }
       },
       onPointerDown = { e =>
-        val position = e.position(magnification, canvas)
+        val position         = e.position(magnification, canvas)
+        val buttons          = e.indigoButtons
+        val movementPosition = e.movementPosition(magnification)
+        val pointerType      = e.indigoPointerType
 
         globalEventStream.pushGlobalEvent(
-          PointerDown(position, PointerId(e.pointerId), Buttons(e.buttons), e.isPrimary)
+          PointerDown(
+            position,
+            buttons,
+            e.altKey,
+            e.ctrlKey,
+            e.metaKey,
+            e.shiftKey,
+            movementPosition,
+            PointerId(e.pointerId),
+            e.width(magnification),
+            e.height(magnification),
+            e.pressure,
+            e.tangentialPressure,
+            Radians.fromDegrees(e.tiltX),
+            Radians.fromDegrees(e.tiltY),
+            Radians.fromDegrees(e.twist),
+            pointerType,
+            e.isPrimary,
+            MouseButton.fromOrdinalOpt(e.button)
+          )
         )
-        MouseButton.fromOrdinalOpt(e.button).foreach { button =>
-          globalEventStream.pushGlobalEvent(MouseEvent.MouseDown(position, button))
+
+        if pointerType == PointerType.Mouse then {
+          MouseButton.fromOrdinalOpt(e.button).foreach { button =>
+            globalEventStream.pushGlobalEvent(
+              MouseEvent.MouseDown(
+                position,
+                buttons,
+                e.altKey,
+                e.ctrlKey,
+                e.metaKey,
+                e.shiftKey,
+                movementPosition,
+                button
+              )
+            )
+          }
         }
         e.preventDefault()
       },
       onPointerUp = { e =>
-        val position = e.position(magnification, canvas)
+        val position         = e.position(magnification, canvas)
+        val buttons          = e.indigoButtons
+        val movementPosition = e.movementPosition(magnification)
+        val pointerType      = e.indigoPointerType
 
         globalEventStream.pushGlobalEvent(
-          PointerUp(position, PointerId(e.pointerId), Buttons(e.buttons), e.isPrimary)
+          PointerUp(
+            position,
+            buttons,
+            e.altKey,
+            e.ctrlKey,
+            e.metaKey,
+            e.shiftKey,
+            movementPosition,
+            PointerId(e.pointerId),
+            e.width(magnification),
+            e.height(magnification),
+            e.pressure,
+            e.tangentialPressure,
+            Radians.fromDegrees(e.tiltX),
+            Radians.fromDegrees(e.tiltY),
+            Radians.fromDegrees(e.twist),
+            pointerType,
+            e.isPrimary,
+            MouseButton.fromOrdinalOpt(e.button)
+          )
         )
-        MouseButton.fromOrdinalOpt(e.button).foreach { button =>
-          globalEventStream.pushGlobalEvent(MouseEvent.MouseUp(position, button))
+
+        if pointerType == PointerType.Mouse then {
+          MouseButton.fromOrdinalOpt(e.button).foreach { button =>
+            globalEventStream.pushGlobalEvent(
+              MouseEvent.MouseUp(
+                position,
+                buttons,
+                e.altKey,
+                e.ctrlKey,
+                e.metaKey,
+                e.shiftKey,
+                movementPosition,
+                button
+              )
+            )
+          }
         }
         e.preventDefault()
       },
       onPointerMove = { e =>
-        val position = e.position(magnification, canvas)
+        val position         = e.position(magnification, canvas)
+        val buttons          = e.indigoButtons
+        val movementPosition = e.movementPosition(magnification)
+        val pointerType      = e.indigoPointerType
 
         globalEventStream.pushGlobalEvent(
-          PointerMove(position, PointerId(e.pointerId), Buttons(e.buttons), e.isPrimary)
+          PointerMove(
+            position,
+            buttons,
+            e.altKey,
+            e.ctrlKey,
+            e.metaKey,
+            e.shiftKey,
+            movementPosition,
+            PointerId(e.pointerId),
+            e.width(magnification),
+            e.height(magnification),
+            e.pressure,
+            e.tangentialPressure,
+            Radians.fromDegrees(e.tiltX),
+            Radians.fromDegrees(e.tiltY),
+            Radians.fromDegrees(e.twist),
+            pointerType,
+            e.isPrimary
+          )
         )
-        globalEventStream.pushGlobalEvent(MouseEvent.Move(position))
+
+        if pointerType == PointerType.Mouse then {
+          globalEventStream.pushGlobalEvent(
+            MouseEvent.Move(
+              position,
+              buttons,
+              e.altKey,
+              e.ctrlKey,
+              e.metaKey,
+              e.shiftKey,
+              movementPosition
+            )
+          )
+        }
         e.preventDefault()
       },
       onPointerCancel = { e =>
-        val position = e.position(magnification, canvas)
+        val position         = e.position(magnification, canvas)
+        val buttons          = e.indigoButtons
+        val movementPosition = e.movementPosition(magnification)
+        val pointerType      = e.indigoPointerType
 
         globalEventStream.pushGlobalEvent(
-          PointerCancel(position, PointerId(e.pointerId), Buttons(e.buttons), e.isPrimary)
+          PointerCancel(
+            position,
+            buttons,
+            e.altKey,
+            e.ctrlKey,
+            e.metaKey,
+            e.shiftKey,
+            movementPosition,
+            PointerId(e.pointerId),
+            e.width(magnification),
+            e.height(magnification),
+            e.pressure,
+            e.tangentialPressure,
+            Radians.fromDegrees(e.tiltX),
+            Radians.fromDegrees(e.tiltY),
+            Radians.fromDegrees(e.twist),
+            pointerType,
+            e.isPrimary
+          )
         )
         e.preventDefault()
       },
@@ -236,12 +463,33 @@ final class WorldEvents:
         absoluteCoordsY(e.pageY.toInt - rect.top.toInt) / magnification
       )
 
-  extension (e: dom.FocusEvent)
-    def isWindowTarget: Boolean =
-      val target = e.target
-      target match {
-        case e: dom.Element if e.tagName == "WINDOW" => true
-        case _                                       => false
+    def movementPosition(magnification: Int): Point =
+      Point(
+        (e.movementX / magnification).toInt,
+        (e.movementY / magnification).toInt
+      )
+
+    def indigoButtons =
+      Batch.fromArray(
+        (0 to 5)
+          .filter(i => ((e.buttons >> i) & 1) == 0)
+          .flatMap(MouseButton.fromOrdinalOpt)
+          .toArray
+      )
+
+  extension (e: dom.PointerEvent)
+    def width(magnification: Int): Int =
+      (e.width / magnification).toInt
+
+    def height(magnification: Int): Int =
+      (e.height / magnification).toInt
+
+    def indigoPointerType =
+      e.pointerType match {
+        case "mouse" => PointerType.Mouse
+        case "pen"   => PointerType.Pen
+        case "touch" => PointerType.Touch
+        case _       => PointerType.Unknown
       }
 
 end WorldEvents

--- a/indigo/indigo/src/main/scala/indigo/platform/events/WorldEvents.scala
+++ b/indigo/indigo/src/main/scala/indigo/platform/events/WorldEvents.scala
@@ -165,7 +165,7 @@ final class WorldEvents:
         val position         = e.position(magnification, canvas)
         val buttons          = e.indigoButtons
         val movementPosition = e.movementPosition(magnification)
-        val pointerType      = e.indigoPointerType
+        val pointerType      = e.toPointerType
 
         globalEventStream.pushGlobalEvent(
           PointerEnter(
@@ -207,7 +207,7 @@ final class WorldEvents:
         val position         = e.position(magnification, canvas)
         val buttons          = e.indigoButtons
         val movementPosition = e.movementPosition(magnification)
-        val pointerType      = e.indigoPointerType
+        val pointerType      = e.toPointerType
 
         globalEventStream.pushGlobalEvent(
           PointerLeave(
@@ -249,7 +249,7 @@ final class WorldEvents:
         val position         = e.position(magnification, canvas)
         val buttons          = e.indigoButtons
         val movementPosition = e.movementPosition(magnification)
-        val pointerType      = e.indigoPointerType
+        val pointerType      = e.toPointerType
 
         globalEventStream.pushGlobalEvent(
           PointerDown(
@@ -296,7 +296,7 @@ final class WorldEvents:
         val position         = e.position(magnification, canvas)
         val buttons          = e.indigoButtons
         val movementPosition = e.movementPosition(magnification)
-        val pointerType      = e.indigoPointerType
+        val pointerType      = e.toPointerType
 
         globalEventStream.pushGlobalEvent(
           PointerUp(
@@ -343,7 +343,7 @@ final class WorldEvents:
         val position         = e.position(magnification, canvas)
         val buttons          = e.indigoButtons
         val movementPosition = e.movementPosition(magnification)
-        val pointerType      = e.indigoPointerType
+        val pointerType      = e.toPointerType
 
         globalEventStream.pushGlobalEvent(
           PointerMove(
@@ -386,7 +386,7 @@ final class WorldEvents:
         val position         = e.position(magnification, canvas)
         val buttons          = e.indigoButtons
         val movementPosition = e.movementPosition(magnification)
-        val pointerType      = e.indigoPointerType
+        val pointerType      = e.toPointerType
 
         globalEventStream.pushGlobalEvent(
           PointerCancel(
@@ -481,7 +481,7 @@ final class WorldEvents:
     def height(magnification: Int): Int =
       (e.height / magnification).toInt
 
-    def indigoPointerType =
+    def toPointerType =
       e.pointerType match {
         case "mouse" => PointerType.Mouse
         case "pen"   => PointerType.Pen

--- a/indigo/indigo/src/main/scala/indigo/shared/events/GlobalEvent.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/events/GlobalEvent.scala
@@ -195,6 +195,18 @@ object MouseEvent:
       movementPosition: Point,
       button: MouseButton
   ) extends MouseEvent
+  object Click:
+    def apply(x: Int, y: Int): Click =
+      Click(
+        position = Point(x, y),
+        buttons = Batch.empty,
+        isAltKeyDown = false,
+        isCtrlKeyDown = false,
+        isMetaKeyDown = false,
+        isShiftKeyDown = false,
+        movementPosition = Point.zero,
+        button = MouseButton.LeftMouseButton
+      )
 
   /** The mouse button was released.
     * @param button
@@ -210,6 +222,40 @@ object MouseEvent:
       movementPosition: Point,
       button: MouseButton
   ) extends MouseEvent
+  object MouseUp:
+    def apply(position: Point): MouseUp =
+      MouseUp(
+        position = position,
+        buttons = Batch.empty,
+        isAltKeyDown = false,
+        isCtrlKeyDown = false,
+        isMetaKeyDown = false,
+        isShiftKeyDown = false,
+        movementPosition = Point.zero,
+        button = MouseButton.LeftMouseButton
+      )
+    def apply(x: Int, y: Int): MouseUp =
+      MouseUp(
+        position = Point(x, y),
+        buttons = Batch.empty,
+        isAltKeyDown = false,
+        isCtrlKeyDown = false,
+        isMetaKeyDown = false,
+        isShiftKeyDown = false,
+        movementPosition = Point.zero,
+        button = MouseButton.LeftMouseButton
+      )
+    def apply(x: Int, y: Int, button: MouseButton): MouseUp =
+      MouseUp(
+        position = Point(x, y),
+        buttons = Batch.empty,
+        isAltKeyDown = false,
+        isCtrlKeyDown = false,
+        isMetaKeyDown = false,
+        isShiftKeyDown = false,
+        movementPosition = Point.zero,
+        button = button
+      )
 
   /** The mouse button was pressed down.
     * @param button
@@ -225,6 +271,40 @@ object MouseEvent:
       movementPosition: Point,
       button: MouseButton
   ) extends MouseEvent
+  object MouseDown:
+    def apply(position: Point): MouseDown =
+      MouseDown(
+        position = position,
+        buttons = Batch.empty,
+        isAltKeyDown = false,
+        isCtrlKeyDown = false,
+        isMetaKeyDown = false,
+        isShiftKeyDown = false,
+        movementPosition = Point.zero,
+        button = MouseButton.LeftMouseButton
+      )
+    def apply(x: Int, y: Int): MouseDown =
+      MouseDown(
+        position = Point(x, y),
+        buttons = Batch.empty,
+        isAltKeyDown = false,
+        isCtrlKeyDown = false,
+        isMetaKeyDown = false,
+        isShiftKeyDown = false,
+        movementPosition = Point.zero,
+        button = MouseButton.LeftMouseButton
+      )
+    def apply(x: Int, y: Int, button: MouseButton): MouseDown =
+      MouseDown(
+        position = Point(x, y),
+        buttons = Batch.empty,
+        isAltKeyDown = false,
+        isCtrlKeyDown = false,
+        isMetaKeyDown = false,
+        isShiftKeyDown = false,
+        movementPosition = Point.zero,
+        button = button
+      )
 
   /** The mouse was moved to a new position.
     */
@@ -237,6 +317,17 @@ object MouseEvent:
       isShiftKeyDown: Boolean,
       movementPosition: Point
   ) extends MouseEvent
+  object Move:
+    def apply(x: Int, y: Int): Move =
+      Move(
+        position = Point(x, y),
+        buttons = Batch.empty,
+        isAltKeyDown = false,
+        isCtrlKeyDown = false,
+        isMetaKeyDown = false,
+        isShiftKeyDown = false,
+        movementPosition = Point.zero
+      )
 
   /** Mouse has moved into canvas hit test boundaries. It's counterpart is [[Leave]].
     */
@@ -277,6 +368,18 @@ object MouseEvent:
       movementPosition: Point,
       amount: Double
   ) extends MouseEvent
+  object Wheel:
+    def apply(x: Int, y: Int, amount: Double): Wheel =
+      Wheel(
+        position = Point(x, y),
+        buttons = Batch.empty,
+        isAltKeyDown = false,
+        isCtrlKeyDown = false,
+        isMetaKeyDown = false,
+        isShiftKeyDown = false,
+        movementPosition = Point.zero,
+        amount = amount
+      )
 
 end MouseEvent
 

--- a/indigo/indigo/src/main/scala/indigo/shared/events/GlobalEvent.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/events/GlobalEvent.scala
@@ -183,6 +183,16 @@ object MouseEvent:
     def apply(x: Int, y: Int): Move =
       Move(Point(x, y))
 
+  /** Mouse has moved into canvas hit test boundaries. It's counterpart is [[Leave]].
+    */
+  final case class Enter(position: Point)
+      extends MouseEvent
+
+  /** Mouse has left canvas hit test boundaries. It's counterpart is [[Enter]].
+    */
+  final case class Leave(position: Point)
+      extends MouseEvent
+
   /** The mouse wheel was rotated a certain amount into the Y axis.
     *
     * @param position

--- a/indigo/indigo/src/main/scala/indigo/shared/events/GlobalEvent.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/events/GlobalEvent.scala
@@ -4,12 +4,14 @@ import indigo.AssetCollection
 import indigo.shared.assets.AssetName
 import indigo.shared.assets.AssetType
 import indigo.shared.audio.Volume
+import indigo.shared.collections.Batch
 import indigo.shared.config.GameViewport
 import indigo.shared.config.RenderingTechnology
 import indigo.shared.constants.Key
 import indigo.shared.datatypes.BindingKey
 import indigo.shared.datatypes.Point
 import indigo.shared.datatypes.RGBA
+import indigo.shared.datatypes.Radians
 
 /** A trait that tells Indigo to allow this instance into the event loop for the duration of one frame.
   */
@@ -110,6 +112,9 @@ case object CanvasLostFocus extends GlobalEvent
 enum MouseButton derives CanEqual:
   case LeftMouseButton, MiddleMouseButton, RightMouseButton, BrowserBackButton, BrowserForwardButton
 
+enum PointerType derives CanEqual:
+  case Mouse, Pen, Touch, Unknown
+
 /** Represents in which direction the mouse wheel was rotated
   */
 enum MouseWheel derives CanEqual:
@@ -136,7 +141,7 @@ trait MouseOrPointerEvent:
 
   /** Pressed buttons
     */
-  def buttons: Buttons
+  def buttons: Batch[MouseButton]
 
   /** Indicates whether buttons are in active state
     */
@@ -158,17 +163,17 @@ trait MouseOrPointerEvent:
     */
   def isShiftKeyDown: Boolean
 
-  /** The delta position between this event and the last event
+  /** The delta position between this event and the last event relative to the magnification level
     */
-  def deltaPosition: Point
+  def movementPosition: Point
 
-  /** The delta X position between this event and the last event
+  /** The delta X position between this event and the last event relative to the magnification level
     */
-  def deltaX: Point = deltaPosition.x
+  def movementX: Int = movementPosition.x
 
-  /** The delta Y position between this event and the last event
+  /** The delta Y position between this event and the last event relative to the magnification level
     */
-  def deltaY: Point = deltaPosition.y
+  def movementY: Int = movementPosition.y
 
 /** Represents all mouse events
   */
@@ -177,84 +182,103 @@ object MouseEvent:
 
   /** The mouse has been clicked.
     *
-    * @param position
-    *   mouse position relative to magnification level
-    */
-  final case class Click(position: Point) extends MouseEvent
-  object Click:
-    def apply(x: Int, y: Int): Click =
-      Click(Point(x, y))
-
-  /** The left mouse button was released.
-    *
-    * @param position
-    *   mouse position relative to magnification level
     * @param button
-    *   Button that triggered this event
+    *   The button that was used for the click
     */
-  final case class MouseUp(position: Point, button: MouseButton) extends MouseEvent
-  object MouseUp:
-    def apply(position: Point): MouseUp =
-      MouseUp(position, MouseButton.LeftMouseButton)
-    def apply(x: Int, y: Int): MouseUp =
-      MouseUp(Point(x, y), MouseButton.LeftMouseButton)
-    def apply(x: Int, y: Int, button: MouseButton): MouseUp =
-      MouseUp(Point(x, y), button)
+  final case class Click(
+      position: Point,
+      buttons: Batch[MouseButton],
+      isAltKeyDown: Boolean,
+      isCtrlKeyDown: Boolean,
+      isMetaKeyDown: Boolean,
+      isShiftKeyDown: Boolean,
+      movementPosition: Point,
+      button: MouseButton
+  ) extends MouseEvent
 
-  /** The left mouse button was pressed down.
-    *
-    * @param position
-    *   mouse position relative to magnification level
+  /** The mouse button was released.
     * @param button
-    *   Button that triggered this event
+    *   The button that was released
     */
-  final case class MouseDown(position: Point, button: MouseButton) extends MouseEvent
-  object MouseDown:
-    def apply(position: Point): MouseDown =
-      MouseDown(position, MouseButton.LeftMouseButton)
-    def apply(x: Int, y: Int): MouseDown =
-      MouseDown(Point(x, y), MouseButton.LeftMouseButton)
-    def apply(x: Int, y: Int, button: MouseButton): MouseDown =
-      MouseDown(Point(x, y), button)
+  final case class MouseUp(
+      position: Point,
+      buttons: Batch[MouseButton],
+      isAltKeyDown: Boolean,
+      isCtrlKeyDown: Boolean,
+      isMetaKeyDown: Boolean,
+      isShiftKeyDown: Boolean,
+      movementPosition: Point,
+      button: MouseButton
+  ) extends MouseEvent
+
+  /** The mouse button was pressed down.
+    * @param button
+    *   The button that was pressed down
+    */
+  final case class MouseDown(
+      position: Point,
+      buttons: Batch[MouseButton],
+      isAltKeyDown: Boolean,
+      isCtrlKeyDown: Boolean,
+      isMetaKeyDown: Boolean,
+      isShiftKeyDown: Boolean,
+      movementPosition: Point,
+      button: MouseButton
+  ) extends MouseEvent
 
   /** The mouse was moved to a new position.
-    *
-    * @param position
-    *   mouse position relative to magnification level
     */
-  final case class Move(position: Point) extends MouseEvent
-
-  object Move:
-    def apply(x: Int, y: Int): Move =
-      Move(Point(x, y))
+  final case class Move(
+      position: Point,
+      buttons: Batch[MouseButton],
+      isAltKeyDown: Boolean,
+      isCtrlKeyDown: Boolean,
+      isMetaKeyDown: Boolean,
+      isShiftKeyDown: Boolean,
+      movementPosition: Point
+  ) extends MouseEvent
 
   /** Mouse has moved into canvas hit test boundaries. It's counterpart is [[Leave]].
     */
-  final case class Enter(position: Point)
-      extends MouseEvent
+  final case class Enter(
+      position: Point,
+      buttons: Batch[MouseButton],
+      isAltKeyDown: Boolean,
+      isCtrlKeyDown: Boolean,
+      isMetaKeyDown: Boolean,
+      isShiftKeyDown: Boolean,
+      movementPosition: Point
+  ) extends MouseEvent
 
   /** Mouse has left canvas hit test boundaries. It's counterpart is [[Enter]].
     */
-  final case class Leave(position: Point)
-      extends MouseEvent
+  final case class Leave(
+      position: Point,
+      buttons: Batch[MouseButton],
+      isAltKeyDown: Boolean,
+      isCtrlKeyDown: Boolean,
+      isMetaKeyDown: Boolean,
+      isShiftKeyDown: Boolean,
+      movementPosition: Point
+  ) extends MouseEvent
 
   /** The mouse wheel was rotated a certain amount into the Y axis.
     *
-    * @param position
-    *   mouse position at where the wheel was actioned
     * @param amount
     *   vertical amount of pixels, pages or other unit, depending on delta mode, the Y axis was scrolled
     */
-  final case class Wheel(position: Point, amount: Double) extends MouseEvent
-
-  object Wheel:
-    def apply(x: Int, y: Int, amount: Double): Wheel =
-      Wheel(Point(x, y), amount)
+  final case class Wheel(
+      position: Point,
+      buttons: Batch[MouseButton],
+      isAltKeyDown: Boolean,
+      isCtrlKeyDown: Boolean,
+      isMetaKeyDown: Boolean,
+      isShiftKeyDown: Boolean,
+      movementPosition: Point,
+      amount: Double
+  ) extends MouseEvent
 
 end MouseEvent
-
-enum PointerType:
-  case Mouse, Pen, Touch, Unknown
 
 /** Represents all mouse, pen and touch events
   */
@@ -273,23 +297,28 @@ sealed trait PointerEvent extends InputEvent with MouseOrPointerEvent:
     */
   def height: Int
 
-  /** The normalized pressure of the pointer input in the range 0 to 1, where 0 and 1 represent the minimum and maximum pressure the hardware is capable of detecting, respectively.
+  /** The normalized pressure of the pointer input in the range 0 to 1, where 0 and 1 represent the minimum and maximum
+    * pressure the hardware is capable of detecting, respectively.
     */
   def pressure: Double
 
-  /** The normalized tangential pressure of the pointer input (also known as barrel pressure or cylinder stress) in the range -1 to 1, where 0 is the neutral position of the control.
+  /** The normalized tangential pressure of the pointer input (also known as barrel pressure or cylinder stress) in the
+    * range -1 to 1, where 0 is the neutral position of the control.
     */
   def tangentialPressure: Double
 
-  /** The plane angle (in radians, in the range of -1.570796 to 1.570796 (-90 - 90 degrees)) between the Y–Z plane and the plane containing both the pointer (e.g. pen stylus) axis and the Y axis.
+  /** The plane angle (in radians, in the range of -1.570796 to 1.570796 (-90 - 90 degrees)) between the Y–Z plane and
+    * the plane containing both the pointer (e.g. pen stylus) axis and the Y axis.
     */
   def tiltX: Radians
 
-  /** The plane angle (in radians, in the range of -1.570796 to 1.570796 (-90 - 90 degrees)) between the X–Z plane and the plane containing both the pointer (e.g. pen stylus) axis and the X axis.
+  /** The plane angle (in radians, in the range of -1.570796 to 1.570796 (-90 - 90 degrees)) between the X–Z plane and
+    * the plane containing both the pointer (e.g. pen stylus) axis and the X axis.
     */
   def tiltY: Radians
 
-  /** The clockwise rotation of the pointer (e.g. pen stylus) around its major axis in degrees, with a value in the range 0 to 6.265732 (0 to 359 degrees)
+  /** The clockwise rotation of the pointer (e.g. pen stylus) around its major axis in degrees, with a value in the
+    * range 0 to 6.265732 (0 to 359 degrees)
     */
   def twist: Radians
 
@@ -312,28 +341,115 @@ object PointerEvent:
 
   /** Pointing device is moved into canvas hit test boundaries. It's counterpart is [[PointerLeave]].
     */
-  final case class PointerEnter(position: Point, pointerId: PointerId, buttons: Buttons, isPrimary: Boolean)
-      extends PointerEvent
+  final case class PointerEnter(
+      position: Point,
+      buttons: Batch[MouseButton],
+      isAltKeyDown: Boolean,
+      isCtrlKeyDown: Boolean,
+      isMetaKeyDown: Boolean,
+      isShiftKeyDown: Boolean,
+      movementPosition: Point,
+      pointerId: PointerId,
+      width: Int,
+      height: Int,
+      pressure: Double,
+      tangentialPressure: Double,
+      tiltX: Radians,
+      tiltY: Radians,
+      twist: Radians,
+      pointerType: PointerType,
+      isPrimary: Boolean
+  ) extends PointerEvent
 
   /** Pointing device left canvas hit test boundaries. It's counterpart is [[PointerEnter]].
     */
-  final case class PointerLeave(position: Point, pointerId: PointerId, buttons: Buttons, isPrimary: Boolean)
-      extends PointerEvent
+  final case class PointerLeave(
+      position: Point,
+      buttons: Batch[MouseButton],
+      isAltKeyDown: Boolean,
+      isCtrlKeyDown: Boolean,
+      isMetaKeyDown: Boolean,
+      isShiftKeyDown: Boolean,
+      movementPosition: Point,
+      pointerId: PointerId,
+      width: Int,
+      height: Int,
+      pressure: Double,
+      tangentialPressure: Double,
+      tiltX: Radians,
+      tiltY: Radians,
+      twist: Radians,
+      pointerType: PointerType,
+      isPrimary: Boolean
+  ) extends PointerEvent
 
   /** Pointing device is in active buttons state.
     */
-  final case class PointerDown(position: Point, pointerId: PointerId, buttons: Buttons, isPrimary: Boolean)
-      extends PointerEvent
+  final case class PointerDown(
+      position: Point,
+      buttons: Batch[MouseButton],
+      isAltKeyDown: Boolean,
+      isCtrlKeyDown: Boolean,
+      isMetaKeyDown: Boolean,
+      isShiftKeyDown: Boolean,
+      movementPosition: Point,
+      pointerId: PointerId,
+      width: Int,
+      height: Int,
+      pressure: Double,
+      tangentialPressure: Double,
+      tiltX: Radians,
+      tiltY: Radians,
+      twist: Radians,
+      pointerType: PointerType,
+      isPrimary: Boolean,
+      button: Option[MouseButton]
+  ) extends PointerEvent
 
   /** Pointing device is no longer in active buttons state.
     */
-  final case class PointerUp(position: Point, pointerId: PointerId, buttons: Buttons, isPrimary: Boolean)
-      extends PointerEvent
+  final case class PointerUp(
+      position: Point,
+      buttons: Batch[MouseButton],
+      isAltKeyDown: Boolean,
+      isCtrlKeyDown: Boolean,
+      isMetaKeyDown: Boolean,
+      isShiftKeyDown: Boolean,
+      movementPosition: Point,
+      pointerId: PointerId,
+      width: Int,
+      height: Int,
+      pressure: Double,
+      tangentialPressure: Double,
+      tiltX: Radians,
+      tiltY: Radians,
+      twist: Radians,
+      pointerType: PointerType,
+      isPrimary: Boolean,
+      button: Option[MouseButton]
+  ) extends PointerEvent
 
   /** Pointing device changed coordinates.
     */
-  final case class PointerMove(position: Point, pointerId: PointerId, buttons: Buttons, isPrimary: Boolean)
-      extends PointerEvent
+  final case class PointerMove(
+      position: Point,
+      buttons: Batch[MouseButton],
+      isAltKeyDown: Boolean,
+      isCtrlKeyDown: Boolean,
+      isMetaKeyDown: Boolean,
+      isShiftKeyDown: Boolean,
+      movementPosition: Point,
+      pointerId: PointerId,
+      width: Int,
+      height: Int,
+      pressure: Double,
+      tangentialPressure: Double,
+      tiltX: Radians,
+      tiltY: Radians,
+      twist: Radians,
+      pointerType: PointerType,
+      isPrimary: Boolean
+  ) extends PointerEvent
 
   /** The ongoing interactions was cancelled due to:
     *   - the pointer device being disconnected
@@ -341,8 +457,25 @@ object PointerEvent:
     *   - palm rejection
     *   - the browser taking over the manipulations like scroll, drag & drop, pinch & zoom or other
     */
-  final case class PointerCancel(position: Point, pointerId: PointerId, buttons: Buttons, isPrimary: Boolean)
-      extends PointerEvent
+  final case class PointerCancel(
+      position: Point,
+      buttons: Batch[MouseButton],
+      isAltKeyDown: Boolean,
+      isCtrlKeyDown: Boolean,
+      isMetaKeyDown: Boolean,
+      isShiftKeyDown: Boolean,
+      movementPosition: Point,
+      pointerId: PointerId,
+      width: Int,
+      height: Int,
+      pressure: Double,
+      tangentialPressure: Double,
+      tiltX: Radians,
+      tiltY: Radians,
+      twist: Radians,
+      pointerType: PointerType,
+      isPrimary: Boolean
+  ) extends PointerEvent
 
 /** Represents all keyboard events
   */

--- a/indigo/indigo/src/main/scala/indigo/shared/events/GlobalEvent.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/events/GlobalEvent.scala
@@ -207,6 +207,17 @@ object MouseEvent:
         movementPosition = Point.zero,
         button = MouseButton.LeftMouseButton
       )
+    def apply(position: Point): Click =
+      Click(
+        position = position,
+        buttons = Batch.empty,
+        isAltKeyDown = false,
+        isCtrlKeyDown = false,
+        isMetaKeyDown = false,
+        isShiftKeyDown = false,
+        movementPosition = Point.zero,
+        button = MouseButton.LeftMouseButton
+      )
 
   /** The mouse button was released.
     * @param button

--- a/indigo/indigo/src/main/scala/indigo/shared/input/Mouse.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/input/Mouse.scala
@@ -50,8 +50,8 @@ final class Mouse(
 
   lazy val scrolled: Option[MouseWheel] =
     val amount = mouseEvents.foldLeft(0d) {
-      case (acc, MouseEvent.Wheel(_, deltaY)) => acc + deltaY
-      case (acc, _)                           => acc
+      case (acc, MouseEvent.Wheel(_, _, _, _, _, _, _, deltaY)) => acc + deltaY
+      case (acc, _)                                             => acc
     }
 
     if amount == 0 then Option.empty[MouseWheel]
@@ -158,9 +158,9 @@ object Mouse:
       remaining match
         case Nil =>
           buttonsDownAcc
-        case MouseEvent.MouseDown(_, button) :: moreEvents =>
+        case MouseEvent.MouseDown(_, _, _, _, _, _, _, button) :: moreEvents =>
           rec(moreEvents, buttonsDownAcc + button)
-        case MouseEvent.MouseUp(_, button) :: moreEvents =>
+        case MouseEvent.MouseUp(_, _, _, _, _, _, _, button) :: moreEvents =>
           rec(moreEvents, buttonsDownAcc - button)
         case _ :: moreEvents =>
           rec(moreEvents, buttonsDownAcc)

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/SandboxView.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/SandboxView.scala
@@ -98,7 +98,7 @@ object SandboxView:
       Text("AB!\n!C", 100, 2, 5, Fonts.fontKey, SandboxAssets.fontMaterial.withAlpha(0.5)).alignCenter,
       Text("AB!\n!C", 200, 2, 5, Fonts.fontKey, SandboxAssets.fontMaterial.withAlpha(0.5)).alignRight
         .withEventHandler {
-          case (txt, MouseEvent.Click(pt)) if bl.bounds(txt).contains(pt) =>
+          case (txt, MouseEvent.Click(pt, _, _, _, _, _, _, _)) if bl.bounds(txt).contains(pt) =>
             println("Clicked me!")
             None
 


### PR DESCRIPTION
This is a breaking change, and I'm not sure I'm happy about it, so a second (or third) pair of eyes would be very welcome.
This change adds a majority of the properties found in both [Mouse Events](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent) and [Pointer Events](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent). The upshot is that in doing so a simple `Click(position)` match now becomes `Click(position, _, _, _, _, _, _, _)`, however we now have a wealth of new information about the event itself. some key changes are:

## Key Down Properties
Various helper properties (`isAltKeyDown` etc.) to check if a key was held down during the event. The difference here compared to, say, keeping a track of key up/down events within Indigo, is that if the button is held down outside of the scope of the game (such as in another window) this property will still be correct, whereas Indigo will think the button is not held down.

## Buttons Properties
The `buttons` proeprty was previously just on `Pointer` events, but is also available for the `Mouse`. As such, this property has now been moved to the `Mouse` event and updated to be a `Batch` of `MouseButton`

## Mouse Enter/Leave
We already have a Pointer Enter/Leave - we now have the same for the mouse, which fixes #512 

## Tilting, Twisting, and Preassure
Pointer events have been updated with Tilt X/Y, Twist, and Preassure properties. More details on these can be found on the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events). The main change from the docs here is that Twist and Tilt properties are in `Radian`s not degrees.

## Limited Firing of Events
Previously we fired mouse events every time we registered a pointer event. We now only do this if the pointer type is `Mouse`.