### PR TITLE
Focus Events

### DIFF
--- a/indigo/docs/gameloop/events.md
+++ b/indigo/docs/gameloop/events.md
@@ -55,6 +55,11 @@ You can create your own events by simply extending `GlobalEvent`.
 - `FullScreenExited` - The game exited full screen mode
 - `FullScreenExitError` - A problem occurred trying to exit full screen
 
+### Focus
+
+- `GainedFocus` - The game has received focus
+- `LostFocus` - The game has lost focus
+
 ### `InputEvent`s
 
 Handling `InputEvent`s can be a bit tricky in some situations, so Indigo includes `Mouse` and `Keyboard` classes that can be accessed from the [frame context](gameloop/frame-context.md), providing a rich interface to gather more complex information from those input devices.

--- a/indigo/docs/gameloop/events.md
+++ b/indigo/docs/gameloop/events.md
@@ -57,8 +57,17 @@ You can create your own events by simply extending `GlobalEvent`.
 
 ### Focus
 
-- `GainedFocus` - The game has received focus
-- `LostFocus` - The game has lost focus
+- `ApplicationGainedFocus` - The application is in focus
+- `ApplicationLostFocus` - The application has lost focus
+- `CanvasGainedFocus` - The game canvas is in focus
+- `CanvasLostFocus` - The game canvas has lost focus
+
+The `CanvasGainedFocus` and `CanvasLostFocus` are very similar to their `Application*`
+counterparts. The main difference is that the game canvas can lose focus independently
+of the application if the game is being run from inside a web application (such as
+a Tyrian App or game site). In this scenario the `Canvas*` events will fire whenever
+the canvas loses or gains focus from the user clicking around the external parts
+of the site, and will also fire when the application loses or gains focus.
 
 ### `InputEvent`s
 

--- a/indigo/indigo/src/main/scala/indigo/package.scala
+++ b/indigo/indigo/src/main/scala/indigo/package.scala
@@ -352,13 +352,17 @@ val RendererDetails: shared.events.RendererDetails.type = shared.events.Renderer
 type ViewportResize = shared.events.ViewportResize
 val ViewportResize: shared.events.ViewportResize.type = shared.events.ViewportResize
 
-val ToggleFullScreen: shared.events.ToggleFullScreen.type         = shared.events.ToggleFullScreen
-val EnterFullScreen: shared.events.EnterFullScreen.type           = shared.events.EnterFullScreen
-val ExitFullScreen: shared.events.ExitFullScreen.type             = shared.events.ExitFullScreen
-val FullScreenEntered: shared.events.FullScreenEntered.type       = shared.events.FullScreenEntered
-val FullScreenEnterError: shared.events.FullScreenEnterError.type = shared.events.FullScreenEnterError
-val FullScreenExited: shared.events.FullScreenExited.type         = shared.events.FullScreenExited
-val FullScreenExitError: shared.events.FullScreenExitError.type   = shared.events.FullScreenExitError
+val ToggleFullScreen: shared.events.ToggleFullScreen.type             = shared.events.ToggleFullScreen
+val EnterFullScreen: shared.events.EnterFullScreen.type               = shared.events.EnterFullScreen
+val ExitFullScreen: shared.events.ExitFullScreen.type                 = shared.events.ExitFullScreen
+val FullScreenEntered: shared.events.FullScreenEntered.type           = shared.events.FullScreenEntered
+val FullScreenEnterError: shared.events.FullScreenEnterError.type     = shared.events.FullScreenEnterError
+val FullScreenExited: shared.events.FullScreenExited.type             = shared.events.FullScreenExited
+val FullScreenExitError: shared.events.FullScreenExitError.type       = shared.events.FullScreenExitError
+val ApplicationGainedFocus: shared.events.ApplicationGainedFocus.type = shared.events.ApplicationGainedFocus
+val CanvasGainedFocus: shared.events.CanvasGainedFocus.type           = shared.events.CanvasGainedFocus
+val ApplicationLostFocus: shared.events.ApplicationLostFocus.type     = shared.events.ApplicationLostFocus
+val CanvasLostFocus: shared.events.CanvasLostFocus.type               = shared.events.CanvasLostFocus
 
 type InputState = shared.events.InputState
 val InputState: shared.events.InputState.type = shared.events.InputState

--- a/indigo/indigo/src/main/scala/indigo/platform/events/WorldEvents.scala
+++ b/indigo/indigo/src/main/scala/indigo/platform/events/WorldEvents.scala
@@ -46,6 +46,9 @@ final class WorldEvents:
       onPointerDown: dom.PointerEvent => Unit,
       onPointerUp: dom.PointerEvent => Unit,
       onPointerMove: dom.PointerEvent => Unit,
+      onPointerCancel: dom.PointerEvent => Unit,
+      onBlur: dom.FocusEvent => Unit,
+      onFocus: dom.FocusEvent => Unit,
       onPointerCancel: dom.PointerEvent => Unit
   ) {
     canvas.addEventListener("click", onClick)
@@ -56,6 +59,8 @@ final class WorldEvents:
     canvas.addEventListener("pointerup", onPointerUp)
     canvas.addEventListener("pointermove", onPointerMove)
     canvas.addEventListener("pointercancel", onPointerCancel)
+    canvas.addEventListener("focus", onFocus)
+    canvas.addEventListener("blur", onBlur)
     onContextMenu.foreach(canvas.addEventListener("contextmenu", _))
     document.addEventListener("keydown", onKeyDown)
     document.addEventListener("keyup", onKeyUp)
@@ -69,6 +74,8 @@ final class WorldEvents:
       canvas.removeEventListener("pointerup", onPointerUp)
       canvas.removeEventListener("pointermove", onPointerMove)
       canvas.removeEventListener("pointercancel", onPointerCancel)
+      canvas.removeEventListener("focus", onFocus)
+      canvas.removeEventListener("blur", onBlur)
       onContextMenu.foreach(canvas.removeEventListener("contextmenu", _))
       document.removeEventListener("keydown", onKeyDown)
       document.removeEventListener("keyup", onKeyUp)
@@ -160,6 +167,18 @@ final class WorldEvents:
 
         globalEventStream.pushGlobalEvent(
           PointerCancel(position, PointerId(e.pointerId), Buttons(e.buttons), e.isPrimary)
+        )
+        e.preventDefault()
+      },
+      onFocus = { e=>
+        globalEventStream.pushGlobalEvent(
+          GainedFocus
+        )
+        e.preventDefault()
+      },
+      onBlur = { e=>
+        globalEventStream.pushGlobalEvent(
+          LostFocus
         )
         e.preventDefault()
       }

--- a/indigo/indigo/src/main/scala/indigo/platform/events/WorldEvents.scala
+++ b/indigo/indigo/src/main/scala/indigo/platform/events/WorldEvents.scala
@@ -182,16 +182,12 @@ final class WorldEvents:
           if e.isWindowTarget then ApplicationGainedFocus
           else CanvasGainedFocus
         )
-
-        e.preventDefault()
       },
       onBlur = { e =>
         globalEventStream.pushGlobalEvent(
           if e.isWindowTarget then ApplicationLostFocus
           else CanvasLostFocus
         )
-
-        e.preventDefault()
       }
     )
   }

--- a/indigo/indigo/src/main/scala/indigo/shared/events/GlobalEvent.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/events/GlobalEvent.scala
@@ -88,15 +88,21 @@ case object FullScreenExited extends ViewEvent
   */
 case object FullScreenExitError extends ViewEvent
 
-/**
-  * The game canvas has received focus
+/** The application has received focus
   */
-case object GainedFocus extends GlobalEvent
+case object ApplicationGainedFocus extends GlobalEvent
 
-/**
-  * The game canvas has lost focus
+/** The game canvas has received focus
   */
-case object LostFocus extends GlobalEvent
+case object CanvasGainedFocus extends GlobalEvent
+
+/** The application has lost focus
+  */
+case object ApplicationLostFocus extends GlobalEvent
+
+/** The game canvas has lost focus
+  */
+case object CanvasLostFocus extends GlobalEvent
 
 /** Follows the MDN spec values https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button Relies on the ordinal
   * behavior of Scala 3 enums to match the button number

--- a/indigo/indigo/src/main/scala/indigo/shared/events/GlobalEvent.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/events/GlobalEvent.scala
@@ -88,6 +88,16 @@ case object FullScreenExited extends ViewEvent
   */
 case object FullScreenExitError extends ViewEvent
 
+/**
+  * The game canvas has received focus
+  */
+case object GainedFocus extends GlobalEvent
+
+/**
+  * The game canvas has lost focus
+  */
+case object LostFocus extends GlobalEvent
+
 /** Follows the MDN spec values https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button Relies on the ordinal
   * behavior of Scala 3 enums to match the button number
   */


### PR DESCRIPTION
This PR adds 4 new events to Indigo:

- `ApplicationGainedFocus`
- `ApplicationLostFocus`
- `CanvasGainedFocus`
- `CanvasLostFocus`

These new events close #513  and fire whenever the application or game canvas gain or lose focus. This can be useful for things like pausing a game whenever the user switches tabs, or taking an action if the user clicks off of the game canvas inside a web app