### PR TITLE
Adds online/offline events

### DIFF
--- a/indigo/docs/gameloop/events.md
+++ b/indigo/docs/gameloop/events.md
@@ -102,6 +102,13 @@ There is only one audio event used to play one off sound effects, since backgrou
 
 ### Network events
 
+- `Online`
+- `Offline`
+
+It's important to be aware that a network is considered online if there is access
+to the local network only. As such, an online network is not a guarantee that
+the internet or indeed a single resource on the internet is available.
+
 #### Web socket events
 
 - `ConnectOnly(webSocketConfig)`

--- a/indigo/docs/platform/networking.md
+++ b/indigo/docs/platform/networking.md
@@ -3,7 +3,12 @@ id: networking
 title: Networking
 ---
 
-Indigo supports basic networking via HTTP or WebSockets.
+Indigo supports basic networking via HTTP or WebSockets. You can also get a
+rudimentary indication as to whether the local machine has an active network
+connection using `indigo.platform.networking.Network.isOnline`. Note, however,
+that this will only indicate the presence of a local network and is not
+necessarily an indication of internet connectivity, or the availability of an
+internet resource.
 
 ## Network calls and the game loop
 

--- a/indigo/indigo/src/main/scala/indigo/package.scala
+++ b/indigo/indigo/src/main/scala/indigo/package.scala
@@ -409,6 +409,9 @@ val FrameTick: shared.events.FrameTick.type = shared.events.FrameTick
 type PlaySound = shared.events.PlaySound
 val PlaySound: shared.events.PlaySound.type = shared.events.PlaySound
 
+type NetworkEvent = shared.events.NetworkEvent
+val NetworkEvent: shared.events.NetworkEvent.type = shared.events.NetworkEvent
+
 type NetworkSendEvent    = shared.events.NetworkSendEvent
 type NetworkReceiveEvent = shared.events.NetworkReceiveEvent
 

--- a/indigo/indigo/src/main/scala/indigo/platform/events/WorldEvents.scala
+++ b/indigo/indigo/src/main/scala/indigo/platform/events/WorldEvents.scala
@@ -9,6 +9,8 @@ import indigo.shared.events.CanvasLostFocus
 import indigo.shared.events.KeyboardEvent
 import indigo.shared.events.MouseButton
 import indigo.shared.events.MouseEvent
+import indigo.shared.events.Offline
+import indigo.shared.events.Online
 import indigo.shared.events.PointerEvent
 import indigo.shared.events.PointerEvent.*
 import org.scalajs.dom
@@ -52,7 +54,9 @@ final class WorldEvents:
       onPointerMove: dom.PointerEvent => Unit,
       onPointerCancel: dom.PointerEvent => Unit,
       onBlur: dom.FocusEvent => Unit,
-      onFocus: dom.FocusEvent => Unit
+      onFocus: dom.FocusEvent => Unit,
+      onOnline: dom.Event => Unit,
+      onOffline: dom.Event => Unit
   ) {
     canvas.addEventListener("click", onClick)
     canvas.addEventListener("wheel", onWheel)
@@ -69,6 +73,8 @@ final class WorldEvents:
     onContextMenu.foreach(canvas.addEventListener("contextmenu", _))
     document.addEventListener("keydown", onKeyDown)
     document.addEventListener("keyup", onKeyUp)
+    window.addEventListener("online", onOnline)
+    window.addEventListener("offline", onOffline)
 
     def unbind(): Unit = {
       canvas.removeEventListener("click", onClick)
@@ -86,6 +92,8 @@ final class WorldEvents:
       onContextMenu.foreach(canvas.removeEventListener("contextmenu", _))
       document.removeEventListener("keydown", onKeyDown)
       document.removeEventListener("keyup", onKeyUp)
+      window.removeEventListener("online", onOnline)
+      window.removeEventListener("offline", onOffline)
     }
   }
 
@@ -188,6 +196,12 @@ final class WorldEvents:
           if e.isWindowTarget then ApplicationLostFocus
           else CanvasLostFocus
         )
+      },
+      onOnline = { e =>
+        globalEventStream.pushGlobalEvent(Online)
+      },
+      onOffline = { e =>
+        globalEventStream.pushGlobalEvent(Offline)
       }
     )
   }

--- a/indigo/indigo/src/main/scala/indigo/platform/events/WorldEvents.scala
+++ b/indigo/indigo/src/main/scala/indigo/platform/events/WorldEvents.scala
@@ -9,8 +9,8 @@ import indigo.shared.events.CanvasLostFocus
 import indigo.shared.events.KeyboardEvent
 import indigo.shared.events.MouseButton
 import indigo.shared.events.MouseEvent
-import indigo.shared.events.Offline
-import indigo.shared.events.Online
+import indigo.shared.events.NetworkEvent
+import indigo.shared.events.NetworkEvent.*
 import indigo.shared.events.PointerEvent
 import indigo.shared.events.PointerEvent.*
 import org.scalajs.dom
@@ -198,10 +198,10 @@ final class WorldEvents:
         )
       },
       onOnline = { e =>
-        globalEventStream.pushGlobalEvent(Online)
+        globalEventStream.pushGlobalEvent(NetworkEvent.Online)
       },
       onOffline = { e =>
-        globalEventStream.pushGlobalEvent(Offline)
+        globalEventStream.pushGlobalEvent(NetworkEvent.Offline)
       }
     )
   }

--- a/indigo/indigo/src/main/scala/indigo/platform/networking/Network.scala
+++ b/indigo/indigo/src/main/scala/indigo/platform/networking/Network.scala
@@ -1,0 +1,10 @@
+package indigo.platform.networking
+
+import org.scalajs.dom.window
+
+object Network:
+  /** Whether the network is online or not. A network is considered online if there is access to the local network only.
+    * As such, an online network is not a guarantee that the internet or indeed a single resource on the internet is
+    * available
+    */
+  def isOnline = window.navigator.onLine

--- a/indigo/indigo/src/main/scala/indigo/shared/events/GlobalEvent.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/events/GlobalEvent.scala
@@ -305,6 +305,18 @@ object KeyboardEvent {
   */
 final case class PlaySound(assetName: AssetName, volume: Volume) extends GlobalEvent
 
+/** A class of events representing general networking events
+  */
+trait NetworkEvent extends GlobalEvent
+
+/** The network has come online and is now available
+  */
+case object Online extends NetworkEvent
+
+/** The network has gone offline and is now unavailable
+  */
+case object Offline extends NetworkEvent
+
 /** A class of events representing outbound communication over a network protocol
   */
 trait NetworkSendEvent extends GlobalEvent

--- a/indigo/indigo/src/main/scala/indigo/shared/events/GlobalEvent.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/events/GlobalEvent.scala
@@ -307,15 +307,15 @@ final case class PlaySound(assetName: AssetName, volume: Volume) extends GlobalE
 
 /** A class of events representing general networking events
   */
-trait NetworkEvent extends GlobalEvent
+sealed trait NetworkEvent extends GlobalEvent
+object NetworkEvent:
+  /** The network has come online and is now available
+    */
+  case object Online extends NetworkEvent
 
-/** The network has come online and is now available
-  */
-case object Online extends NetworkEvent
-
-/** The network has gone offline and is now unavailable
-  */
-case object Offline extends NetworkEvent
+  /** The network has gone offline and is now unavailable
+    */
+  case object Offline extends NetworkEvent
 
 /** A class of events representing outbound communication over a network protocol
   */


### PR DESCRIPTION
Adds the capability to check whether the application has network access. The caveat here is that having network access does not guarentee internet access, only local network access. Regardless, it should work as a nice indicator for the player to know whether they are experiencing a network issue or not (for example if their router goes down).