### PR TITLE
fix: fixing path finding method for close impassable staying

### DIFF
--- a/indigo/indigo-extras/src/main/scala/indigoextras/pathfinding/SearchGrid.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/pathfinding/SearchGrid.scala
@@ -79,13 +79,29 @@ object SearchGrid {
           scored ++ unscored
 
         case (remainingSquares, lastScoredLocations) =>
+          // Calculating bounds coords of checked locations
+          val minMax: (Coords, Coords) = minMaxCoords(lastScoredLocations)
+          val maxCoords = minMax._2
+          val minCoords = minMax._1
+          
+          // Filtering only those coords which are in bounds of checked coords
+          // It will let us to minimize check locations later 
+          val filteredRemaining = remainingSquares.filter(gs => gs.coords.x >= minCoords.x - 1
+            && gs.coords.x <= maxCoords.x + 1
+            && gs.coords.y >= minCoords.y - 1
+            && gs.coords.y <= maxCoords.y + 1
+          )
+
           // Find the squares from the remaining pile that the previous scores squares touched.
           val roughEdges: List[List[GridSquare]] =
             lastScoredLocations.map(c => sampleAt(searchGrid, c, searchGrid.validationWidth))
 
           // Filter out any squares that aren't in the remainingSquares list
+          // we should remove impassable squares to prevent incorrect path calculations
           val edges: List[GridSquare] =
-            roughEdges.flatMap(_.filter(c => remainingSquares.contains(c)))
+            roughEdges
+              .flatMap(_.filter(c => filteredRemaining.contains(c))) // using filtered remaining coords
+              .filter(gs => !gs.score.contains(GridSquare.max) || gs.isStart) // or we can filter by name =! "impassable"
 
           // Deduplicate and score
           val next: List[GridSquare] =
@@ -107,6 +123,15 @@ object SearchGrid {
     val (done, todo) = searchGrid.grid.partition(_.isEnd)
 
     rec(searchGrid.start, todo, 1, List(searchGrid.end), done).sortBy(_.index)
+  }
+
+  private def minMaxCoords(lastScoredLocations: List[Coords]) = {
+    val initialValue = (lastScoredLocations.head, lastScoredLocations.head)
+    lastScoredLocations.foldLeft(initialValue) { (result, coords) =>
+      if (coords.x < result._1.x || coords.y < result._1.y) (Coords(coords.x.min(result._1.x), coords.y.min(result._1.y)), result._2)
+      else if (coords.x > result._2.x || coords.y > result._2.y) (result._1, Coords(coords.x.max(result._2.x), coords.y.max(result._2.y)))
+      else result
+    }
   }
 
   def score(searchGrid: SearchGrid): SearchGrid =

--- a/indigo/indigo-extras/src/main/scala/indigoextras/pathfinding/SearchGrid.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/pathfinding/SearchGrid.scala
@@ -81,15 +81,16 @@ object SearchGrid {
         case (remainingSquares, lastScoredLocations) =>
           // Calculating bounds coords of checked locations
           val minMax: (Coords, Coords) = minMaxCoords(lastScoredLocations)
-          val maxCoords = minMax._2
-          val minCoords = minMax._1
-          
+          val maxCoords                = minMax._2
+          val minCoords                = minMax._1
+
           // Filtering only those coords which are in bounds of checked coords
-          // It will let us to minimize check locations later 
-          val filteredRemaining = remainingSquares.filter(gs => gs.coords.x >= minCoords.x - 1
-            && gs.coords.x <= maxCoords.x + 1
-            && gs.coords.y >= minCoords.y - 1
-            && gs.coords.y <= maxCoords.y + 1
+          // It will let us to minimize check locations later
+          val filteredRemaining = remainingSquares.filter(gs =>
+            gs.coords.x >= minCoords.x - 1
+              && gs.coords.x <= maxCoords.x + 1
+              && gs.coords.y >= minCoords.y - 1
+              && gs.coords.y <= maxCoords.y + 1
           )
 
           // Find the squares from the remaining pile that the previous scores squares touched.
@@ -101,7 +102,9 @@ object SearchGrid {
           val edges: List[GridSquare] =
             roughEdges
               .flatMap(_.filter(c => filteredRemaining.contains(c))) // using filtered remaining coords
-              .filter(gs => !gs.score.contains(GridSquare.max) || gs.isStart) // or we can filter by name =! "impassable"
+              .filter(gs =>
+                !gs.score.contains(GridSquare.max) || gs.isStart
+              ) // or we can filter by name =! "impassable"
 
           // Deduplicate and score
           val next: List[GridSquare] =
@@ -127,9 +130,12 @@ object SearchGrid {
 
   private def minMaxCoords(lastScoredLocations: List[Coords]) = {
     val initialValue = (lastScoredLocations.head, lastScoredLocations.head)
+
     lastScoredLocations.foldLeft(initialValue) { (result, coords) =>
-      if (coords.x < result._1.x || coords.y < result._1.y) (Coords(coords.x.min(result._1.x), coords.y.min(result._1.y)), result._2)
-      else if (coords.x > result._2.x || coords.y > result._2.y) (result._1, Coords(coords.x.max(result._2.x), coords.y.max(result._2.y)))
+      if (coords.x < result._1.x || coords.y < result._1.y)
+        (Coords(coords.x.min(result._1.x), coords.y.min(result._1.y)), result._2)
+      else if (coords.x > result._2.x || coords.y > result._2.y)
+        (result._1, Coords(coords.x.max(result._2.x), coords.y.max(result._2.y)))
       else result
     }
   }

--- a/indigo/indigo-extras/src/test/scala/indigoextras/pathfinding/PathFindingTests.scala
+++ b/indigo/indigo-extras/src/test/scala/indigoextras/pathfinding/PathFindingTests.scala
@@ -30,6 +30,29 @@ class PathFindingTests extends munit.FunSuite {
 
   }
 
+
+  test("Finding a path with start near impassable.should be able to find a route") {
+    /*
+    | | | |   =   |*|*|*| or | | | |
+    |?|X|!|   =   |*|X|*|    |*|X|*|
+    | | | |   =   | | | |    |*|*|*|
+    */
+    val start: Coords      = Coords(0, 1)
+    val end: Coords        = Coords(2, 1)
+    val impassable: Coords = Coords(1, 1)
+
+    val searchGrid = SearchGrid.generate(start, end, List(impassable), 3, 3)
+
+    val path: List[Coords] = searchGrid.locatePath(Dice.fromSeed(0))
+
+    val possiblePaths: List[List[Coords]] = List(
+      List(start, Coords(0, 2), Coords(1, 2),Coords(2,2), end),
+      List(start, Coords(0, 0), Coords(1, 0),Coords(2,0), end),
+    )
+
+    assertEquals(possiblePaths.contains(path), true)
+  }
+
   test("Scoring the grid.should be able to score a grid") {
     val start: Coords      = Coords(2, 1)
     val end: Coords        = Coords(0, 2)

--- a/indigo/indigo-extras/src/test/scala/indigoextras/pathfinding/PathFindingTests.scala
+++ b/indigo/indigo-extras/src/test/scala/indigoextras/pathfinding/PathFindingTests.scala
@@ -30,13 +30,12 @@ class PathFindingTests extends munit.FunSuite {
 
   }
 
-
-  test("Finding a path with start near impassable.should be able to find a route") {
+  test("Finding a path with start near impassable horizontal.should be able to find a route") {
     /*
     | | | |   =   |*|*|*| or | | | |
     |?|X|!|   =   |*|X|*|    |*|X|*|
     | | | |   =   | | | |    |*|*|*|
-    */
+     */
     val start: Coords      = Coords(0, 1)
     val end: Coords        = Coords(2, 1)
     val impassable: Coords = Coords(1, 1)
@@ -46,8 +45,74 @@ class PathFindingTests extends munit.FunSuite {
     val path: List[Coords] = searchGrid.locatePath(Dice.fromSeed(0))
 
     val possiblePaths: List[List[Coords]] = List(
-      List(start, Coords(0, 2), Coords(1, 2),Coords(2,2), end),
-      List(start, Coords(0, 0), Coords(1, 0),Coords(2,0), end),
+      List(start, Coords(0, 2), Coords(1, 2), Coords(2, 2), end),
+      List(start, Coords(0, 0), Coords(1, 0), Coords(2, 0), end)
+    )
+
+    assertEquals(possiblePaths.contains(path), true)
+  }
+
+  test("Finding a path with start near impassable vertical.should be able to find a route") {
+    /*
+    | |?| |   =   | |*|*| or |*|*| |
+    | |X| |   =   | |X|*|    |*|X| |
+    | |!| |   =   | |*|*|    |*|*| |
+     */
+    val start: Coords      = Coords(1, 0)
+    val end: Coords        = Coords(1, 2)
+    val impassable: Coords = Coords(1, 1)
+
+    val searchGrid = SearchGrid.generate(start, end, List(impassable), 3, 3)
+
+    val path: List[Coords] = searchGrid.locatePath(Dice.fromSeed(0))
+
+    val possiblePaths: List[List[Coords]] = List(
+      List(start, Coords(2, 0), Coords(2, 1), Coords(2, 2), end),
+      List(start, Coords(0, 0), Coords(0, 1), Coords(0, 2), end)
+    )
+
+    assertEquals(possiblePaths.contains(path), true)
+  }
+
+  test("Finding a path with start near impassable vertical reversed.should be able to find a route") {
+    /*
+    | |!| |   =   | |*|*| or |*|*| |
+    | |X| |   =   | |X|*|    |*|X| |
+    | |?| |   =   | |*|*|    |*|*| |
+     */
+    val start: Coords      = Coords(1, 2)
+    val end: Coords        = Coords(1, 0)
+    val impassable: Coords = Coords(1, 1)
+
+    val searchGrid = SearchGrid.generate(start, end, List(impassable), 3, 3)
+
+    val path: List[Coords] = searchGrid.locatePath(Dice.fromSeed(0))
+
+    val possiblePaths: List[List[Coords]] = List(
+      List(start, Coords(2, 2), Coords(2, 1), Coords(2, 0), end),
+      List(start, Coords(0, 2), Coords(0, 1), Coords(0, 0), end)
+    )
+
+    assertEquals(possiblePaths.contains(path), true)
+  }
+
+  test("Finding a path with start near impassable horizontal reversed.should be able to find a route") {
+    /*
+    | | | |   =   |*|*|*| or | | | |
+    |!|X|?|   =   |*|X|*|    |*|X|*|
+    | | | |   =   | | | |    |*|*|*|
+     */
+    val start: Coords      = Coords(2, 1)
+    val end: Coords        = Coords(0, 1)
+    val impassable: Coords = Coords(1, 1)
+
+    val searchGrid = SearchGrid.generate(start, end, List(impassable), 3, 3)
+
+    val path: List[Coords] = searchGrid.locatePath(Dice.fromSeed(0))
+
+    val possiblePaths: List[List[Coords]] = List(
+      List(start, Coords(2, 2), Coords(1, 2), Coords(0, 2), end),
+      List(start, Coords(2, 0), Coords(1, 0), Coords(0, 0), end)
     )
 
     assertEquals(possiblePaths.contains(path), true)


### PR DESCRIPTION
This request contains two changes:

1. Fix for issue #580 
2. Optimizing path building

During local tests optimized version of path building is two times faster on some situations because of filtering a large number of remaining squares which will not be added to edges in any case

Fixes #580