### PR TITLE
Fixed #612: Friendly mouse event extractors

### DIFF
--- a/indigo/indigo/src/main/scala/indigo/shared/events/GlobalEvent.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/events/GlobalEvent.scala
@@ -223,6 +223,8 @@ object MouseEvent:
         movementPosition = Point.zero,
         button = MouseButton.LeftMouseButton
       )
+    def unapply(e: Click): Option[Point] =
+      Option(e.position)
 
   /** The mouse button was released.
     * @param button
@@ -272,6 +274,8 @@ object MouseEvent:
         movementPosition = Point.zero,
         button = button
       )
+    def unapply(e: MouseUp): Option[Point] =
+      Option(e.position)
 
   /** The mouse button was pressed down.
     * @param button
@@ -321,6 +325,8 @@ object MouseEvent:
         movementPosition = Point.zero,
         button = button
       )
+    def unapply(e: MouseDown): Option[Point] =
+      Option(e.position)
 
   /** The mouse was moved to a new position.
     */
@@ -344,6 +350,8 @@ object MouseEvent:
         isShiftKeyDown = false,
         movementPosition = Point.zero
       )
+    def unapply(e: Move): Option[Point] =
+      Option(e.position)
 
   /** Mouse has moved into canvas hit test boundaries. It's counterpart is [[Leave]].
     */
@@ -356,6 +364,9 @@ object MouseEvent:
       isShiftKeyDown: Boolean,
       movementPosition: Point
   ) extends MouseEvent
+  object Enter:
+    def unapply(e: Enter): Option[Point] =
+      Option(e.position)
 
   /** Mouse has left canvas hit test boundaries. It's counterpart is [[Enter]].
     */
@@ -368,6 +379,9 @@ object MouseEvent:
       isShiftKeyDown: Boolean,
       movementPosition: Point
   ) extends MouseEvent
+  object Leave:
+    def unapply(e: Leave): Option[Point] =
+      Option(e.position)
 
   /** The mouse wheel was rotated a certain amount into the Y axis.
     *
@@ -396,6 +410,8 @@ object MouseEvent:
         movementPosition = Point.zero,
         amount = amount
       )
+    def unapply(e: Wheel): Option[(Point, Double)] =
+      Option((e.position, e.amount))
 
 end MouseEvent
 
@@ -479,6 +495,9 @@ object PointerEvent:
       pointerType: PointerType,
       isPrimary: Boolean
   ) extends PointerEvent
+  object PointerEnter:
+    def unapply(e: PointerEnter): Option[Point] =
+      Option(e.position)
 
   /** Pointing device left canvas hit test boundaries. It's counterpart is [[PointerEnter]].
     */
@@ -501,6 +520,9 @@ object PointerEvent:
       pointerType: PointerType,
       isPrimary: Boolean
   ) extends PointerEvent
+  object PointerLeave:
+    def unapply(e: PointerLeave): Option[Point] =
+      Option(e.position)
 
   /** Pointing device is in active buttons state.
     */
@@ -524,6 +546,9 @@ object PointerEvent:
       isPrimary: Boolean,
       button: Option[MouseButton]
   ) extends PointerEvent
+  object PointerDown:
+    def unapply(e: PointerDown): Option[Point] =
+      Option(e.position)
 
   /** Pointing device is no longer in active buttons state.
     */
@@ -547,6 +572,9 @@ object PointerEvent:
       isPrimary: Boolean,
       button: Option[MouseButton]
   ) extends PointerEvent
+  object PointerUp:
+    def unapply(e: PointerUp): Option[Point] =
+      Option(e.position)
 
   /** Pointing device changed coordinates.
     */
@@ -569,6 +597,9 @@ object PointerEvent:
       pointerType: PointerType,
       isPrimary: Boolean
   ) extends PointerEvent
+  object PointerMove:
+    def unapply(e: PointerMove): Option[Point] =
+      Option(e.position)
 
   /** The ongoing interactions was cancelled due to:
     *   - the pointer device being disconnected
@@ -595,6 +626,9 @@ object PointerEvent:
       pointerType: PointerType,
       isPrimary: Boolean
   ) extends PointerEvent
+  object PointerCancel:
+    def unapply(e: PointerCancel): Option[Point] =
+      Option(e.position)
 
 /** Represents all keyboard events
   */

--- a/indigo/indigo/src/main/scala/indigo/shared/input/Mouse.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/input/Mouse.scala
@@ -50,7 +50,7 @@ final class Mouse(
 
   lazy val scrolled: Option[MouseWheel] =
     val amount = mouseEvents.foldLeft(0d) {
-      case (acc, MouseEvent.Wheel(_, _, _, _, _, _, _, deltaY)) => acc + deltaY
+      case (acc, MouseEvent.Wheel(_, deltaY)) => acc + deltaY
       case (acc, _)                                             => acc
     }
 
@@ -158,10 +158,10 @@ object Mouse:
       remaining match
         case Nil =>
           buttonsDownAcc
-        case MouseEvent.MouseDown(_, _, _, _, _, _, _, button) :: moreEvents =>
-          rec(moreEvents, buttonsDownAcc + button)
-        case MouseEvent.MouseUp(_, _, _, _, _, _, _, button) :: moreEvents =>
-          rec(moreEvents, buttonsDownAcc - button)
+        case (e: MouseEvent.MouseDown) :: moreEvents =>
+          rec(moreEvents, buttonsDownAcc + e.button)
+        case (e: MouseEvent.MouseUp) :: moreEvents =>
+          rec(moreEvents, buttonsDownAcc - e.button)
         case _ :: moreEvents =>
           rec(moreEvents, buttonsDownAcc)
 

--- a/indigo/indigo/src/main/scala/indigo/shared/input/Mouse.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/input/Mouse.scala
@@ -51,7 +51,7 @@ final class Mouse(
   lazy val scrolled: Option[MouseWheel] =
     val amount = mouseEvents.foldLeft(0d) {
       case (acc, MouseEvent.Wheel(_, deltaY)) => acc + deltaY
-      case (acc, _)                                             => acc
+      case (acc, _)                           => acc
     }
 
     if amount == 0 then Option.empty[MouseWheel]

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/SandboxView.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/SandboxView.scala
@@ -98,7 +98,7 @@ object SandboxView:
       Text("AB!\n!C", 100, 2, 5, Fonts.fontKey, SandboxAssets.fontMaterial.withAlpha(0.5)).alignCenter,
       Text("AB!\n!C", 200, 2, 5, Fonts.fontKey, SandboxAssets.fontMaterial.withAlpha(0.5)).alignRight
         .withEventHandler {
-          case (txt, MouseEvent.Click(pt, _, _, _, _, _, _, _)) if bl.bounds(txt).contains(pt) =>
+          case (txt, MouseEvent.Click(pt)) if bl.bounds(txt).contains(pt) =>
             println("Clicked me!")
             None
 


### PR DESCRIPTION
This change makes the bold assumption that 9 times out of 10, you what to know - for example - that the mouse was clicked and where that happened, and that all of the other information is _generally_ less interesting.

So now you can do this:

```scala
case MouseEvent.Click(pt) => ???
```

Instead of:

```scala
case MouseEvent.Click(pt, _, _, _, _, _, _, _) => ???
```

You can still access the other properties, like so:

```scala
case e: MouseEvent.Click => e.button

// Or at the head of a list of events...
case (e: MouseEvent.Click) :: evts => e.button
```
