### PR TITLE
Fixed #658: Large box overlap small circle check

### DIFF
--- a/indigo/indigo/src/main/scala/indigo/shared/geometry/BoundingBox.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/geometry/BoundingBox.scala
@@ -75,7 +75,7 @@ final case class BoundingBox(position: Vertex, size: Vertex) derives CanEqual:
   def overlaps(other: BoundingBox): Boolean =
     BoundingBox.overlapping(this, other)
   def overlaps(other: BoundingCircle): Boolean =
-    BoundingCircle.overlapping(other, this)
+    contains(other.position) || Math.abs(sdf(other.position)) <= Math.abs(other.radius)
 
   def moveBy(amount: Vertex): BoundingBox =
     this.copy(position = position + amount)

--- a/indigo/indigo/src/test/scala/indigo/shared/geometry/BoundingBoxTests.scala
+++ b/indigo/indigo/src/test/scala/indigo/shared/geometry/BoundingBoxTests.scala
@@ -249,6 +249,27 @@ class BoundingBoxTests extends munit.FunSuite {
     assertEquals(BoundingBox.overlapping(a, b), false)
   }
 
+  test("overlaps BoundingCircle (encompasses)") {
+    val b = BoundingBox(Vertex(0, 0), Vertex(500))
+    val c = BoundingCircle(Vertex(250), 10)
+
+    assert(b.overlaps(c) == true)
+  }
+
+  test("overlaps BoundingCircle (edge)") {
+    val b = BoundingBox(Vertex(0, 0), Vertex(500))
+    val c = BoundingCircle(Vertex(505), 10)
+
+    assert(b.overlaps(c) == true)
+  }
+
+  test("overlaps BoundingCircle (doesn't overlap)") {
+    val b = BoundingBox(Vertex(0, 0), Vertex(500))
+    val c = BoundingCircle(Vertex(600), 10)
+
+    assert(b.overlaps(c) == false)
+  }
+
   test("Expand should be able to expand in size by a given amount") {
     val a = BoundingBox(10, 10, 20, 20)
     val b = BoundingBox(0, 10, 100, 5)

--- a/indigo/indigo/src/test/scala/indigo/shared/geometry/BoundingCircleTests.scala
+++ b/indigo/indigo/src/test/scala/indigo/shared/geometry/BoundingCircleTests.scala
@@ -55,6 +55,13 @@ class BoundingCircleTests extends munit.FunSuite {
     assert(c.moveTo(51, 10).overlaps(b) == false) // Just past.
   }
 
+  test("overlaps BoundingBox (encompasses)") {
+    val b = BoundingBox(Vertex(0, 0), Vertex(1))
+    val c = BoundingCircle(Vertex(0, 0), 200)
+
+    assert(c.overlaps(b) == true)
+  }
+
   test("moveBy | moveTo") {
     val c = BoundingCircle(Vertex(20, 20), 10)
 


### PR DESCRIPTION
Relates to https://github.com/PurpleKingdomGames/indigo/issues/658