### PR TITLE
Fixed #672: Added SparseGrid datatype

### DIFF
--- a/indigo/indigo-extras/src/main/scala/indigoextras/datatypes/SparseGrid.scala
+++ b/indigo/indigo-extras/src/main/scala/indigoextras/datatypes/SparseGrid.scala
@@ -1,0 +1,256 @@
+package indigoextras.datatypes
+
+import indigo.shared.collections.Batch
+import indigo.shared.datatypes.Circle
+import indigo.shared.datatypes.Point
+import indigo.shared.datatypes.Rectangle
+import indigo.shared.datatypes.Size
+import indigo.shared.geometry.LineSegment
+import indigoextras.utils.Bresenham
+
+import scala.annotation.tailrec
+
+import scalajs.js
+import js.JSConverters._
+
+/** SparseGrid is a collection for managing grid of values where grid squares may or may not actually contain a value.
+  */
+final class SparseGrid[A](
+    val size: Size,
+    values: Batch[js.UndefOr[A]]
+):
+  /** Returns the length of the grid, i.e. width * height */
+  lazy val length: Int = size.width * size.height
+
+  /** Put a value into the grid */
+  def put(
+      coords: Point,
+      value: A
+  ): SparseGrid[A] =
+    new SparseGrid(
+      size,
+      values(SparseGrid.pointToIndex(coords, size.width)) = value
+    )
+
+  /** Put a batch of values into the grid */
+  def put(newValues: Batch[(Point, A)]): SparseGrid[A] =
+    val arr = values.toJSArray
+    newValues.foreach { t =>
+      val idx = SparseGrid.pointToIndex(t._1, size.width)
+      val tt  = t._2
+
+      if idx < length then arr(idx) = tt
+    }
+
+    new SparseGrid(size, Batch(arr))
+
+  /** Put a batch of values into the grid, at an offset position */
+  def put(values: Batch[(Point, A)], offset: Point): SparseGrid[A] =
+    put(values.map(p => p._1 + offset -> p._2))
+
+  /** Put repeating values into the grid */
+  def put(values: (Point, A)*): SparseGrid[A] =
+    put(Batch.fromSeq(values))
+
+  /** Fill the grid with the given value */
+  def fill(value: A): SparseGrid[A] =
+    new SparseGrid[A](size, Batch.fill(size.width * size.height)(value))
+
+  /** Get the value at the given coordinates */
+  def get(coords: Point): Option[A] =
+    val idx = SparseGrid.pointToIndex(coords, size.width)
+    values(idx).toOption
+
+  /** Remove the value at the given coordinates */
+  def remove(coords: Point): SparseGrid[A] =
+    new SparseGrid(
+      size,
+      values(SparseGrid.pointToIndex(coords, size.width)) = js.undefined
+    )
+
+  /** Empty the grid */
+  def clear: SparseGrid[A] =
+    SparseGrid(size)
+
+  /** Returns all set values, guarantees order. */
+  def toBatch: Batch[Option[A]] =
+    values.map(_.toOption)
+
+  /** Returns all set values and a default for any value that is not present, guarantees order. */
+  def toBatch(default: A): Batch[A] =
+    values.map(v => v.getOrElse(default))
+
+  /** Returns all values in a given region. */
+  @SuppressWarnings(Array("scalafix:DisableSyntax.while", "scalafix:DisableSyntax.var"))
+  def toBatch(region: Rectangle): Batch[A] =
+    val count = length
+    var i     = 0
+    var j     = 0
+    val acc   = new js.Array[js.UndefOr[A]](length)
+
+    while i < count do
+      if region.contains(SparseGrid.indexToPoint(i, size.width)) then acc(j) = values(i)
+      j += 1
+      i += 1
+
+    Batch(acc.collect { case p if p.isDefined => p.get })
+
+  /** Returns all values in a given region, or the provided default for any missing values. */
+  @SuppressWarnings(Array("scalafix:DisableSyntax.while", "scalafix:DisableSyntax.var"))
+  def toBatch(region: Rectangle, default: A): Batch[A] =
+    val count = length
+    var i     = 0
+    var j     = 0
+    val acc   = new js.Array[js.UndefOr[A]](length)
+
+    while i < count do
+      if region.contains(SparseGrid.indexToPoint(i, size.width)) then
+        val v = values(i)
+        acc(j) = v.getOrElse(default)
+      j += 1
+      i += 1
+
+    Batch(acc.collect { case p if p.isDefined => p.get })
+
+  /** Returns all set values with their grid positions.
+    */
+  @SuppressWarnings(Array("scalafix:DisableSyntax.while", "scalafix:DisableSyntax.var"))
+  def toPositionedBatch: Batch[(Point, A)] =
+    val count = length
+    var i     = 0
+    var j     = 0
+    val acc   = new js.Array[js.UndefOr[(Point, A)]](length)
+
+    while i < count do
+      val v  = values(i)
+      val pt = SparseGrid.indexToPoint(i, size.width)
+      if !js.isUndefined(v) then acc(j) = pt -> v.get
+      j += 1
+      i += 1
+
+    Batch(acc.collect { case p if p.isDefined => p.get })
+
+  /** Returns all values with their grid positions in a given region.
+    */
+  @SuppressWarnings(Array("scalafix:DisableSyntax.while", "scalafix:DisableSyntax.var"))
+  def toPositionedBatch(region: Rectangle): Batch[(Point, A)] =
+    val count = length
+    var i     = 0
+    var j     = 0
+    val acc   = new js.Array[js.UndefOr[(Point, A)]](length)
+
+    while i < count do
+      val v  = values(i)
+      val pt = SparseGrid.indexToPoint(i, size.width)
+      if !js.isUndefined(v) && region.contains(pt) then acc(j) = pt -> v.get
+      j += 1
+      i += 1
+
+    Batch(acc.collect { case p if p.isDefined => p.get })
+
+  /** Alias for `combine`. Takes all of the 'set' entries of 'other' and puts them into this grid.
+    */
+  def |+|(other: SparseGrid[A]): SparseGrid[A] =
+    combine(other)
+
+  /** Takes all of the 'set' entries of 'other' and puts them into this grid. */
+  def combine(other: SparseGrid[A]): SparseGrid[A] =
+    put(other.toPositionedBatch)
+
+  /** Combines two grids be insetting one within the other, at an offset. */
+  def inset(other: SparseGrid[A], offset: Point): SparseGrid[A] =
+    put(other.toPositionedBatch, offset)
+
+  /** Modify a specific point on the grid */
+  def modifyAt(coords: Point)(modifier: Option[A] => Option[A]): SparseGrid[A] =
+    val idx = SparseGrid.pointToIndex(coords, size.width)
+    val t   = values(idx)
+
+    modifier(t.toOption) match
+      case None        => remove(coords)
+      case Some(value) => put(coords, value)
+
+  /** Map over and modify all the points on the grid */
+  def map(modifier: (Point, Option[A]) => Option[A]): SparseGrid[A] =
+    new SparseGrid[A](
+      size,
+      values.zipWithIndex.map { case (v, i) =>
+        val pt = SparseGrid.indexToPoint(i, size.width)
+        modifier(pt, v.toOption).orUndefined
+      }
+    )
+
+  /** Map over and modify all the points on the grid that are within the rectangle */
+  def mapRectangle(region: Rectangle)(
+      modifier: (Point, Option[A]) => Option[A]
+  ): SparseGrid[A] =
+    new SparseGrid[A](
+      size,
+      values.zipWithIndex.map { case (v, i) =>
+        val pt = SparseGrid.indexToPoint(i, size.width)
+        if region.contains(pt) then modifier(pt, v.toOption).orUndefined
+        else v
+      }
+    )
+
+  /** Fill a rectangle on the grid with a value */
+  def fillRectangle(region: Rectangle, value: A): SparseGrid[A] =
+    mapRectangle(region)((_, _) => Option(value))
+
+  /** Map over and modify all the points on the grid that are within the circle */
+  def mapCircle(circle: Circle)(modifier: (Point, Option[A]) => Option[A]): SparseGrid[A] =
+    new SparseGrid[A](
+      size,
+      values.zipWithIndex.map { case (v, i) =>
+        val pt = SparseGrid.indexToPoint(i, size.width)
+        if circle.contains(pt) then modifier(pt, v.toOption).orUndefined
+        else v
+      }
+    )
+
+  /** Fill a circle on the grid with a value */
+  def fillCircle(circle: Circle, value: A): SparseGrid[A] =
+    mapCircle(circle)((_, _) => Option(value))
+
+  /** Map over the grid squares on a line (bresenham) and modify */
+  def mapLine(from: Point, to: Point)(
+      modifier: (Point, Option[A]) => Option[A]
+  ): SparseGrid[A] =
+    val pts = Bresenham.line(from, to)
+    new SparseGrid[A](
+      size,
+      values.zipWithIndex.map { case (v, i) =>
+        val pt = SparseGrid.indexToPoint(i, size.width)
+        if pts.contains(pt) then modifier(pt, v.toOption).orUndefined
+        else v
+      }
+    )
+
+  /** Map over the grid squares on a line (bresenham) and modify */
+  def mapLine(line: LineSegment)(modifier: (Point, Option[A]) => Option[A]): SparseGrid[A] =
+    mapLine(line.start.toPoint, line.end.toPoint)(modifier)
+
+  /** Fill a line (bresenham) with a value */
+  def fillLine(from: Point, to: Point, value: A): SparseGrid[A] =
+    mapLine(from, to)((_, _) => Option(value))
+
+  /** Fill a line (bresenham) with a value */
+  def fillLine(line: LineSegment, value: A): SparseGrid[A] =
+    mapLine(line.start.toPoint, line.end.toPoint)((_, _) => Option(value))
+
+object SparseGrid:
+
+  inline def pointToIndex(point: Point, gridWidth: Int): Int =
+    point.x + (point.y * gridWidth)
+
+  inline def indexToPoint(index: Int, gridWidth: Int): Point =
+    Point(
+      x = index % gridWidth,
+      y = index / gridWidth
+    )
+
+  def apply[A](size: Size): SparseGrid[A] =
+    new SparseGrid[A](
+      size,
+      Batch(new js.Array[A](size.width * size.height))
+    )

--- a/indigo/indigo-extras/src/test/scala/indigoextras/datatypes/SparseGridTests.scala
+++ b/indigo/indigo-extras/src/test/scala/indigoextras/datatypes/SparseGridTests.scala
@@ -1,0 +1,640 @@
+package indigoextras.datatypes
+
+import indigo.*
+
+class SparseGridTests extends munit.FunSuite {
+
+  test("should be able to put and get an element at a given position") {
+    val grid =
+      SparseGrid(Size(3))
+        .put(Point(1, 1), "@")
+
+    val expected =
+      Option("@")
+
+    val actual =
+      grid.get(Point(1))
+
+    assertEquals(expected, actual)
+  }
+
+  test("trying to get at an empty location returns None") {
+    val grid =
+      SparseGrid(Size(3))
+        .put(Point(1, 1), "@")
+
+    val expected: Option[String] =
+      None
+
+    val actual =
+      grid.get(Point(0))
+
+    assertEquals(expected, actual)
+  }
+
+  test("should be able to remove an element at a given position") {
+    val grid =
+      SparseGrid(Size(3))
+        .put(Point(1), "@")
+        .remove(Point(1))
+
+    val expected: Option[String] =
+      None
+
+    val actual =
+      grid.get(Point(1))
+
+    assertEquals(expected, actual)
+  }
+
+  test("should be able insert multiple items") {
+    val list =
+      Batch(
+        (Point(8, 2), "@"),
+        (Point(0, 0), "!"),
+        (Point(9, 9), "?")
+      )
+
+    val grid =
+      SparseGrid(Size(10))
+        .put(list)
+
+    assert(
+      Batch(Point(8, 2), Point(0, 0), Point(9, 9)).forall { v =>
+        clue(grid.get(clue(v))) == list.find(p => p._1 == v).map(_._2)
+      }
+    )
+  }
+
+  test("continuous list (empty)") {
+    val grid =
+      SparseGrid[Int](Size(3))
+
+    val actual =
+      grid.toBatch
+
+    val expected =
+      Batch.fill[Option[Int]](9)(None)
+
+    assertEquals(actual.length, expected.length)
+    assertEquals(actual.toList, expected.toList)
+  }
+
+  test("continuous list (full)") {
+    val coords =
+      (0 to 2).flatMap { y =>
+        (0 to 2).map { x =>
+          Point(x, y)
+        }
+      }.toList
+
+    val items: Batch[(Point, String)] =
+      Batch.fromList(coords.zip(List.fill(8)("!") :+ "@"))
+
+    val grid =
+      SparseGrid(Size(3))
+        .put(items)
+
+    val actual =
+      grid.toBatch.collect { case Some(v) => v }
+
+    val expected =
+      List(
+        "!",
+        "!",
+        "!",
+        "!",
+        "!",
+        "!",
+        "!",
+        "!",
+        "@"
+      )
+
+    assertEquals(actual.length, expected.length)
+    assertEquals(actual.toList, expected)
+  }
+
+  test("continuous list (sparse)") {
+    val coords =
+      List(
+        Point(0, 0),
+        // Point(0, 1),
+        // Point(0, 2),
+        Point(1, 0),
+        Point(1, 1),
+        // Point(1, 2),
+        Point(2, 0),
+        Point(2, 1),
+        Point(2, 2)
+      )
+
+    val items: List[String] =
+      List(
+        "a",
+        "b",
+        "c",
+        "d",
+        "e",
+        "f"
+      )
+
+    val itemsWithCoords: Batch[(Point, String)] =
+      Batch.fromList(coords.zip(items))
+
+    val grid =
+      SparseGrid(Size(3))
+        .put(itemsWithCoords)
+
+    val actual =
+      grid.toBatch.collect { case Some(v) => v }
+
+    val expected =
+      List(
+        "a",
+        "b",
+        "c",
+        "d",
+        "e",
+        "f"
+      )
+
+    assertEquals(actual.length, expected.length)
+    assert(actual.forall(expected.contains))
+    // fail("asd")
+  }
+
+  test("continuous list (sparse, with default)") {
+    val coords =
+      List(
+        Point(0, 0),
+        // Point(0, 1),
+        // Point(0, 2),
+        Point(1, 0),
+        Point(1, 1),
+        // Point(1, 2),
+        Point(2, 0),
+        Point(2, 1),
+        Point(2, 2)
+      )
+
+    val items: List[String] =
+      List(
+        "a",
+        "b",
+        "c",
+        "d",
+        "e",
+        "f"
+      )
+
+    val itemsWithCoords: Batch[(Point, String)] =
+      Batch.fromList(coords.zip(items))
+
+    val grid =
+      SparseGrid(Size(3))
+        .put(itemsWithCoords)
+
+    val actual =
+      grid.toBatch("x")
+
+    val expected =
+      List(
+        "a",
+        "x",
+        "x",
+        "b",
+        "c",
+        "x",
+        "d",
+        "e",
+        "f"
+      )
+
+    assertEquals(actual.length, expected.length)
+    assert(actual.forall(expected.contains))
+  }
+
+  test("combine") {
+    val consoleA =
+      SparseGrid(Size(3))
+        .put(Point(1, 1), "@")
+
+    val consoleB =
+      SparseGrid(Size(3))
+        .put(Point(2, 2), "!")
+
+    val combined =
+      consoleA combine consoleB
+
+    assert(combined.get(Point(1)).get == "@")
+    assert(combined.get(Point(2)).get == "!")
+  }
+
+  test("toBatch") {
+    val consoleA =
+      SparseGrid(Size(3))
+        .put(Point(1, 1), "@")
+
+    val consoleB =
+      SparseGrid(Size(3))
+        .put(Point(2, 2), "!")
+
+    val expected =
+      List(None, None, None, None, Some("@"), None, None, None, Some("!"))
+
+    val actual =
+      (consoleA combine consoleB).toBatch
+
+    assert(actual.length == expected.length)
+    assert(actual.forall(expected.contains))
+  }
+
+  test("toBatch - region") {
+    val grid =
+      SparseGrid(Size(3))
+        .fill("!")
+        .put(Point(1), "@")
+
+    val expected =
+      Batch(
+        "@",
+        "!",
+        "!",
+        "!"
+      )
+
+    val actual =
+      grid.toBatch(Rectangle(1, 1, 2, 2))
+
+    assert(clue(actual.length) == clue(expected.length))
+    assert(clue(actual).forall(clue(expected).contains))
+  }
+
+  test("toBatch - region") {
+    val grid =
+      SparseGrid(Size(3))
+        .fill("!")
+        .put(Point(1), "@")
+
+    val expected =
+      Batch(
+        "@",
+        "!",
+        "!",
+        "!"
+      )
+
+    val actual =
+      grid.toBatch(Rectangle(1, 1, 2, 2))
+
+    assert(clue(actual.length) == clue(expected.length))
+    assert(clue(actual).forall(clue(expected).contains))
+    assert(clue(actual).head == "@")
+  }
+
+  test("toBatch - region with default") {
+    val grid =
+      SparseGrid(Size(3))
+        .put(Point(1), "@")
+
+    val expected =
+      Batch(
+        "@",
+        "x",
+        "x",
+        "x"
+      )
+
+    val actual =
+      grid.toBatch(Rectangle(1, 1, 2, 2), "x")
+
+    assert(clue(actual.length) == clue(expected.length))
+    assert(clue(actual).forall(clue(expected).contains))
+    assert(clue(actual).head == "@")
+  }
+
+  test("toPositionedBatch") {
+    val consoleA =
+      SparseGrid(Size(3))
+        .put(Point(1, 1), "@")
+
+    val consoleB =
+      SparseGrid(Size(3))
+        .put(Point(2, 2), "!")
+
+    val expected =
+      List((Point(1), "@"), (Point(2), "!"))
+
+    val actual =
+      (consoleA combine consoleB).toPositionedBatch
+
+    assert(actual.length == expected.length)
+    assert(actual.forall(expected.contains))
+  }
+
+  test("toPositionedBatch - region") {
+    val grid =
+      SparseGrid(Size(3))
+        .fill("!")
+        .put(Point(1), "@")
+
+    val expected =
+      Batch(
+        Point(1, 1) -> "@",
+        Point(2, 1) -> "!",
+        Point(1, 2) -> "!",
+        Point(2, 2) -> "!"
+      )
+
+    val actual =
+      grid.toPositionedBatch(Rectangle(1, 1, 2, 2))
+
+    assert(clue(actual.length) == clue(expected.length))
+    assert(clue(actual).forall(clue(expected).contains))
+    assert(clue(actual).exists(p => p._1 == Point(1) && p._2 == "@"))
+  }
+
+  test("placing something in the center works.") {
+    val grid =
+      SparseGrid(Size(80, 50))
+        .put(Point(40, 25), "@")
+
+    val expected =
+      Option("@")
+
+    val actual =
+      grid.get(Point(40, 25))
+
+    assertEquals(expected, actual)
+
+    val list =
+      grid.toPositionedBatch
+
+    assert(list.contains((Point(40, 25), "@")))
+
+    val drawn =
+      grid.toBatch
+
+    val foundAt =
+      drawn.zipWithIndex.find(p => p._1 == Some("@")).map(_._2)
+
+    assert(drawn.contains(Some("@")))
+    assert(drawn.filter(_ == Some("@")).length == 1)
+    assert(drawn.length == 80 * 50)
+    assert(foundAt.nonEmpty)
+    assert(clue(foundAt.get) == 2040)
+  }
+
+  test("inset") {
+    val gridA =
+      SparseGrid(Size(3))
+        .put(Point(0), "@")
+    val gridB =
+      SparseGrid(Size(803))
+        .put(Point(0, 0), "!")
+        .put(Point(1, 1), "!")
+        .put(Point(0, 1), "?")
+
+    val expected =
+      Batch(
+        Some("@"),
+        None,
+        None,
+        None,
+        Some("!"),
+        None,
+        None,
+        Some("?"),
+        Some("!")
+      )
+
+    val actual =
+      gridA.inset(gridB, Point(1)).toBatch
+
+    assertEquals(actual, expected)
+  }
+
+  test("modifyAt") {
+    val actual =
+      SparseGrid(Size(3))
+        .fill(".")
+        .modifyAt(Point(1))(_.map(_ + "!"))
+        .toBatch
+
+    val expected =
+      Batch(
+        Batch(
+          ".",
+          ".",
+          "."
+        ),
+        Batch(
+          ".",
+          ".!",
+          "."
+        ),
+        Batch(
+          ".",
+          ".",
+          "."
+        )
+      ).flatten
+
+    assert(actual.length == expected.length)
+    assert(actual.map(_.get).zip(expected).forall(_ == _))
+  }
+
+  test("map") {
+    val actual =
+      SparseGrid(Size(3))
+        .fill(".")
+        .map {
+          case (pt, _) if pt == Point(0) || pt == Point(1) || pt == Point(2) =>
+            Option("?")
+
+          case (_, mt) =>
+            mt
+        }
+        .toBatch
+
+    val expected =
+      Batch(
+        Batch(
+          "?",
+          ".",
+          "."
+        ),
+        Batch(
+          ".",
+          "?",
+          "."
+        ),
+        Batch(
+          ".",
+          ".",
+          "?"
+        )
+      ).flatten
+
+    assert(actual.length == expected.length)
+    assert(actual.map(_.get).zip(expected).forall(_ == _))
+  }
+
+  test("mapRectangle") {
+    val actual =
+      SparseGrid(Size(5))
+        .fill("-")
+        .mapRectangle(Rectangle(1, 1, 3, 3)) { (_, _) =>
+          Option(".")
+        }
+        .toBatch
+
+    val expected =
+      Batch(
+        Batch(
+          "-",
+          "-",
+          "-",
+          "-",
+          "-"
+        ),
+        Batch(
+          "-",
+          ".",
+          ".",
+          ".",
+          "-"
+        ),
+        Batch(
+          "-",
+          ".",
+          ".",
+          ".",
+          "-"
+        ),
+        Batch(
+          "-",
+          ".",
+          ".",
+          ".",
+          "-"
+        ),
+        Batch(
+          "-",
+          "-",
+          "-",
+          "-",
+          "-"
+        )
+      ).flatten
+
+    assert(actual.length == expected.length)
+    assert(actual.map(_.get).zip(expected).forall(_ == _))
+  }
+
+  test("mapCircle") {
+    val actual =
+      SparseGrid(Size(5))
+        .fill("-")
+        .mapCircle(Circle(2, 2, 2)) { (_, _) =>
+          Option(".")
+        }
+        .toBatch
+
+    val expected =
+      Batch(
+        Batch(
+          "-",
+          "-",
+          ".",
+          "-",
+          "-"
+        ),
+        Batch(
+          "-",
+          ".",
+          ".",
+          ".",
+          "-"
+        ),
+        Batch(
+          ".",
+          ".",
+          ".",
+          ".",
+          "."
+        ),
+        Batch(
+          "-",
+          ".",
+          ".",
+          ".",
+          "-"
+        ),
+        Batch(
+          "-",
+          "-",
+          ".",
+          "-",
+          "-"
+        )
+      ).flatten
+
+    assert(actual.length == expected.length)
+    assert(actual.map(_.get).zip(expected).forall(_ == _))
+  }
+
+  test("mapLine") {
+    val actual =
+      SparseGrid(Size(5))
+        .fill("-")
+        .mapLine(Point(0), Point(4)) { (_, _) =>
+          Option(".")
+        }
+        .toBatch
+
+    val expected =
+      Batch(
+        Batch(
+          ".",
+          "-",
+          "-",
+          "-",
+          "-"
+        ),
+        Batch(
+          "-",
+          ".",
+          "-",
+          "-",
+          "-"
+        ),
+        Batch(
+          "-",
+          "-",
+          ".",
+          "-",
+          "-"
+        ),
+        Batch(
+          "-",
+          "-",
+          "-",
+          ".",
+          "-"
+        ),
+        Batch(
+          "-",
+          "-",
+          "-",
+          "-",
+          "."
+        )
+      ).flatten
+
+    assert(actual.length == expected.length)
+    assert(actual.map(_.get).zip(expected).forall(_ == _))
+  }
+
+}


### PR DESCRIPTION
A general purpose data type for managing ...sparse ...grids!

Good for inserting and looking up data, also has facilities for mapping over and returning regions based on lines (via Bresenham's algo), rectangles, and circles.

Ported from the Roguelike-Starterkit.