### PR TITLE
Physics: Terminal Velocity

### DIFF
--- a/indigo/benchmarks/src/main/scala/indigo/benchmarks/PhysicsWorldBenchmarks.scala
+++ b/indigo/benchmarks/src/main/scala/indigo/benchmarks/PhysicsWorldBenchmarks.scala
@@ -10,7 +10,7 @@ import japgolly.scalajs.benchmark.gui._
 object PhysicsWorldBenchmarks:
 
   def render[A]: Collider[A] => SceneNode = {
-    case Collider.Circle(_, bounds, _, _, _, _, _, _, _) =>
+    case Collider.Circle(_, bounds, _, _, _, _, _, _, _, _) =>
       Shape.Circle(
         bounds.position.toPoint,
         bounds.radius.toInt,
@@ -18,7 +18,7 @@ object PhysicsWorldBenchmarks:
         Stroke(1, RGBA.White)
       )
 
-    case Collider.Box(_, bounds, _, _, _, _, _, _, _) =>
+    case Collider.Box(_, bounds, _, _, _, _, _, _, _, _) =>
       Shape.Box(
         bounds.toRectangle,
         Fill.Color(RGBA.White.withAlpha(0.2)),

--- a/indigo/indigo/src/main/scala/indigo/physics/Collider.scala
+++ b/indigo/indigo/src/main/scala/indigo/physics/Collider.scala
@@ -11,6 +11,7 @@ enum Collider[A]:
   def tag: A
   def static: Boolean
   def velocity: Vector2
+  def terminalVelocity: Vector2
   def mass: Mass
   def restitution: Restitution
   def canCollideWith: A => Boolean
@@ -26,6 +27,7 @@ enum Collider[A]:
       bounds: BoundingCircle,
       mass: Mass,
       velocity: Vector2,
+      terminalVelocity: Vector2,
       restitution: Restitution,
       friction: Friction,
       static: Boolean,
@@ -37,6 +39,7 @@ enum Collider[A]:
       bounds: BoundingBox,
       mass: Mass,
       velocity: Vector2,
+      terminalVelocity: Vector2,
       restitution: Restitution,
       friction: Friction,
       static: Boolean,
@@ -58,6 +61,7 @@ object Collider:
         bounds,
         Mass.default,
         Vector2.zero,
+        Vector2.max,
         Restitution.default,
         Friction.zero,
         false,
@@ -72,6 +76,7 @@ object Collider:
         bounds,
         Mass.default,
         Vector2.zero,
+        Vector2.max,
         Restitution.default,
         Friction.zero,
         false,
@@ -86,6 +91,7 @@ object Collider:
         c.bounds.toIncircleBoundingBox,
         c.mass,
         c.velocity,
+        c.terminalVelocity,
         c.restitution,
         c.friction,
         c.static,
@@ -135,6 +141,13 @@ object Collider:
         case cc: Box[_]    => cc.copy(velocity = value)
     def withVelocity(x: Double, y: Double): Collider[A] =
       withVelocity(Vector2(x, y))
+
+    def withTerminalVelocity(value: Vector2): Collider[A] =
+      c match
+        case cc: Circle[_] => cc.copy(terminalVelocity = value)
+        case cc: Box[_]    => cc.copy(terminalVelocity = value)
+    def withTerminalVelocity(x: Double, y: Double): Collider[A] =
+      withTerminalVelocity(Vector2(x, y))
 
     def withPosition(value: Vertex): Collider[A] =
       c match
@@ -199,16 +212,19 @@ object Collider:
 
     def reflect(ray: LineSegment): Option[ReflectionData] =
       c match
-        case Circle(_, bounds, _, _, _, _, _, _, _) => bounds.reflect(ray)
-        case Box(_, bounds, _, _, _, _, _, _, _)    => bounds.reflect(ray)
+        case Circle(_, bounds, _, _, _, _, _, _, _, _) => bounds.reflect(ray)
+        case Box(_, bounds, _, _, _, _, _, _, _, _)    => bounds.reflect(ray)
 
     def ~==(other: Collider[A])(using CanEqual[A, A]): Boolean =
       (c, other) match
-        case (Collider.Circle(aT, a, aM, aV, aR, aF, aS, _, _), Collider.Circle(bT, b, bM, bV, bR, bF, bS, _, _)) =>
-          (aT == bT) && (a ~== b) && (aM ~== bM) && (aV ~== bV) && (aR ~== bR) && (aF ~== bF) && aS == bS
+        case (
+              Collider.Circle(aT, a, aM, aV, aTV, aR, aF, aS, _, _),
+              Collider.Circle(bT, b, bM, bV, bTV, bR, bF, bS, _, _)
+            ) =>
+          (aT == bT) && (a ~== b) && (aM ~== bM) && (aV ~== bV) && (aTV ~== bTV) && (aR ~== bR) && (aF ~== bF) && aS == bS
 
-        case (Collider.Box(aT, a, aM, aV, aR, aF, aS, _, _), Collider.Box(bT, b, bM, bV, bR, bF, bS, _, _)) =>
-          (aT == bT) && (a ~== b) && (aM ~== bM) && (aV ~== bV) && (aR ~== bR) && (aF ~== bF) && aS == bS
+        case (Collider.Box(aT, a, aM, aV, aTV, aR, aF, aS, _, _), Collider.Box(bT, b, bM, bV, bTV, bR, bF, bS, _, _)) =>
+          (aT == bT) && (a ~== b) && (aM ~== bM) && (aV ~== bV) && (aTV ~== bTV) && (aR ~== bR) && (aF ~== bF) && aS == bS
 
         case _ =>
           false

--- a/indigo/indigo/src/main/scala/indigo/physics/Physics.scala
+++ b/indigo/indigo/src/main/scala/indigo/physics/Physics.scala
@@ -85,7 +85,15 @@ object Physics:
           IndexedCollider(index, c, c)
 
         case c @ Collider.Circle(_, bounds, mass, velocity, terminalVelocity, _, _, _, _, _) =>
-          val (p, v) = calculateNewMovement(timeDelta, worldForces, worldResistance, c.bounds.position, velocity, terminalVelocity, mass)
+          val (p, v) = calculateNewMovement(
+            timeDelta,
+            worldForces,
+            worldResistance,
+            c.bounds.position,
+            velocity,
+            terminalVelocity,
+            mass
+          )
 
           IndexedCollider(
             index,
@@ -97,7 +105,15 @@ object Physics:
           IndexedCollider(index, c, c)
 
         case c @ Collider.Box(_, bounds, mass, velocity, terminalVelocity, _, _, _, _, _) =>
-          val (p, v) = calculateNewMovement(timeDelta, worldForces, worldResistance, c.bounds.position, velocity, terminalVelocity, mass)
+          val (p, v) = calculateNewMovement(
+            timeDelta,
+            worldForces,
+            worldResistance,
+            c.bounds.position,
+            velocity,
+            terminalVelocity,
+            mass
+          )
 
           IndexedCollider(
             index,

--- a/indigo/indigo/src/main/scala/indigo/shared/datatypes/Vector2.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/datatypes/Vector2.scala
@@ -26,6 +26,8 @@ final case class Vector2(x: Double, y: Double) derives CanEqual:
 
   def clamp(min: Double, max: Double): Vector2 =
     Vector2(Math.min(max, Math.max(min, x)), Math.min(max, Math.max(min, y)))
+  def clamp(min: Vector2, max: Vector2): Vector2 =
+    this.min(max).max(min)
 
   def length: Double =
     Math.sqrt(x * x + y * y)
@@ -145,6 +147,7 @@ object Vector2:
   val zero: Vector2     = Vector2(0d, 0d)
   val one: Vector2      = Vector2(1d, 1d)
   val minusOne: Vector2 = Vector2(-1d, -1d)
+  val max: Vector2      = Vector2(Double.MaxValue, Double.MaxValue)
 
   def fromPoints(start: Point, end: Point): Vector2 =
     Vector2((end.x - start.x).toDouble, (end.y - start.y).toDouble)

--- a/indigo/indigo/src/main/scala/indigo/shared/datatypes/Vector3.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/datatypes/Vector3.scala
@@ -28,6 +28,8 @@ final case class Vector3(x: Double, y: Double, z: Double) derives CanEqual:
 
   def clamp(min: Double, max: Double): Vector3 =
     Vector3(Math.min(max, Math.max(min, x)), Math.min(max, Math.max(min, y)), Math.min(max, Math.max(min, z)))
+  def clamp(min: Vector3, max: Vector3): Vector3 =
+    this.min(max).max(min)
 
   def length: Double =
     Math.sqrt(x * x + y * y + z * z)

--- a/indigo/indigo/src/main/scala/indigo/shared/datatypes/Vector4.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/datatypes/Vector4.scala
@@ -36,6 +36,8 @@ final case class Vector4(x: Double, y: Double, z: Double, w: Double) derives Can
       Math.min(max, Math.max(min, z)),
       Math.min(max, Math.max(min, w))
     )
+  def clamp(min: Vector4, max: Vector4): Vector4 =
+    this.min(max).max(min)
 
   def length: Double =
     Math.sqrt(x * x + y * y + z * z + w * w)

--- a/indigo/indigo/src/test/scala/indigo/physics/PhysicsTests.scala
+++ b/indigo/indigo/src/test/scala/indigo/physics/PhysicsTests.scala
@@ -54,6 +54,50 @@ class PhysicsTests extends munit.FunSuite:
     assertEquals(actual, expected)
   }
 
+  test("moveColliders - respect terminal velocity") {
+    val colliderA =
+      Collider
+        .Circle(tag, BoundingCircle(10, 10, 5))
+        .withVelocity(Vector2(0, -10))
+        .withTerminalVelocity(Vector2(5))
+        .withFriction(Friction.zero)
+    val colliderB =
+      Collider
+        .Circle(tag, BoundingCircle(10, 10, 5))
+        .withVelocity(Vector2(0, 10))
+        .withTerminalVelocity(Vector2(5))
+        .withFriction(Friction.zero)
+
+    val colliders =
+      Batch(colliderA, colliderB)
+
+    val w = World(
+      colliders,
+      Batch(Vector2(0)),
+      Resistance.zero,
+      settings
+    )
+
+    val actual =
+      Physics.Internal.moveColliders(1.second, w)
+
+    val expected =
+      Batch(
+        Physics.Internal.IndexedCollider(
+          0,
+          colliderA,
+          colliderA.moveTo(Vertex(10, 5)).withVelocity(Vector2(0, -5))
+        ),
+        Physics.Internal.IndexedCollider(
+          1,
+          colliderB,
+          colliderB.moveTo(Vertex(10, 15)).withVelocity(Vector2(0, 5))
+        )
+      )
+
+    assertEquals(actual, expected)
+  }
+
   test("findCollisionGroups") {
     val c1 = Collider.Circle(tag, BoundingCircle(3, 2, 2)).withFriction(Friction.zero)   // overlaps c2 and c3
     val c2 = Collider.Circle(tag, BoundingCircle(1, 4, 2)).withFriction(Friction.zero)   // overlaps c1

--- a/indigo/indigo/src/test/scala/indigo/shared/datatypes/Vector2Tests.scala
+++ b/indigo/indigo/src/test/scala/indigo/shared/datatypes/Vector2Tests.scala
@@ -87,10 +87,19 @@ class Vector2Tests extends munit.FunSuite {
     assertEquals(Vector2(10, 10).max(Vector2(50, 5)), Vector2(50, 10))
   }
 
-  test("clamp") {
+  test("clamp - Double") {
     assertEquals(Vector2(0.1, 0.1).clamp(0, 1), Vector2(0.1, 0.1))
     assertEquals(Vector2(-0.1, 1.1).clamp(0, 1), Vector2(0.0, 1.0))
     assertEquals(Vector2(1, 4).clamp(2, 3), Vector2(2, 3))
+    assertEquals(Vector2(-2, 2).clamp(-1, 1), Vector2(-1, 1))
+  }
+
+  test("clamp - Vector2") {
+    assertEquals(Vector2(0.1, 0.1).clamp(Vector2(0), Vector2(1)), Vector2(0.1, 0.1))
+    assertEquals(Vector2(-0.1, 1.1).clamp(Vector2(0), Vector2(1)), Vector2(0.0, 1.0))
+    assertEquals(Vector2(1, 4).clamp(Vector2(2), Vector2(3)), Vector2(2, 3))
+    assertEquals(Vector2(-2, 2).clamp(Vector2(-1), Vector2(1)), Vector2(-1, 1))
+    assertEquals(Vector2(-2, 2).clamp(Vector2(-1, 0), Vector2(0, 1)), Vector2(-1, 1))
   }
 
   test("length") {

--- a/indigo/indigo/src/test/scala/indigo/shared/datatypes/Vector3Tests.scala
+++ b/indigo/indigo/src/test/scala/indigo/shared/datatypes/Vector3Tests.scala
@@ -63,10 +63,18 @@ class Vector3Tests extends munit.FunSuite {
     assertEquals(Vector3(10, 10, 10).max(Vector3(50, 5, 2)), Vector3(50, 10, 10))
   }
 
-  test("clamp") {
+  test("clamp - Double") {
     assertEquals(Vector3(0.1, 0.1, 0.1).clamp(0, 1), Vector3(0.1, 0.1, 0.1))
     assertEquals(Vector3(-0.1, 1.1, 0.1).clamp(0, 1), Vector3(0.0, 1.0, 0.1))
     assertEquals(Vector3(1, 4, 5).clamp(2, 3), Vector3(2, 3, 3))
+  }
+
+  test("clamp - Vector3") {
+    assertEquals(Vector3(0.1, 0.1, 0.1).clamp(Vector3(0), Vector3(1)), Vector3(0.1, 0.1, 0.1))
+    assertEquals(Vector3(-0.1, 1.1, 0.1).clamp(Vector3(0), Vector3(1)), Vector3(0.0, 1.0, 0.1))
+    assertEquals(Vector3(1, 4, 5).clamp(Vector3(2), Vector3(3)), Vector3(2, 3, 3))
+    assertEquals(Vector3(-2, 2, -2).clamp(Vector3(-1), Vector3(1)), Vector3(-1, 1, -1))
+    assertEquals(Vector3(-2, 2, 2).clamp(Vector3(-1, 0, 0), Vector3(0, 1, 5)), Vector3(-1, 1, 2))
   }
 
   test("length") {

--- a/indigo/indigo/src/test/scala/indigo/shared/datatypes/Vector4Tests.scala
+++ b/indigo/indigo/src/test/scala/indigo/shared/datatypes/Vector4Tests.scala
@@ -63,10 +63,18 @@ class Vector4Tests extends munit.FunSuite {
     assertEquals(Vector4(10, 10, 10, 10).max(Vector4(50, 5, 2, 100)), Vector4(50, 10, 10, 100))
   }
 
-  test("clamp") {
+  test("clamp - Double") {
     assertEquals(Vector4(0.1, 0.1, 0.1, 0.1).clamp(0, 1), Vector4(0.1, 0.1, 0.1, 0.1))
     assertEquals(Vector4(-0.1, 1.1, 0.1, 0.1).clamp(0, 1), Vector4(0.0, 1.0, 0.1, 0.1))
     assertEquals(Vector4(1, 4, 5, 0).clamp(2, 3), Vector4(2, 3, 3, 2))
+  }
+
+  test("clamp - Vector4") {
+    assertEquals(Vector4(0.1, 0.1, 0.1, 0.1).clamp(Vector4(0), Vector4(1)), Vector4(0.1, 0.1, 0.1, 0.1))
+    assertEquals(Vector4(-0.1, 1.1, 0.1, 0.1).clamp(Vector4(0), Vector4(1)), Vector4(0.0, 1.0, 0.1, 0.1))
+    assertEquals(Vector4(1, 4, 5, 0).clamp(Vector4(2), Vector4(3)), Vector4(2, 3, 3, 2))
+    assertEquals(Vector4(-2, 2, -2, 2).clamp(Vector4(-1), Vector4(1)), Vector4(-1, 1, -1, 1))
+    assertEquals(Vector4(-2, 2, 2, -2).clamp(Vector4(-1, 0, 0, 0), Vector4(0, 1, 5, 1)), Vector4(-1, 1, 2, 0))
   }
 
   test("length") {

--- a/indigo/physics/src/main/scala/example/View.scala
+++ b/indigo/physics/src/main/scala/example/View.scala
@@ -9,7 +9,7 @@ object View:
     Outcome(
       SceneUpdateFragment(
         world.present {
-          case Collider.Circle(_, bounds, _, _, _, _, _, _, _) =>
+          case Collider.Circle(_, bounds, _, _, _, _, _, _, _, _) =>
             Shape.Circle(
               bounds.position.toPoint,
               bounds.radius.toInt,
@@ -17,7 +17,7 @@ object View:
               Stroke(1, RGBA.White)
             )
 
-          case Collider.Box(_, bounds, _, _, _, _, _, _, _) =>
+          case Collider.Box(_, bounds, _, _, _, _, _, _, _, _) =>
             Shape.Box(
               bounds.toRectangle,
               Fill.Color(RGBA.White.withAlpha(0.2)),

--- a/indigo/physics/src/main/scala/example/VolumeScene.scala
+++ b/indigo/physics/src/main/scala/example/VolumeScene.scala
@@ -30,6 +30,7 @@ object VolumeScene extends PhysicsScene:
           )
         )
           .withVelocity(Vector2(Math.sin(i.toDouble) * energy, Math.cos(i.toDouble) * energy))
+          .withTerminalVelocity(Vector2(50))
       }
 
     World


### PR DESCRIPTION
Relates to: https://github.com/PurpleKingdomGames/indigo/issues/670

Allows colliders to have a terminal / maximum velocity specified. Obviously the main purpose of this is to set a max speed that a collider can accumulate, but which ever way you look at it, it's a bit a cheat since things do not have a max possible speed in reality, the "max" is just the accumulation of other forces / factors.

However, the use of this is to control your game a bit and keep it playable. It helps make sure projectiles remain visible and that the possibility for tunnelling can be reduced/controlled.