### PR TITLE
Ensures fonts are auto-generated correctly

### DIFF
--- a/indigo-plugin/indigo-plugin/src/indigoplugin/generators/AssetListing.scala
+++ b/indigo-plugin/indigo-plugin/src/indigoplugin/generators/AssetListing.scala
@@ -262,6 +262,7 @@ object AssetListing {
 
   val FontFileExtensions: Set[String] =
     Set(
+      "eot",
       "ttf",
       "woff",
       "woff2"

--- a/indigo-plugin/indigo-plugin/src/indigoplugin/generators/AssetListing.scala
+++ b/indigo-plugin/indigo-plugin/src/indigoplugin/generators/AssetListing.scala
@@ -163,7 +163,7 @@ object AssetListing {
             val safeName = toSafeName(name, ext)
 
             val vals =
-              s"""${indentSpacesNext}val ${safeName}: AssetName               = AssetName("${name}")
+              s"""${indentSpacesNext}val ${safeName}: AssetName               = AssetName("${name}_${ext}")
               |${indentSpacesNext}val ${safeName}FontFamily: FontFamily    = FontFamily(${safeName}.toString())"""
 
             val loadable =

--- a/indigo-plugin/indigo-plugin/src/indigoplugin/generators/AssetListing.scala
+++ b/indigo-plugin/indigo-plugin/src/indigoplugin/generators/AssetListing.scala
@@ -159,6 +159,21 @@ object AssetListing {
 
             (vals, loadable, named)
 
+          case PathTree.File(name, ext, path) if FontFileExtensions.contains(ext) =>
+            val safeName = toSafeName(name, ext)
+
+            val vals =
+              s"""${indentSpacesNext}val ${safeName}: AssetName               = AssetName("${name}")
+              |${indentSpacesNext}val ${safeName}FontFamily: FontFamily    = FontFamily(${safeName}.toString())"""
+
+            val loadable =
+              s"""${indentSpacesNext}    AssetType.Font(${safeName}, AssetPath(baseUrl + "${path}"))"""
+
+            val named =
+              s"""${indentSpacesNext}    $safeName"""
+
+            (vals, loadable, named)
+
           case PathTree.File(name, ext, path) =>
             val safeName = toSafeName(name, ext)
 
@@ -245,4 +260,10 @@ object AssetListing {
       "tiff"
     )
 
+  val FontFileExtensions: Set[String] =
+    Set(
+      "ttf",
+      "woff",
+      "woff2"
+    )
 }


### PR DESCRIPTION
This ensures that font files are loaded as `Font` asset types and also gives direct access to the `FontFamily` for that font. Supported fonts are `ttf`, `woff`, and `woff2` 