### PR TITLE
Physics iterations

### DIFF
--- a/indigo/indigo/src/main/scala/indigo/physics/Displacement.scala
+++ b/indigo/indigo/src/main/scala/indigo/physics/Displacement.scala
@@ -26,7 +26,7 @@ final case class Displacement(amount: Double, normal: Vector2, contact: LineSegm
 
 object Displacement:
 
-  val boxBoxCornerThreshold: Double = 0.1
+  val boxBoxCornerThreshold: Double = 0.001
 
   def calculate[A](ca: Collider[A], cb: Collider[A]): Displacement =
     (ca, cb) match

--- a/indigo/indigo/src/main/scala/indigo/physics/SimulationSettings.scala
+++ b/indigo/indigo/src/main/scala/indigo/physics/SimulationSettings.scala
@@ -15,8 +15,17 @@ import indigo.BoundingBox
   *   much smaller than your smallest collider. Defaults to 1.
   * @param maxDepth
   *   The maximum depth the spatial tree should go to. Defaults to 16.
+  * @param maxIterations
+  *   The maximum number of solver iterations to perform. Fewer iterations improves performance at the cost of accuracy.
+  *   Defaults to 4.
   */
-final case class SimulationSettings(bounds: BoundingBox, idealCount: Int, minSize: Double, maxDepth: Int):
+final case class SimulationSettings(
+    bounds: BoundingBox,
+    idealCount: Int,
+    minSize: Double,
+    maxDepth: Int,
+    maxIterations: Int
+):
 
   def withBounds(value: BoundingBox): SimulationSettings =
     this.copy(bounds = value)
@@ -30,17 +39,24 @@ final case class SimulationSettings(bounds: BoundingBox, idealCount: Int, minSiz
   def withMaxDepth(value: Int): SimulationSettings =
     this.copy(maxDepth = value)
 
+  def withMaxIterations(value: Int): SimulationSettings =
+    this.copy(maxIterations = value)
+
 object SimulationSettings:
 
-  val DefaultIdealCount: Int = 16
-  val DefaultMinSize: Double = 1
-  val DefaultMaxDepth: Int   = 16
+  val DefaultIdealCount: Int    = 16
+  val DefaultMinSize: Double    = 1
+  val DefaultMaxDepth: Int      = 16
+  val DefaultMaxIterations: Int = 4
 
   def apply(bounds: BoundingBox): SimulationSettings =
-    SimulationSettings(bounds, DefaultIdealCount, DefaultMinSize, DefaultMaxDepth)
+    SimulationSettings(bounds, DefaultIdealCount, DefaultMinSize, DefaultMaxDepth, DefaultMaxIterations)
 
   def apply(bounds: BoundingBox, idealCount: Int): SimulationSettings =
-    SimulationSettings(bounds, idealCount, DefaultMinSize, DefaultMaxDepth)
+    SimulationSettings(bounds, idealCount, DefaultMinSize, DefaultMaxDepth, DefaultMaxIterations)
 
   def apply(bounds: BoundingBox, idealCount: Int, minSize: Double): SimulationSettings =
-    SimulationSettings(bounds, idealCount, minSize, DefaultMaxDepth)
+    SimulationSettings(bounds, idealCount, minSize, DefaultMaxDepth, DefaultMaxIterations)
+
+  def apply(bounds: BoundingBox, idealCount: Int, minSize: Double, maxDepth: Int): SimulationSettings =
+    SimulationSettings(bounds, idealCount, minSize, maxDepth, DefaultMaxIterations)

--- a/indigo/indigo/src/test/scala/indigo/physics/PhysicsTests.scala
+++ b/indigo/indigo/src/test/scala/indigo/physics/PhysicsTests.scala
@@ -40,7 +40,7 @@ class PhysicsTests extends munit.FunSuite:
     )
 
     val actual =
-      Physics.Internal.moveColliders(1.second, w)
+      Physics.Internal.moveColliders(1.second, w.colliders, w.combinedForce, w.resistance)
 
     val expected =
       Batch(
@@ -79,7 +79,7 @@ class PhysicsTests extends munit.FunSuite:
     )
 
     val actual =
-      Physics.Internal.moveColliders(1.second, w)
+      Physics.Internal.moveColliders(1.second, w.colliders, w.combinedForce, w.resistance)
 
     val expected =
       Batch(

--- a/indigo/indigo/src/test/scala/indigo/physics/PhysicsTests.scala
+++ b/indigo/indigo/src/test/scala/indigo/physics/PhysicsTests.scala
@@ -194,9 +194,9 @@ class PhysicsTests extends munit.FunSuite:
         c3.withPosition(5.8284, 4.8284).withVelocity(7.07106, 7.07106)
       )
 
-    assert(clue(actual(0)) ~== clue(expected(0)))
-    assert(clue(actual(1)) ~== clue(expected(1)))
-    assert(clue(actual(2)) ~== clue(expected(2)))
+    assert(clue(actual(0).proposed) ~== clue(expected(0)))
+    assert(clue(actual(1).proposed) ~== clue(expected(1)))
+    assert(clue(actual(2).proposed) ~== clue(expected(2)))
   }
 
   test("(Circles) solveCollisions - two dynamic - no movement") {
@@ -218,8 +218,8 @@ class PhysicsTests extends munit.FunSuite:
         c3
       )
 
-    assert(clue(actual(0)) ~== clue(expected(0)))
-    assert(clue(actual(1)) ~== clue(expected(1)))
+    assert(clue(actual(0).proposed) ~== clue(expected(0)))
+    assert(clue(actual(1).proposed) ~== clue(expected(1)))
   }
 
   test("(Circles) solveCollisions - two dynamic - collide") {
@@ -241,8 +241,8 @@ class PhysicsTests extends munit.FunSuite:
         c5.withPosition(9, 4).withVelocity(10, 0)
       )
 
-    assert(clue(actual(0)) ~== clue(expected(0)))
-    assert(clue(actual(1)) ~== clue(expected(1)))
+    assert(clue(actual(0).proposed) ~== clue(expected(0)))
+    assert(clue(actual(1).proposed) ~== clue(expected(1)))
   }
 
   test("(Boxes) solveCollisions - two dynamic - collide") {
@@ -264,8 +264,8 @@ class PhysicsTests extends munit.FunSuite:
         b2.withPosition(7, 2).withVelocity(10, 0)
       )
 
-    assert(clue(actual(0)) ~== clue(expected(0)))
-    assert(clue(actual(1)) ~== clue(expected(1)))
+    assert(clue(actual(0).proposed) ~== clue(expected(0)))
+    assert(clue(actual(1).proposed) ~== clue(expected(1)))
   }
 
   test("(Circles) solveCollisions - two dynamic - collide - zero time delta - displacement resolved") {
@@ -287,8 +287,8 @@ class PhysicsTests extends munit.FunSuite:
         c5.withPosition(9, 4).withVelocity(10, 0)
       )
 
-    assert(clue(actual(0)) ~== clue(expected(0)))
-    assert(clue(actual(1)) ~== clue(expected(1)))
+    assert(clue(actual(0).proposed) ~== clue(expected(0)))
+    assert(clue(actual(1).proposed) ~== clue(expected(1)))
   }
 
   test("(Boxes) solveCollisions - two dynamic - collide - zero time delta - displacement resolved") {
@@ -310,8 +310,8 @@ class PhysicsTests extends munit.FunSuite:
         c5.withPosition(7, 2).withVelocity(10, 0)
       )
 
-    assert(clue(actual(0)) ~== clue(expected(0)))
-    assert(clue(actual(1)) ~== clue(expected(1)))
+    assert(clue(actual(0).proposed) ~== clue(expected(0)))
+    assert(clue(actual(1).proposed) ~== clue(expected(1)))
   }
 
   test("(Circles) solveCollisions - two dynamic - collide - half bounce") {
@@ -342,8 +342,8 @@ class PhysicsTests extends munit.FunSuite:
         c5.withPosition(8.75, 4).withVelocity(5, 0)
       )
 
-    assert(clue(actual(0)) ~== clue(expected(0)))
-    assert(clue(actual(1)) ~== clue(expected(1)))
+    assert(clue(actual(0).proposed) ~== clue(expected(0)))
+    assert(clue(actual(1).proposed) ~== clue(expected(1)))
   }
 
   test("(Boxes) solveCollisions - two dynamic - collide - half bounce") {
@@ -374,8 +374,8 @@ class PhysicsTests extends munit.FunSuite:
         c5.withPosition(6.75, 2).withVelocity(5, 0)
       )
 
-    assert(clue(actual(0)) ~== clue(expected(0)))
-    assert(clue(actual(1)) ~== clue(expected(1)))
+    assert(clue(actual(0).proposed) ~== clue(expected(0)))
+    assert(clue(actual(1).proposed) ~== clue(expected(1)))
   }
 
   test("(Circles) solveCollisions - one dynamic one static - collide") {
@@ -398,8 +398,8 @@ class PhysicsTests extends munit.FunSuite:
         c5
       )
 
-    assert(clue(actual(0)) ~== clue(expected(0)))
-    assert(clue(actual(1)) ~== clue(expected(1)))
+    assert(clue(actual(0).proposed) ~== clue(expected(0)))
+    assert(clue(actual(1).proposed) ~== clue(expected(1)))
   }
 
   test("(Boxes) solveCollisions - one dynamic one static - collide") {
@@ -422,8 +422,8 @@ class PhysicsTests extends munit.FunSuite:
         c5
       )
 
-    assert(clue(actual(0)) ~== clue(expected(0)))
-    assert(clue(actual(1)) ~== clue(expected(1)))
+    assert(clue(actual(0).proposed) ~== clue(expected(0)))
+    assert(clue(actual(1).proposed) ~== clue(expected(1)))
   }
 
   test("(Boxes) solveCollisions - one dynamic one static - collide - vertical") {
@@ -446,8 +446,8 @@ class PhysicsTests extends munit.FunSuite:
         c5
       )
 
-    assert(clue(actual(0)) ~== clue(expected(0)))
-    assert(clue(actual(1)) ~== clue(expected(1)))
+    assert(clue(actual(0).proposed) ~== clue(expected(0)))
+    assert(clue(actual(1).proposed) ~== clue(expected(1)))
   }
 
   test("Example: A circle coming to rest on top of a box, as it reaches the edge, should fall off not bounce back.") {
@@ -471,7 +471,7 @@ class PhysicsTests extends munit.FunSuite:
         circle.withPosition(-0.0855, -1.1425).withVelocity(-10, 0)
       )
 
-    assert(clue(actual(0)) ~== clue(expected(0)))
+    assert(clue(actual(0).proposed) ~== clue(expected(0)))
   }
 
   test("Example: A box travelling down y whose corner hits a static circle at ~45 degrees should not get stuck.") {
@@ -496,7 +496,7 @@ class PhysicsTests extends munit.FunSuite:
         box.withPosition(1.4284, -4.4284).withVelocity(7.07106, -7.07106)
       )
 
-    assert(clue(actual(0)) ~== clue(expected(0)))
+    assert(clue(actual(0).proposed) ~== clue(expected(0)))
   }
 
   test("Example: From the top, striking the corner") {
@@ -520,7 +520,7 @@ class PhysicsTests extends munit.FunSuite:
         circle.withPosition(-0.4901, -1.0651).withVelocity(-10, -10)
       )
 
-    assert(clue(actual(0)) ~== clue(expected(0)))
+    assert(clue(actual(0).proposed) ~== clue(expected(0)))
   }
 
   test("Physics.update should update the world") {
@@ -563,8 +563,8 @@ class PhysicsTests extends munit.FunSuite:
         c2.withPosition(7, 0).withVelocity(0, 0)
       )
 
-    assert(clue(actual(0)) ~== clue(expected(0)))
-    assert(clue(actual(1)) ~== clue(expected(1)))
+    assert(clue(actual(0).proposed) ~== clue(expected(0)))
+    assert(clue(actual(1).proposed) ~== clue(expected(1)))
   }
 
   test("Physics.update should consider, but not return transient colliders") {

--- a/indigo/physics/src/main/scala/example/BoxesAndBallsScene.scala
+++ b/indigo/physics/src/main/scala/example/BoxesAndBallsScene.scala
@@ -36,7 +36,7 @@ object BoxesAndBallsScene extends PhysicsScene:
       }
 
     World
-      .empty[MyTag](SimulationSettings(BoundingBox(0, 0, 800, 600)))
+      .empty[MyTag](SimulationSettings(BoundingBox(0, 0, 800, 600)).withMaxIterations(8))
       .addForces(Vector2(0, 600))
       .withResistance(Resistance(0.01))
       .withColliders(

--- a/indigo/physics/src/main/scala/example/BoxesScene.scala
+++ b/indigo/physics/src/main/scala/example/BoxesScene.scala
@@ -22,7 +22,7 @@ object BoxesScene extends PhysicsScene:
       }
 
     World
-      .empty[MyTag](SimulationSettings(BoundingBox(0, 0, 800, 600)))
+      .empty[MyTag](SimulationSettings(BoundingBox(0, 0, 800, 600)).withMaxIterations(8))
       .addForces(Vector2(0, 600))
       .withResistance(Resistance(0.01))
       .withColliders(

--- a/indigo/physics/src/main/scala/example/VolumeScene.scala
+++ b/indigo/physics/src/main/scala/example/VolumeScene.scala
@@ -20,7 +20,7 @@ object VolumeScene extends PhysicsScene:
     val cols   = (500 - 40) / size
 
     val balls =
-      (0 to 250).toBatch.map { i =>
+      (0 to 1000).toBatch.map { i =>
         Collider(
           MyTag.Ball,
           BoundingCircle(

--- a/indigo/physics/src/main/scala/example/VolumeScene.scala
+++ b/indigo/physics/src/main/scala/example/VolumeScene.scala
@@ -14,13 +14,13 @@ object VolumeScene extends PhysicsScene:
     Lens(_.volume, (m, w) => m.copy(volume = w))
 
   def world(dice: Dice): World[MyTag] =
-    val energy = 400
+    val energy = 1000
     val r      = 5
     val size   = (r + 2) * 2
     val cols   = (500 - 40) / size
 
     val balls =
-      (0 to 1000).toBatch.map { i =>
+      (0 to 250).toBatch.map { i =>
         Collider(
           MyTag.Ball,
           BoundingCircle(
@@ -30,7 +30,7 @@ object VolumeScene extends PhysicsScene:
           )
         )
           .withVelocity(Vector2(Math.sin(i.toDouble) * energy, Math.cos(i.toDouble) * energy))
-          .withTerminalVelocity(Vector2(50))
+          .withTerminalVelocity(Vector2(100))
       }
 
     World


### PR DESCRIPTION
This work adds iterative solving to the physics engine. 

The idea is very simple but [they're good at making it sound complicated](https://en.wikipedia.org/wiki/Gauss%E2%80%93Seidel_method), or maybe I'm just not clever enough to really appreciate it. (Very likely.)

In the current version of Indigo we solve all collisions _once_ and average out the result. Surprisingly, this works kind of ok, but it inevitably means that it's possible in a multi collision scenario, to end up in an undesirable state. This is _always_ possible, but we'd like to reduce the likelihood of that happening. But how?

Well it turns out, the easiest thing to do, is to just keep solving. So for each frame, instead of solving all collisions once, we do it repeatedly until one of two states occurs:

1. Convergence - we reach a state where there are no more collisions to solve.
2. Divergence - we can't resolve a good state in an acceptable time frame, so we give up and hope it sorts itself out next time.

There is a new `maxIterations` param in the `SimulationSettings` and this tells the engine how many times to run the solver per frame. The default is 4, but it makes quite a difference to the hygiene(?) of the results. Now you can trade off accuracy for performance. For example, if all you're doing is spraying bullets and reporting collisions, set iterations to 1 but that's more than good enough; but if you're simulating a bunch of collisions and need more accuracy, dial up the iterations.

*Known problem:* This is particularly in relation to [the sticky corners problem](https://github.com/PurpleKingdomGames/indigo/issues/693), if the iterations are too high, then sticky corners can become a bigger problem. Experiment and adjust as necessary for now.
