### PR TITLE
Updates the Mouse Wheel to allow for more than 1 axis

### DIFF
--- a/indigo/docs/03-gameloop/events.md
+++ b/indigo/docs/03-gameloop/events.md
@@ -94,7 +94,7 @@ The following events are available:
 - `MouseUp(position, buttons, isAltKeyDown, isCtrlKeyDown, isMetaKeyDown, isShiftKeyDown, movementPosition, button)`
 - `MouseDown(position, buttons, isAltKeyDown, isCtrlKeyDown, isMetaKeyDown, isShiftKeyDown, movementPosition, button)`
 - `Move(position, buttons, isAltKeyDown, isCtrlKeyDown, isMetaKeyDown, isShiftKeyDown, movementPosition)`
-- `Wheel(position, buttons, isAltKeyDown, isCtrlKeyDown, isMetaKeyDown, isShiftKeyDown, movementPosition, amount)`
+- `Wheel(position, buttons, isAltKeyDown, isCtrlKeyDown, isMetaKeyDown, isShiftKeyDown, movementPosition, deltaX, deltaY, deltaZ)`
 
 #### `KeyboardEvent`s
 

--- a/indigo/indigo/src/main/scala/indigo/platform/events/WorldEvents.scala
+++ b/indigo/indigo/src/main/scala/indigo/platform/events/WorldEvents.scala
@@ -156,7 +156,9 @@ final class WorldEvents:
           e.metaKey,
           e.shiftKey,
           movementPosition,
-          e.deltaY
+          e.deltaX,
+          e.deltaY,
+          e.deltaZ
         )
 
         globalEventStream.pushGlobalEvent(wheel)

--- a/indigo/indigo/src/main/scala/indigo/shared/events/GlobalEvent.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/events/GlobalEvent.scala
@@ -383,10 +383,14 @@ object MouseEvent:
     def unapply(e: Leave): Option[Point] =
       Option(e.position)
 
-  /** The mouse wheel was rotated a certain amount into the Y axis.
+  /** The mouse wheel was rotated a certain amount around an axis.
     *
-    * @param amount
-    *   vertical amount of pixels, pages or other unit, depending on delta mode, the Y axis was scrolled
+    * @param deltaX
+    *   horizontal amount of pixels, pages or other unit, depending on delta mode, the X axis was scrolled
+    * @param deltaY
+    *   horizontal amount of pixels, pages or other unit, depending on delta mode, the Y axis was scrolled
+    * @param deltaZ
+    *   horizontal amount of pixels, pages or other unit, depending on delta mode, the Z axis was scrolled
     */
   final case class Wheel(
       position: Point,
@@ -396,10 +400,12 @@ object MouseEvent:
       isMetaKeyDown: Boolean,
       isShiftKeyDown: Boolean,
       movementPosition: Point,
-      amount: Double
+      deltaX: Double,
+      deltaY: Double,
+      deltaZ: Double
   ) extends MouseEvent
   object Wheel:
-    def apply(x: Int, y: Int, amount: Double): Wheel =
+    def apply(x: Int, y: Int, deltaX: Double, deltaY: Double, deltaZ: Double): Wheel =
       Wheel(
         position = Point(x, y),
         buttons = Batch.empty,
@@ -408,10 +414,26 @@ object MouseEvent:
         isMetaKeyDown = false,
         isShiftKeyDown = false,
         movementPosition = Point.zero,
-        amount = amount
+        deltaX = deltaX,
+        deltaY = deltaY,
+        deltaZ = deltaZ
+      )
+
+    def apply(x: Int, y: Int, deltaY: Double): Wheel =
+      Wheel(
+        position = Point(x, y),
+        buttons = Batch.empty,
+        isAltKeyDown = false,
+        isCtrlKeyDown = false,
+        isMetaKeyDown = false,
+        isShiftKeyDown = false,
+        movementPosition = Point.zero,
+        deltaX = 0,
+        deltaY = deltaY,
+        deltaZ = 0
       )
     def unapply(e: Wheel): Option[(Point, Double)] =
-      Option((e.position, e.amount))
+      Option((e.position, e.deltaY))
 
 end MouseEvent
 


### PR DESCRIPTION
The mouse wheel event previously had an `amount` property, which represented the movement on the Y axis of a mouse wheel (the up/down motion). However, many devices support more than 1 axis (such as side scrolling), and so this is now represented by the properties `deltaX`, `deltaY`, and `deltaZ`.

The 2 parameter constructor and deconstructor remain the same (assigning the `amount` to the `deltaY`), and so the tests for this remain the same.

This is, however, a breaking change, with anyone who currently uses the `amount` property needing to change that accessor to `deltaY`.