### PR TITLE
Fixed #732: Content Layers support clone blanks

### DIFF
--- a/indigo/indigo/src/main/scala/indigo/shared/platform/SceneProcessor.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/platform/SceneProcessor.scala
@@ -4,6 +4,7 @@ import indigo.shared.AnimationsRegister
 import indigo.shared.BoundaryLocator
 import indigo.shared.FontRegister
 import indigo.shared.QuickCache
+import indigo.shared.collections.Batch
 import indigo.shared.config.RenderingTechnology
 import indigo.shared.datatypes.Depth
 import indigo.shared.datatypes.RGBA
@@ -94,8 +95,11 @@ final class SceneProcessor(
         case _ =>
           None
 
+    val gatheredCloneBlanks: Batch[CloneBlank] =
+      scene.cloneBlanks ++ scene.layers.flatMap(_.layer.gatherCloneBlanks)
+
     val cloneBlankDisplayObjects: scalajs.js.Dictionary[DisplayObject] =
-      scene.cloneBlanks.foldLeft(scalajs.js.Dictionary.empty[DisplayObject]) { (acc, blank) =>
+      gatheredCloneBlanks.foldLeft(scalajs.js.Dictionary.empty[DisplayObject]) { (acc, blank) =>
         val maybeDO =
           if blank.isStatic then
             QuickCache(blank.id.toString) {

--- a/indigo/indigo/src/main/scala/indigo/shared/scenegraph/LayerEntry.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/scenegraph/LayerEntry.scala
@@ -38,10 +38,14 @@ enum LayerEntry:
       case l: LayerEntry.Untagged => l.copy(layer = f(l.layer))
       case l: LayerEntry.Tagged   => l.copy(layer = f(l.layer))
 
-  def withMagnification(level: Int): LayerEntry =
+  /** Apply a magnification to this layer entry's layer, and all it's child layers.
+    *
+    * @param level
+    */
+  def withMagnificationForAll(level: Int): LayerEntry =
     this match
-      case l: LayerEntry.Untagged => l.copy(layer = l.layer.withMagnification(level))
-      case l: LayerEntry.Tagged   => l.copy(layer = l.layer.withMagnification(level))
+      case l: LayerEntry.Untagged => l.copy(layer = l.layer.withMagnificationForAll(level))
+      case l: LayerEntry.Tagged   => l.copy(layer = l.layer.withMagnificationForAll(level))
 
   def toBatch: Batch[Layer.Content] =
     layer.toBatch

--- a/indigo/indigo/src/main/scala/indigo/shared/scenegraph/SceneUpdateFragment.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/scenegraph/SceneUpdateFragment.scala
@@ -114,11 +114,15 @@ final case class SceneUpdateFragment(
   def withAudio(sceneAudio: SceneAudio): SceneUpdateFragment =
     this.copy(audio = Some(sceneAudio))
 
-  def addCloneBlanks(blanks: CloneBlank*): SceneUpdateFragment =
-    addCloneBlanks(blanks.toBatch)
+  def withCloneBlanks(blanks: Batch[CloneBlank]): SceneUpdateFragment =
+    this.copy(cloneBlanks = blanks)
+  def withCloneBlanks(blanks: CloneBlank*): SceneUpdateFragment =
+    withCloneBlanks(blanks.toBatch)
 
   def addCloneBlanks(blanks: Batch[CloneBlank]): SceneUpdateFragment =
     this.copy(cloneBlanks = cloneBlanks ++ blanks)
+  def addCloneBlanks(blanks: CloneBlank*): SceneUpdateFragment =
+    addCloneBlanks(blanks.toBatch)
 
   def withBlendMaterial(newBlendMaterial: BlendMaterial): SceneUpdateFragment =
     this.copy(blendMaterial = Option(newBlendMaterial))
@@ -127,7 +131,7 @@ final case class SceneUpdateFragment(
 
   def withMagnification(level: Int): SceneUpdateFragment =
     this.copy(
-      layers = layers.map(_.withMagnification(level))
+      layers = layers.map(_.withMagnificationForAll(level))
     )
 
   def withCamera(newCamera: Camera): SceneUpdateFragment =

--- a/indigo/indigo/src/test/scala/indigo/shared/scenegraph/SceneUpdateFragmentTests.scala
+++ b/indigo/indigo/src/test/scala/indigo/shared/scenegraph/SceneUpdateFragmentTests.scala
@@ -165,7 +165,7 @@ class SceneUpdateFragmentTests extends munit.FunSuite {
           fail("Should have been a tagged layer entry")
 
         case l @ LayerEntry.Tagged(key, layer) =>
-          l.withTag(BindingKey(key.toString + "?")).withMagnification(2)
+          l.withTag(BindingKey(key.toString + "?")).withMagnificationForAll(2)
       }
 
     assert(actual.layers.flatMap(_.toBatch).length == 2)

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/SandboxGame.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/SandboxGame.scala
@@ -49,7 +49,7 @@ object SandboxGame extends IndigoGame[SandboxBootData, SandboxStartupData, Sandb
   val viewportHeight: Int     = gameHeight * magnificationLevel // 256
 
   def initialScene(bootData: SandboxBootData): Option[SceneName] =
-    Some(TextScene.name)
+    Some(CameraWithCloneTilesScene.name)
 
   def scenes(bootData: SandboxBootData): NonEmptyList[Scene[SandboxStartupData, SandboxGameModel, SandboxViewModel]] =
     NonEmptyList(

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/CameraWithCloneTilesScene.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/CameraWithCloneTilesScene.scala
@@ -62,9 +62,12 @@ object CameraWithCloneTilesScene extends Scene[SandboxStartupData, SandboxGameMo
   ): Outcome[SceneUpdateFragment] =
     Outcome(
       SceneUpdateFragment(
-        Layer(
-          CloneTiles(cloneId, crates)
-        ).withCamera(Camera.LookAt(Point(96)))
+        Layer
+          .Content(
+            CloneTiles(cloneId, crates)
+          )
+          .withCamera(Camera.LookAt(Point(96)))
           .withMagnification(2)
-      ).addCloneBlanks(cloneBlanks)
+          .addCloneBlanks(cloneBlanks)
+      )
     )


### PR DESCRIPTION
Relates to https://github.com/PurpleKingdomGames/indigo/issues/732

This PR allows you to add `CloneBlank`s to `Layer`s (cotent layers, specifically), where previously they had to be added to `SceneUpdateFragment`s.

This makes the new nested layer system more powerful and useful, as you have less need to pull all the way back up to SUFs for visual requirements that need clones.

As discussed on the issue, I've decided against supporting `SceneAudio`  here too, for now. It feels different to clones.

While I was here, I also tweaked the way applying magnification works because it was bothering me. There is now a distinction between applying magnification to a single content layer, vs a recursive add to a tree of layers.