### PR TITLE
Fix Gamepad handling when only one axis is present

### DIFF
--- a/indigo/indigo/src/main/scala/indigo/platform/input/GamepadInputCaptureImpl.scala
+++ b/indigo/indigo/src/main/scala/indigo/platform/input/GamepadInputCaptureImpl.scala
@@ -64,12 +64,18 @@ object GamepadInputCaptureImpl {
     // Filter won't work here since some browsers like Chromium return `null` values in the gamepads array
     gamepads.find(Option(_).exists(_.connected)) match {
       case Some(gp) =>
+        val gameAnalogControls = {
+          val numberOfAxes = gp.axes.length / 2
+          GamepadAnalogControls(
+            AnalogAxis(gp.axes(0), gp.axes(1), gp.buttons(10).pressed),
+            if numberOfAxes >= 2 then AnalogAxis(gp.axes(2), gp.axes(3), gp.buttons(11).pressed)
+            else AnalogAxis.default,
+            numberOfAxes
+          )
+        }
         new Gamepad(
           connected = true,
-          new GamepadAnalogControls(
-            new AnalogAxis(gp.axes(0), gp.axes(1), gp.buttons(10).pressed),
-            new AnalogAxis(gp.axes(2), gp.axes(3), gp.buttons(11).pressed)
-          ),
+          gameAnalogControls,
           new GamepadDPad(
             gp.buttons(12).pressed,
             gp.buttons(13).pressed,

--- a/indigo/indigo/src/main/scala/indigo/shared/input/Gamepad.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/input/Gamepad.scala
@@ -83,10 +83,10 @@ object GamepadDPad {
     GamepadDPad(false, false, false, false)
 }
 
-final case class GamepadAnalogControls(left: AnalogAxis, right: AnalogAxis)
+final case class GamepadAnalogControls(left: AnalogAxis, right: AnalogAxis, numberOfAxes: Int)
 object GamepadAnalogControls {
   val default: GamepadAnalogControls =
-    GamepadAnalogControls(AnalogAxis.default, AnalogAxis.default)
+    GamepadAnalogControls(AnalogAxis.default, AnalogAxis.default, 0)
 }
 
 final case class AnalogAxis(x: Double, y: Double, pressed: Boolean)

--- a/indigo/indigo/src/test/scala/indigo/shared/events/InputStateTests.scala
+++ b/indigo/indigo/src/test/scala/indigo/shared/events/InputStateTests.scala
@@ -341,7 +341,8 @@ class InputStateTests extends munit.FunSuite {
       true,
       new GamepadAnalogControls(
         new AnalogAxis(-1.0, -1.0, false),
-        new AnalogAxis(0.5, 0.0, true)
+        new AnalogAxis(0.5, 0.0, true),
+        2
       ),
       new GamepadDPad(true, false, true, false),
       new GamepadButtons(


### PR DESCRIPTION
... in particular, a single connected Joy-Con.

Fixes https://github.com/PurpleKingdomGames/indigo/issues/760

I imagine we could go one step further and handle the hypothetical case where there is 0 axis (They seem to exist*). But as I don't own one, I can't verify whether it would actually translate to the axes array to be of length 0. So I would leave it like that for now.

*
![image](https://github.com/user-attachments/assets/ced3a6c3-2e44-4095-bcd9-d36919ffc082)
