### PR TITLE
Added BlankEntity size modifiers

### DIFF
--- a/indigo/indigo/src/main/scala/indigo/shared/scenegraph/BlankEntity.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/scenegraph/BlankEntity.scala
@@ -85,7 +85,7 @@ final case class BlankEntity(
     resizeTo(newSize)
 
   def resizeBy(amount: Size): BlankEntity =
-    this.copy(size = size * amount)
+    this.copy(size = size + amount)
   def resizeBy(w: Int, h: Int): BlankEntity =
     resizeBy(Size(w, h))
 

--- a/indigo/indigo/src/main/scala/indigo/shared/scenegraph/BlankEntity.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/scenegraph/BlankEntity.scala
@@ -77,6 +77,18 @@ final case class BlankEntity(
   def withRef(x: Int, y: Int): BlankEntity =
     withRef(Point(x, y))
 
+  def resizeTo(newSize: Size): BlankEntity =
+    this.copy(size = newSize)
+  def resizeTo(w: Int, h: Int): BlankEntity =
+    resizeTo(Size(width, height))
+  def withSize(newSize: Size): BlankEntity =
+    resizeTo(newSize)
+
+  def resizeBy(amount: Size): BlankEntity =
+    this.copy(size = size * amount)
+  def resizeBy(w: Int, h: Int): BlankEntity =
+    resizeBy(Size(w, h))
+
   lazy val toShaderData: ShaderData =
     shaderData
 


### PR DESCRIPTION
Closes #813 

Not sure to add `size` override to `transform(To|By)` so skipped.

```scala
  def transformTo(newPosition: Point, newRotation: Radians, newScale: Vector2, newSize: Size): BlankEntity =
    this.copy(position = newPosition, rotation = newRotation, scale = newScale, size = newSize)

  def transformBy(positionDiff: Point, rotationDiff: Radians, scaleDiff: Vector2, sizeDiff: Size): BlankEntity =
    transformTo(position + positionDiff, rotation + rotationDiff, scale * scaleDiff, size = size * sizeDiff)
```
