### PR TITLE
Stabilize Batch#hashCode

### DIFF
--- a/indigo/indigo/src/main/scala/indigo/shared/collections/Batch.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/collections/Batch.scala
@@ -371,6 +371,10 @@ object Batch:
 
     lazy val size: Int = batch1.size + batch2.size
 
+    override def hashCode(): Int =
+      val t = batch1.foldLeft(31)((acc, v) => 31 * acc + v.hashCode())
+      batch2.foldLeft(t)((acc, v) => 31 * acc + v.hashCode())
+
     override def equals(that: Any): Boolean =
       given CanEqual[Combine[?], Any] = CanEqual.derived
       given CanEqual[Wrapped[?], Any] = CanEqual.derived
@@ -396,6 +400,8 @@ object Batch:
     def toJSArray[B >: A]: js.Array[B] = values.asInstanceOf[js.Array[B]]
 
     lazy val size: Int = values.length
+
+    override def hashCode: Int = values.foldLeft(31)((acc, v) => 31 * acc + v.hashCode())
 
     override def equals(that: Any): Boolean =
       given CanEqual[Combine[?], Any] = CanEqual.derived

--- a/indigo/indigo/src/main/scala/indigo/shared/collections/Batch.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/collections/Batch.scala
@@ -246,6 +246,9 @@ sealed trait Batch[+A]:
   def zip[B](other: Batch[B]): Batch[(A, B)] =
     Batch.Wrapped(_jsArray.zip(other.toJSArray))
 
+  override def hashCode(): Int =
+    _jsArray.foldLeft(31)((acc, v) => 31 * acc + v.hashCode())
+
 object Batch:
 
   extension [A](s: Seq[A]) def toBatch: Batch[A] = Batch.fromSeq(s)
@@ -371,10 +374,6 @@ object Batch:
 
     lazy val size: Int = batch1.size + batch2.size
 
-    override def hashCode(): Int =
-      val t = batch1.foldLeft(31)((acc, v) => 31 * acc + v.hashCode())
-      batch2.foldLeft(t)((acc, v) => 31 * acc + v.hashCode())
-
     override def equals(that: Any): Boolean =
       given CanEqual[Combine[?], Any] = CanEqual.derived
       given CanEqual[Wrapped[?], Any] = CanEqual.derived
@@ -400,8 +399,6 @@ object Batch:
     def toJSArray[B >: A]: js.Array[B] = values.asInstanceOf[js.Array[B]]
 
     lazy val size: Int = values.length
-
-    override def hashCode: Int = values.foldLeft(31)((acc, v) => 31 * acc + v.hashCode())
 
     override def equals(that: Any): Boolean =
       given CanEqual[Combine[?], Any] = CanEqual.derived

--- a/indigo/indigo/src/test/scala/indigo/shared/collections/BatchSpecification.scala
+++ b/indigo/indigo/src/test/scala/indigo/shared/collections/BatchSpecification.scala
@@ -1,0 +1,22 @@
+package indigo.shared.collections
+
+import org.scalacheck.*
+
+import scala.annotation.nowarn
+
+@SuppressWarnings(Array("scalafix:DisableSyntax.var"))
+@nowarn("msg=unused")
+class BatchSpecification extends Properties("Batch") {
+  property("hashCode - both Wrapped") = Prop.forAll { (a: List[Int]) =>
+    Batch(a*).hashCode == Batch(a*).hashCode
+  }
+
+  property("hashCode - both Combined") = Prop.forAll { (a: List[Int], b: List[Int], c: List[Int]) =>
+    Batch.Combine(Batch.Combine(Batch(a*), Batch(b*)), Batch(c*)).hashCode ==
+      Batch.Combine(Batch(a*), Batch.Combine(Batch(b*), Batch(c*))).hashCode
+  }
+
+  property("hashCode - Wrapped and Combined, same elements") = Prop.forAll { (a: List[Int], b: List[Int]) =>
+    Batch((a ++ b)*).hashCode == Batch.Combine(Batch(a*), Batch(b*)).hashCode
+  }
+}


### PR DESCRIPTION
Closes #740

`Batch#hashCode` is now stable regardless of concrete classes (`Wrapped` or `Combine`), since now calculated from elements.
Calculation time is increasing proportionally to number of elements.