### PR TITLE
Fix various windowisms

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,15 +1,16 @@
-Set-Location -Path indigo-plugin -PassThru
-& .\build.ps1
-Set-Location -Path .. -PassThru
+function build {
+    param (
+        [string]$ProjectPath
+    )
 
-Set-Location -Path sbt-indigo -PassThru
-& .\build.ps1
-Set-Location -Path .. -PassThru
+    echo ">>> $ProjectPath"
+    Set-Location -Path $ProjectPath -PassThru
+    & .\build.ps1
+    Set-Location -Path .. -PassThru
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+}
 
-Set-Location -Path mill-indigo -PassThru
-& .\build.ps1
-Set-Location -Path .. -PassThru
-
-Set-Location -Path indigo -PassThru
-& .\build.ps1
-Set-Location -Path .. -PassThru
+build "indigo-plugin"
+build "sbt-indigo"
+build "mill-indigo"
+build "indigo"

--- a/indigo-plugin/build.ps1
+++ b/indigo-plugin/build.ps1
@@ -1,14 +1,22 @@
+function mill {
+    param (
+        [string]$Command
+    )
+
+    .\millw.bat -i $Command
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+}
 
 Remove-Item -Recurse -Force -Path .\out
 
-.\millw.bat -i clean
-.\millw.bat -i clean indigo-plugin[2.12]
-.\millw.bat -i clean indigo-plugin[2.13]
-.\millw.bat -i indigo-plugin[2.12].compile
-.\millw.bat -i indigo-plugin[2.13].compile
-.\millw.bat -i indigo-plugin[2.12].test
-.\millw.bat -i indigo-plugin[2.13].test
-.\millw.bat -i indigo-plugin[2.12].checkFormat
-.\millw.bat -i indigo-plugin[2.13].checkFormat
-.\millw.bat -i indigo-plugin[2.12].publishLocal
-.\millw.bat -i indigo-plugin[2.13].publishLocal
+mill clean
+mill clean indigo-plugin[2.12]
+mill clean indigo-plugin[2.13]
+mill indigo-plugin[2.12].compile
+mill indigo-plugin[2.13].compile
+mill indigo-plugin[2.12].test
+mill indigo-plugin[2.13].test
+mill indigo-plugin[2.12].checkFormat
+mill indigo-plugin[2.13].checkFormat
+mill indigo-plugin[2.12].publishLocal
+mill indigo-plugin[2.13].publishLocal

--- a/indigo-plugin/indigo-plugin/src/indigoplugin/generators/EmbedGLSLShaderPair.scala
+++ b/indigo-plugin/indigo-plugin/src/indigoplugin/generators/EmbedGLSLShaderPair.scala
@@ -97,8 +97,8 @@ object EmbedGLSLShaderPair {
     """.stripMargin
 
   def extractShaderCode(text: String, tag: String, newName: String): List[ShaderSnippet] =
-    s"""//<indigo-$tag>\n((.|\n|\r)*)//</indigo-$tag>""".r
-      .findAllIn(text)
+    s"""//<indigo-$tag>\\n((.|\\n|\\r)*)//</indigo-$tag>""".r
+      .findAllIn(text.replaceAll("\\R", "\n"))
       .toList
       .map(_.toString)
       .map(_.split('\n').drop(1).dropRight(1).mkString("\n"))

--- a/indigo-plugin/indigo-plugin/test/src/indigoplugin/generators/AssetListingTests.scala
+++ b/indigo-plugin/indigo-plugin/test/src/indigoplugin/generators/AssetListingTests.scala
@@ -144,10 +144,8 @@ class AssetListingTests extends munit.FunSuite {
       Set(
         a
       )
-      """.trim
+      """
 
-    assertEquals(actual.trim, expected.trim)
-
+    assertNoDiff(actual, expected)
   }
-
 }

--- a/indigo-plugin/indigo-plugin/test/src/indigoplugin/generators/EmbedDataTests.scala
+++ b/indigo-plugin/indigo-plugin/test/src/indigoplugin/generators/EmbedDataTests.scala
@@ -61,7 +61,7 @@ class EmbedDataTests extends munit.FunSuite {
       |  case Stan extends GameScores(None, -2.0, true)
       """.stripMargin
 
-    assertEquals(actualEnum.trim, expectedEnum.trim)
+    assertNoDiff(actualEnum, expectedEnum)
 
     val actualEnumWithExtends =
       actual.renderEnum("GameScores", Option("ScoreData"))
@@ -74,7 +74,7 @@ class EmbedDataTests extends munit.FunSuite {
       |  case Stan extends GameScores(None, -2.0, true)
       """.stripMargin
 
-    assertEquals(actualEnumWithExtends.trim, expectedEnumWithExtends.trim)
+    assertNoDiff(actualEnumWithExtends, expectedEnumWithExtends)
 
     val actualMap =
       actual.renderMap("GameScores")
@@ -91,8 +91,7 @@ class EmbedDataTests extends munit.FunSuite {
       |    )
       """.stripMargin
 
-    assertEquals(actualMap.trim, expectedMap.trim)
-
+    assertNoDiff(actualMap, expectedMap)
   }
 
   test("Extract row data - csv - simple") {

--- a/indigo-plugin/indigo-plugin/test/src/indigoplugin/generators/EmbedGLSLShaderPairTests.scala
+++ b/indigo-plugin/indigo-plugin/test/src/indigoplugin/generators/EmbedGLSLShaderPairTests.scala
@@ -84,7 +84,7 @@ void fragment(){
         )
       )
 
-    assertEquals(actual, expected)
+    assertNoDiff(actual.toString(), expected.toString())
   }
 
   val sampleVertexProgram: String =

--- a/indigo-plugin/indigo-plugin/test/src/indigoplugin/generators/GeneratorAcceptanceTests.scala
+++ b/indigo-plugin/indigo-plugin/test/src/indigoplugin/generators/GeneratorAcceptanceTests.scala
@@ -85,7 +85,7 @@ class GeneratorAcceptanceTests extends munit.FunSuite {
           |  case Fortitude extends StatsEnum(4, 1, Some(false))
           |""".stripMargin
 
-        assertEquals(actual.trim, expected.trim)
+        assertNoDiff(actual, expected)
     }
   }
 
@@ -121,7 +121,7 @@ class GeneratorAcceptanceTests extends munit.FunSuite {
           |    )
           |""".stripMargin
 
-        assertEquals(actual.trim, expected.trim)
+        assertNoDiff(actual, expected)
     }
   }
 
@@ -152,7 +152,7 @@ class GeneratorAcceptanceTests extends munit.FunSuite {
           |  case ChainMail extends Armour(3)
           |""".stripMargin
 
-        assertEquals(actual.trim, expected.trim)
+        assertNoDiff(actual, expected)
     }
   }
 
@@ -189,7 +189,7 @@ class GeneratorAcceptanceTests extends munit.FunSuite {
           |*/
           |""".stripMargin
 
-        assertEquals(actual.trim, expected.trim)
+        assertNoDiff(actual, expected)
     }
   }
 
@@ -268,7 +268,7 @@ class GeneratorAcceptanceTests extends munit.FunSuite {
     val files =
       IndigoGenerators("com.example.test")
         .embed("ColoursList", sourceColours) { text =>
-          "val colours: List[String] = " + text.split("\n").map(t => s"""\"$t\"""").mkString("List(", ", ", ")")
+          "val colours: List[String] = " + text.replaceAll("\\R","\n").split("\n").map(t => s"""\"$t\"""").mkString("List(", ", ", ")")
         }
         .toSourcePaths(targetDir)
 

--- a/indigo/indigo-extras/src/test/scala/indigoextras/effectmaterials/shaders/LegacyEffectsShadersTests.scala
+++ b/indigo/indigo-extras/src/test/scala/indigoextras/effectmaterials/shaders/LegacyEffectsShadersTests.scala
@@ -40,7 +40,7 @@ class LegacyEffectsShadersTests extends munit.FunSuite {
       |}
       |""".stripMargin.trim
 
-    assertEquals(actual, expected)
+    assertNoDiff(actual, expected)
   }
 
 }

--- a/indigo/indigo/src/main/scala/indigo/shared/shader/RawShaderCode.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/shader/RawShaderCode.scala
@@ -47,7 +47,7 @@ object RawShaderCode {
           |${customShader.light}
           |
           |${customShader.composite}
-          |""".stripMargin.trim
+          |"""
         )
     }
 

--- a/indigo/indigo/src/test/scala/indigo/shared/shader/library/BaseBlendShaderTests.scala
+++ b/indigo/indigo/src/test/scala/indigo/shared/shader/library/BaseBlendShaderTests.scala
@@ -17,19 +17,25 @@ class BaseBlendShaderTests extends munit.FunSuite {
       }
 
     val actual =
-      BlendShader.vertex(modifyVertex, IndigoUV.VertexEnv.reference).toOutput.code
+      BlendShader
+        .vertex(modifyVertex, IndigoUV.VertexEnv.reference)
+        .toOutput
+        .code
+        .stripMargin
+        .trim
+        .replaceAll("\\R", "\n")
 
     val expected1: String =
       """
       |vec4 vertex(in vec4 v){
       |  return v+vec4(1.0);
       |}
-      |""".stripMargin.trim
+      |""".stripMargin.trim.replaceAll("\\R", "\n")
 
     val expected2: String =
       """
       |VERTEX=vertex(VERTEX);
-      |""".stripMargin.trim
+      |""".stripMargin.trim.replaceAll("\\R", "\n")
 
     assert(clue(actual).contains(clue(expected1)))
     assert(clue(actual).contains(clue(expected2)))
@@ -59,19 +65,23 @@ class BaseBlendShaderTests extends munit.FunSuite {
       }
 
     val actual =
-      BlendShader.fragment(modifyColor, IndigoUV.BlendFragmentEnv.reference).toOutput.code
+      BlendShader
+        .fragment(modifyColor, IndigoUV.BlendFragmentEnv.reference)
+        .toOutput
+        .code
+        .replaceAll("\\R", "\n")
 
     val expected1: String =
       """
       |vec4 fragment(in vec4 v){
       |  return v+vec4(1.0);
       |}
-      |""".stripMargin.trim
+      |""".stripMargin.trim.replaceAll("\\R", "\n")
 
     val expected2: String =
       """
       |COLOR=fragment(COLOR);
-      |""".stripMargin.trim
+      |""".stripMargin.trim.replaceAll("\\R", "\n")
 
     assert(clue(actual).contains(clue(expected1)))
     assert(clue(actual).contains(clue(expected2)))

--- a/indigo/indigo/src/test/scala/indigo/shared/shader/library/BaseEntityShaderTests.scala
+++ b/indigo/indigo/src/test/scala/indigo/shared/shader/library/BaseEntityShaderTests.scala
@@ -18,19 +18,19 @@ class BaseEntityShaderTests extends munit.FunSuite {
       }
 
     val actual =
-      EntityShader.vertex(modifyVertex, IndigoUV.VertexEnv.reference).toOutput.code
+      EntityShader.vertex(modifyVertex, IndigoUV.VertexEnv.reference).toOutput.code.replaceAll("\\R", "\n")
 
     val expected1: String =
       """
       |vec4 vertex(in vec4 v){
       |  return v+vec4(1.0);
       |}
-      |""".stripMargin.trim
+      |""".stripMargin.trim.replaceAll("\\R", "\n")
 
     val expected2: String =
       """
       |VERTEX=vertex(VERTEX);
-      |""".stripMargin.trim
+      |""".stripMargin.trim.replaceAll("\\R", "\n")
 
     assert(clue(actual).contains(clue(expected1)))
     assert(clue(actual).contains(clue(expected2)))
@@ -86,33 +86,34 @@ vec4 vertex(vec4 v){
         .fragment(modifyColor, IndigoUV.FragmentEnv.reference)
         .toOutput
         .code
+        .replaceAll("\\R", "\n")
 
     val expected1: String =
       """
       |vec4 fragment(in vec4 v){
       |  return v+vec4(1.0);
       |}
-      |""".stripMargin.trim
+      |""".stripMargin.trim.replaceAll("\\R", "\n")
 
     val expected2: String =
       """
       |COLOR=fragment(COLOR);
-      |""".stripMargin.trim
+      |""".stripMargin.trim.replaceAll("\\R", "\n")
 
     val expected3: String =
       """
       |void prepare(){}
-      |""".stripMargin.trim
+      |""".stripMargin.trim.replaceAll("\\R", "\n")
 
     val expected4: String =
       """
       |void light(){}
-      |""".stripMargin.trim
+      |""".stripMargin.trim.replaceAll("\\R", "\n")
 
     val expected5: String =
       """
       |void composite(){}
-      |""".stripMargin.trim
+      |""".stripMargin.trim.replaceAll("\\R", "\n")
 
     assert(clue(actual).contains(clue(expected1)))
     assert(clue(actual).contains(clue(expected2)))

--- a/indigo/indigo/src/test/scala/indigo/shared/shader/library/LightingTests.scala
+++ b/indigo/indigo/src/test/scala/indigo/shared/shader/library/LightingTests.scala
@@ -59,9 +59,9 @@ class LightingTests extends munit.FunSuite {
       |    roughnessColor=mix(roughnessColor,CHANNEL_3,CHANNEL_3.w*LIGHT_ROUGHNESS.y);
       |  }
       |}
-      |""".stripMargin.trim
+      |""".stripMargin
 
-    assertEquals(actual, expected)
+    assertNoDiff(actual, expected)
   }
 
   test("Lighting light") {
@@ -150,9 +150,9 @@ class LightingTests extends munit.FunSuite {
       |    lightAcc=lightAcc+lightResult;
       |  }
       |}
-      |""".stripMargin.trim
+      |""".stripMargin
 
-    assertEquals(actual, expected)
+    assertNoDiff(actual, expected)
   }
 
   test("Lighting composite") {
@@ -168,9 +168,9 @@ class LightingTests extends munit.FunSuite {
       |  vec4 colorLightSpec=vec4(COLOR.xyz*(lightAcc.xyz+specularAcc.xyz),COLOR.w);
       |  COLOR=mix(colorLightSpec,emissiveResult,emissiveResult.w);
       |}
-      |""".stripMargin.trim
+      |""".stripMargin
 
-    assertEquals(actual, expected)
+    assertNoDiff(actual, expected)
   }
 
 }

--- a/indigo/indigo/src/test/scala/indigo/shared/shader/library/TileAndStretchTests.scala
+++ b/indigo/indigo/src/test/scala/indigo/shared/shader/library/TileAndStretchTests.scala
@@ -28,9 +28,7 @@ class TileAndStretchTests extends munit.FunSuite {
     val actual =
       fragment.toGLSL[WebGL2].toOutput.code
 
-    // println(actual)
-
-    assertEquals(
+    assertNoDiff(
       actual,
       s"""
       |vec2 uv=vec2(1.0);
@@ -39,7 +37,7 @@ class TileAndStretchTests extends munit.FunSuite {
       |vec2 entitySize=vec2(4.0);
       |vec2 textureSize=vec2(5.0);
       |channelPos+((fract(uv*(entitySize/textureSize)))*channelSize);
-      |""".stripMargin.trim
+      |""".stripMargin
     )
 
   }
@@ -64,16 +62,14 @@ class TileAndStretchTests extends munit.FunSuite {
     val actual =
       fragment.toGLSL[WebGL2].toOutput.code
 
-    // println(actual)
-
-    assertEquals(
+    assertNoDiff(
       actual,
       s"""
       |vec2 uv=vec2(1.0);
       |vec2 channelPos=vec2(2.0);
       |vec2 channelSize=vec2(3.0);
       |channelPos+(uv*channelSize);
-      |""".stripMargin.trim
+      |""".stripMargin
     )
 
   }

--- a/indigo/indigo/src/test/scala/indigo/shared/shader/library/WebGL1Tests.scala
+++ b/indigo/indigo/src/test/scala/indigo/shared/shader/library/WebGL1Tests.scala
@@ -47,9 +47,9 @@ class WebGL1Tests extends munit.FunSuite {
       |  gl_Position=((u_projection*u_baseTransform)*transform)*vertices;
       |  v_texcoord=scaleTexCoords(texcoords);
       |}
-      |""".stripMargin.trim
+      |""".stripMargin
 
-    assertEquals(actual, expected)
+    assertNoDiff(actual, expected)
   }
 
   test("Base WebGL 1.0 fragment shader") {
@@ -65,9 +65,9 @@ class WebGL1Tests extends munit.FunSuite {
       |void main(){
       |  gl_FragColor=texture2D(u_texture,v_texcoord);
       |}
-      |""".stripMargin.trim
+      |""".stripMargin
 
-    assertEquals(actual, expected)
+    assertNoDiff(actual, expected)
   }
 
 }

--- a/mill-indigo/build.ps1
+++ b/mill-indigo/build.ps1
@@ -1,6 +1,15 @@
-.\millw.bat clean
-.\millw.bat clean mill-indigo[2.13]
-.\millw.bat mill-indigo[2.13].compile
-.\millw.bat mill-indigo[2.13].test
-.\millw.bat mill-indigo[2.13].checkFormat
-.\millw.bat mill-indigo[2.13].publishLocal
+function mill {
+    param (
+        [string]$Command
+    )
+
+    .\millw.bat -i $Command
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+}
+
+mill clean
+mill clean mill-indigo[2.13]
+mill mill-indigo[2.13].compile
+mill mill-indigo[2.13].test
+mill mill-indigo[2.13].checkFormat
+mill mill-indigo[2.13].publishLocal


### PR DESCRIPTION
Fixes #833 

Amends tests that fail because of incidental CRLF causing assertEquals to fail to instead use assertNoDiff. This also removes the need for some trims on expected and actual.

Another test fix is to convert to string expressions before comparison, where the CRLF are embedded.

One test retrieves its input from the os, and when constructing the expected value presumes lines are separated by NEWLINE, the regex technique explained next is used to coerce the string into the expected format.

EmbedGLSLShaderPair.extractShaderCode presumes the input string is formatted with leading NEWLINE. When a file is read from windows it is CRLF aka RETURN & NEWLINE. This fix sidesteps the issue by regex replacing all instances of the magical regex "\\R"  newline with exactly NEWLINE.