### PR TITLE
Fixed #753 & #737: Make layer modification easier

### DIFF
--- a/indigo/indigo/src/main/scala/indigo/shared/scenegraph/LayerEntry.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/scenegraph/LayerEntry.scala
@@ -32,19 +32,17 @@ enum LayerEntry:
 
   def modify(f: LayerEntry => LayerEntry): LayerEntry =
     f(this)
-  def modifyLayer(f: Layer => Layer): LayerEntry =
+  def modifyLayer(pf: PartialFunction[Layer, Layer]): LayerEntry =
     this match
-      case l: LayerEntry.NoKey => l.copy(layer = f(l.layer))
-      case l: LayerEntry.Keyed => l.copy(layer = f(l.layer))
+      case l: LayerEntry.NoKey => l.copy(layer = layer.modify(pf))
+      case l: LayerEntry.Keyed => l.copy(layer = layer.modify(pf))
 
   /** Apply a magnification to this layer entry's layer, and all it's child layers.
     *
     * @param level
     */
   def withMagnificationForAll(level: Int): LayerEntry =
-    this match
-      case l: LayerEntry.NoKey => l.copy(layer = l.layer.withMagnificationForAll(level))
-      case l: LayerEntry.Keyed => l.copy(layer = l.layer.withMagnificationForAll(level))
+    this.modifyLayer(_.withMagnificationForAll(level))
 
   def toBatch: Batch[Layer.Content] =
     layer.toBatch

--- a/indigo/indigo/src/main/scala/indigo/shared/scenegraph/SceneUpdateFragment.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/scenegraph/SceneUpdateFragment.scala
@@ -92,7 +92,7 @@ final case class SceneUpdateFragment(
   def withLayers(layers: Layer*): SceneUpdateFragment =
     withLayers(layers.toBatch.map(LayerEntry.apply))
 
-  def mapLayers(f: LayerEntry => LayerEntry): SceneUpdateFragment =
+  def modifyLayers(f: LayerEntry => LayerEntry): SceneUpdateFragment =
     this.copy(layers = layers.map(_.modify(f)))
 
   def noLights: SceneUpdateFragment =

--- a/indigo/indigo/src/test/scala/indigo/shared/scenegraph/LayerTests.scala
+++ b/indigo/indigo/src/test/scala/indigo/shared/scenegraph/LayerTests.scala
@@ -81,4 +81,49 @@ class LayerTests extends munit.FunSuite {
     )
   }
 
+  test("modify - Content layer") {
+    val l = Layer.Content.empty.withMagnification(1)
+
+    val actual   = l.modify { case l: Layer.Content => l.withMagnification(2) }
+    val expected = Layer.Content.empty.withMagnification(2)
+
+    assertEquals(actual, expected)
+  }
+
+  test("modify - Stack layer") {
+    val l = Layer.Stack(Layer.Content.empty, Layer.Content.empty, Layer.Content.empty)
+
+    val actual   = l.modify { case ll: Layer.Stack => Layer.Stack(ll.layers.take(1)) }
+    val expected = Layer.Stack(Layer.Content.empty)
+
+    assertEquals(actual, expected)
+  }
+
+  test("modify - perform a deep modification") {
+    val l = Layer.Stack(
+      Layer.Stack(
+        Layer.Content.empty.withMagnification(1),
+        Layer.Content.empty.withMagnification(1),
+        Layer.Content.empty.withMagnification(1)
+      ),
+      Layer.Content.empty.withMagnification(1),
+      Layer.Content.empty.withMagnification(1),
+      Layer.Content.empty.withMagnification(1)
+    )
+
+    val actual = l.modify { case l: Layer.Content => l.withMagnification(2) }
+    val expected = Layer.Stack(
+      Layer.Stack(
+        Layer.Content.empty.withMagnification(2),
+        Layer.Content.empty.withMagnification(2),
+        Layer.Content.empty.withMagnification(2)
+      ),
+      Layer.Content.empty.withMagnification(2),
+      Layer.Content.empty.withMagnification(2),
+      Layer.Content.empty.withMagnification(2)
+    )
+
+    assertEquals(actual, expected)
+  }
+
 }

--- a/indigo/indigo/src/test/scala/indigo/shared/scenegraph/SceneUpdateFragmentTests.scala
+++ b/indigo/indigo/src/test/scala/indigo/shared/scenegraph/SceneUpdateFragmentTests.scala
@@ -153,14 +153,14 @@ class SceneUpdateFragmentTests extends munit.FunSuite {
         fail("match failed")
   }
 
-  test("Map over layers") {
+  test("Modify layers") {
     val scene =
       SceneUpdateFragment.empty
         .addLayer(LayerKey("key A") -> Layer.empty.withMagnification(1))
         .addLayer(LayerKey("key B") -> Layer.empty.withMagnification(1))
 
     val actual =
-      scene.mapLayers {
+      scene.modifyLayers {
         case LayerEntry.NoKey(_) =>
           fail("Should have been a tagged layer entry")
 
@@ -174,6 +174,18 @@ class SceneUpdateFragmentTests extends munit.FunSuite {
       actual.layers.map(_.giveKey.get).toList,
       List(LayerKey("key A?"), LayerKey("key B?"))
     )
+    assertEquals(actual.layers.flatMap(_.toBatch).map(_.magnification.get).toList, List(2, 2))
+  }
+
+  test("Setting the magnification for all layers") {
+    val scene =
+      SceneUpdateFragment.empty
+        .addLayer(LayerKey("key A") -> Layer.empty.withMagnification(1))
+        .addLayer(LayerKey("key B") -> Layer.empty.withMagnification(1))
+
+    val actual =
+      scene.withMagnification(2)
+
     assertEquals(actual.layers.flatMap(_.toBatch).map(_.magnification.get).toList, List(2, 2))
   }
 


### PR DESCRIPTION
My only concern with this approach is the possibility of infinite loops,i.e. `Layer(..).modify(_.modify(...))`... but maybe people will just have to be sensible and unit test things?