### PR TITLE
Fixed #843: Allow Indigo to be elegantly halted

### DIFF
--- a/indigo/indigo/src/main/scala/indigo/GameLauncher.scala
+++ b/indigo/indigo/src/main/scala/indigo/GameLauncher.scala
@@ -21,11 +21,9 @@ trait GameLauncher[StartUpData, Model, ViewModel]:
       case None =>
         throw new Exception(s"Missing Element! Could not find an element with id '$containerId' on the page.")
 
-  @SuppressWarnings(Array("scalafix:DisableSyntax.null"))
   @JSExport
   def halt(): Unit =
     game.kill()
-    game = null
     ()
 
   @JSExport

--- a/indigo/indigo/src/main/scala/indigo/gameengine/GameEngine.scala
+++ b/indigo/indigo/src/main/scala/indigo/gameengine/GameEngine.scala
@@ -85,29 +85,17 @@ final class GameEngine[StartUpData, GameModel, ViewModel](
   @SuppressWarnings(Array("scalafix:DisableSyntax.var", "scalafix:DisableSyntax.null"))
   var platform: Platform = null
 
-  @SuppressWarnings(Array("scalafix:DisableSyntax.null"))
   def kill(): Unit =
     platform.kill()
     gameLoopInstance.kill()
     animationsRegister.kill()
     fontRegister.kill()
     shaderRegister.kill()
-    shaderRegister.kill()
     boundaryLocator.purgeCache()
     sceneProcessor.purgeCaches()
     audioPlayer.kill()
     globalEventStream.kill()
 
-    gameConfig = null
-    storage = null
-    globalEventStream = null
-    gamepadInputCapture = null
-    gameLoopInstance = null
-    accumulatedAssetCollection = null
-    assetMapping = null
-    renderer = null
-    startUpData = null.asInstanceOf[StartUpData]
-    platform = null
     ()
 
   @SuppressWarnings(Array("scalafix:DisableSyntax.null"))

--- a/indigo/indigo/src/main/scala/indigo/gameengine/GameLoop.scala
+++ b/indigo/indigo/src/main/scala/indigo/gameengine/GameLoop.scala
@@ -95,13 +95,8 @@ final class GameLoop[StartUpData, GameModel, ViewModel](
             gameEngine.platform.tick(gameEngine.gameLoop(t))
           else gameEngine.platform.tick(loop(lastUpdateTime))
 
-  @SuppressWarnings(Array("scalafix:DisableSyntax.null"))
   def kill(): Unit =
     _running = false
-    _gameModelState = null.asInstanceOf[GameModel]
-    _viewModelState = null.asInstanceOf[ViewModel]
-    _runningTimeReference = 0
-    _inputState = null
     ()
 
   def loop(lastUpdateTime: Double): Double => Unit = { time =>

--- a/indigo/indigo/src/main/scala/indigo/platform/audio/AudioPlayer.scala
+++ b/indigo/indigo/src/main/scala/indigo/platform/audio/AudioPlayer.scala
@@ -208,12 +208,9 @@ final class AudioPlayer(context: AudioContextProxy):
   private def needsVolumeChange(playing: AudioSourceState, next: SceneAudioSource): Boolean =
     playing.bindingKey == next.bindingKey && !(playing.volume ~== next.volume)
 
-  @SuppressWarnings(Array("scalafix:DisableSyntax.null"))
   def kill(): Unit =
     soundAssets = Set()
-    sourceA = null
-    sourceB = null
-    sourceC = null
+    playAudio(None)
     ()
 
   private class AudioSourceState(val bindingKey: BindingKey, val volume: Volume, val audioNodes: AudioNodes)

--- a/indigo/tyrian-sandbox/tyrianapp.js
+++ b/indigo/tyrian-sandbox/tyrianapp.js
@@ -1,5 +1,5 @@
 import {
   TyrianApp
-} from './target/scala-3.4.1/tyrian-sandbox-fastopt/main.js';
+} from './target/scala-3.6.2/tyrian-sandbox-fastopt/main.js';
 
 TyrianApp.launch("myapp");


### PR DESCRIPTION
Relates to https://github.com/PurpleKingdomGames/indigo/issues/843

Below is a demo of the tyrian / indigo sandbox halting and removing two games. You can see that no null pointer exceptions are now thrown in the logs, and after a waiting a moment, the memory usage plunges once the GC kicks in.

Essentially all I've done is removed all the nulling out of internal service instances, which means that halting now clears some memory by purging all the caches, but the instance is still present until the SPA (in this case a Tyrian app, but whatever) removes the instance and it's canvas element. After that, all remaining memory is cleaned up.

https://github.com/user-attachments/assets/15b317ce-1d78-43a1-894e-9ca6460a501d

(cc @mprevel)