### PR TITLE
Fixed #858: Allow asset renaming during generation

### DIFF
--- a/indigo-plugin/indigo-plugin/src/indigoplugin/IndigoAssets.scala
+++ b/indigo-plugin/indigo-plugin/src/indigoplugin/IndigoAssets.scala
@@ -12,7 +12,7 @@ final case class IndigoAssets(
     gameAssetsDirectory: os.RelPath,
     include: os.RelPath => Boolean,
     exclude: os.RelPath => Boolean,
-    rename: Option[(String, String) => String]
+    rename: PartialFunction[(String, String), String]
 ) {
 
   val workspaceDir = Utils.findWorkspace
@@ -49,8 +49,8 @@ final case class IndigoAssets(
     * @param f
     *   Function that takes a tuple of Strings, file name and extension, and returns a new 'safe for Scala' name.
     */
-  def withRenameFunction(f: (String, String) => String): IndigoAssets =
-    this.copy(rename = Option(f))
+  def withRenameFunction(f: PartialFunction[(String, String), String]): IndigoAssets =
+    this.copy(rename = f)
 
   /** Decides if a relative path will be included in the assets or not. */
   def isCopyAllowed(rel: os.RelPath): Boolean =
@@ -85,10 +85,19 @@ final case class IndigoAssets(
 
 object IndigoAssets {
 
+  val noRename: PartialFunction[(String, String), String] = { case (name, _) =>
+    name
+  }
+
   /** Default settings for an Indigo game's asset management */
   val defaults: IndigoAssets = {
     val pf: PartialFunction[os.RelPath, Boolean] = { case _ => false }
 
-    IndigoAssets(gameAssetsDirectory = os.RelPath("assets"), pf, pf, None)
+    IndigoAssets(
+      gameAssetsDirectory = os.RelPath("assets"),
+      pf,
+      pf,
+      noRename
+    )
   }
 }

--- a/indigo-plugin/indigo-plugin/src/indigoplugin/IndigoOptions.scala
+++ b/indigo-plugin/indigo-plugin/src/indigoplugin/IndigoOptions.scala
@@ -96,6 +96,17 @@ final case class IndigoOptions(
   def excludeAssets(rules: os.RelPath => Boolean): IndigoOptions =
     this.copy(assets = assets.withExclude(rules))
 
+  /** Provide a custom asset renaming function (arguments are (name, ext) => new name) used during asset listing
+    * generation to rename assets. The purpose is to avoid name clashes in the generated code where you have two
+    * similarly named items that would normally result in identical names, e.g. character.png and character.json.
+    * Original file names will not be affected.
+    *
+    * Assets names are processed by this function before being 'made safe' by the usual process. So be aware that you
+    * may still not get the exact name you mapped to.
+    */
+  def renameAssets(f: PartialFunction[(String, String), String]): IndigoOptions =
+    this.copy(assets = assets.withRenameFunction(f))
+
   /** Set the window start width */
   def withWindowWidth(value: Int): IndigoOptions =
     this.copy(metadata = metadata.withWindowWidth(value))

--- a/indigo-plugin/indigo-plugin/test/src/indigoplugin/core/AcceptanceTests.scala
+++ b/indigo-plugin/indigo-plugin/test/src/indigoplugin/core/AcceptanceTests.scala
@@ -42,7 +42,7 @@ class AcceptanceTests extends munit.FunSuite {
         case p if p.endsWith(os.RelPath("colours.txt"))      => true
         case _                                               => false
       },
-      None
+      IndigoAssets.noRename
     )
 
   val indigoOptions =

--- a/indigo-plugin/indigo-plugin/test/src/indigoplugin/core/IndigoBuildTests.scala
+++ b/indigo-plugin/indigo-plugin/test/src/indigoplugin/core/IndigoBuildTests.scala
@@ -10,7 +10,7 @@ class IndigoBuildTests extends munit.FunSuite {
     val toCopy: os.RelPath             = os.RelPath("some/path/foo.txt")
     val include: os.RelPath => Boolean = _ => false
     val exclude: os.RelPath => Boolean = _ => false
-    val indigoAssets: IndigoAssets     = IndigoAssets(base, include, exclude, None)
+    val indigoAssets: IndigoAssets     = IndigoAssets(base, include, exclude, IndigoAssets.noRename)
 
     val actual = indigoAssets.isCopyAllowed(toCopy)
 
@@ -23,7 +23,7 @@ class IndigoBuildTests extends munit.FunSuite {
     val toCopy: os.RelPath             = os.RelPath("some/path/foo.txt")
     val include: os.RelPath => Boolean = _ => false
     val exclude: os.RelPath => Boolean = _ == os.RelPath("path/foo.txt")
-    val indigoAssets: IndigoAssets     = IndigoAssets(base, include, exclude, None)
+    val indigoAssets: IndigoAssets     = IndigoAssets(base, include, exclude, IndigoAssets.noRename)
 
     val actual = indigoAssets.isCopyAllowed(toCopy)
 
@@ -36,7 +36,7 @@ class IndigoBuildTests extends munit.FunSuite {
     val toCopy: os.RelPath             = os.RelPath("some/path/foo.txt")
     val include: os.RelPath => Boolean = _ == os.RelPath("path/foo.txt")
     val exclude: os.RelPath => Boolean = _ => false
-    val indigoAssets: IndigoAssets     = IndigoAssets(base, include, exclude, None)
+    val indigoAssets: IndigoAssets     = IndigoAssets(base, include, exclude, IndigoAssets.noRename)
 
     val actual = indigoAssets.isCopyAllowed(toCopy)
 
@@ -49,7 +49,7 @@ class IndigoBuildTests extends munit.FunSuite {
     val toCopy: os.RelPath             = os.RelPath("some/path/foo.txt")
     val include: os.RelPath => Boolean = _ == os.RelPath("path/foo.txt")
     val exclude: os.RelPath => Boolean = _ == os.RelPath("path")
-    val indigoAssets: IndigoAssets     = IndigoAssets(base, include, exclude, None)
+    val indigoAssets: IndigoAssets     = IndigoAssets(base, include, exclude, IndigoAssets.noRename)
 
     val actual = indigoAssets.isCopyAllowed(toCopy)
 

--- a/indigo-plugin/indigo-plugin/test/src/indigoplugin/generators/AssetListingTests.scala
+++ b/indigo-plugin/indigo-plugin/test/src/indigoplugin/generators/AssetListingTests.scala
@@ -3,7 +3,7 @@ package indigoplugin.generators
 class AssetListingTests extends munit.FunSuite {
 
   test("should be able to convert file and folder names into something safe (using default)") {
-    def toSafeName(name: String) = AssetListing.toDefaultSafeName(name, "")
+    def toSafeName(name: String) = AssetListing.toDefaultSafeName((n, _) => n)(name, "")
 
     assertEquals(toSafeName("hello"), "hello")
     assertEquals(toSafeName("hello-there-01"), "helloThere01")
@@ -21,7 +21,7 @@ class AssetListingTests extends munit.FunSuite {
       )
 
     val actual =
-      AssetListing.renderContent(paths, AssetListing.toDefaultSafeName)
+      AssetListing.renderContent(paths, AssetListing.toDefaultSafeName((n, _) => n))
 
     val expected =
       """
@@ -72,8 +72,13 @@ class AssetListingTests extends munit.FunSuite {
         os.RelPath.rel / "assets" / "folderA" / "e.svg"
       )
 
+    val rename: (String, String) => String = {
+      case ("e", "svg") => "ee"
+      case (n, _)       => n
+    }
+
     val actual =
-      AssetListing.renderContent(paths, AssetListing.toDefaultSafeName)
+      AssetListing.renderContent(paths, AssetListing.toDefaultSafeName(rename))
 
     val expected =
       """
@@ -102,18 +107,18 @@ class AssetListingTests extends munit.FunSuite {
             d
           )
 
-      val e: AssetName               = AssetName("e.svg")
-      val eMaterial: Material.Bitmap = Material.Bitmap(e)
+      val ee: AssetName               = AssetName("e.svg")
+      val eeMaterial: Material.Bitmap = Material.Bitmap(ee)
 
       def assetSet(baseUrl: String): Set[AssetType] =
         Set(
-          AssetType.Image(e, AssetPath(baseUrl + "assets/folderA/e.svg"), Option(AssetTag("folderA")))
+          AssetType.Image(ee, AssetPath(baseUrl + "assets/folderA/e.svg"), Option(AssetTag("folderA")))
         )
       def assetSet: Set[AssetType] = assetSet("./")
 
       def assetNameSet: Set[AssetName] =
         Set(
-          e
+          ee
         )
 
     object folderC:


### PR DESCRIPTION
Allows you to rename assets during the listing generator to avoid name clashes.