### PR TITLE
Fixed #900: Viewport info in Context

### DIFF
--- a/indigo/indigo/src/main/scala/indigo/gameengine/GameLoop.scala
+++ b/indigo/indigo/src/main/scala/indigo/gameengine/GameLoop.scala
@@ -8,6 +8,7 @@ import indigo.shared.IndigoLogger
 import indigo.shared.Outcome
 import indigo.shared.collections.Batch
 import indigo.shared.config.GameConfig
+import indigo.shared.config.GameViewport
 import indigo.shared.dice.Dice
 import indigo.shared.events.FrameTick
 import indigo.shared.events.GlobalEvent
@@ -126,7 +127,13 @@ final class GameLoop[StartUpData, GameModel, ViewModel](
     val context =
       new Context[StartUpData](
         gameEngine.startUpData,
-        Context.Frame(Dice.fromSeconds(gameTime.running), gameTime, _inputState),
+        Context.Frame(
+          Dice.fromSeconds(gameTime.running),
+          gameTime,
+          _inputState,
+          GameViewport(renderer.screenWidth, renderer.screenHeight),
+          gameConfig.magnification
+        ),
         _services
       )
 

--- a/indigo/indigo/src/main/scala/indigo/shared/Context.scala
+++ b/indigo/indigo/src/main/scala/indigo/shared/Context.scala
@@ -4,7 +4,9 @@ import indigo.FontKey
 import indigo.platform.renderer.ScreenCaptureConfig
 import indigo.shared.assets.AssetType
 import indigo.shared.collections.Batch
+import indigo.shared.config.GameViewport
 import indigo.shared.datatypes.Rectangle
+import indigo.shared.datatypes.Size
 import indigo.shared.dice.Dice
 import indigo.shared.events.InputState
 import indigo.shared.scenegraph.SceneNode
@@ -64,6 +66,8 @@ object Context:
       gameTime: GameTime,
       dice: Dice,
       inputState: InputState,
+      viewport: GameViewport,
+      globalMagnification: Int,
       boundaryLocator: BoundaryLocator,
       startUpData: StartUpData,
       _captureScreen: Batch[ScreenCaptureConfig] => Batch[Either[String, AssetType.Image]]
@@ -73,7 +77,9 @@ object Context:
       Frame(
         dice,
         gameTime,
-        inputState
+        inputState,
+        viewport,
+        globalMagnification
       ),
       Services(
         boundaryLocator,
@@ -87,23 +93,31 @@ object Context:
   final class Frame(
       val dice: Dice,
       val time: GameTime,
-      val input: InputState
+      val input: InputState,
+      val viewport: GameViewport,
+      val globalMagnification: Int
   ):
     def withDice(newDice: Dice): Frame =
-      new Frame(newDice, time, input)
+      new Frame(newDice, time, input, viewport, globalMagnification)
 
     def withTime(newTime: GameTime): Frame =
-      new Frame(dice, newTime, input)
+      new Frame(dice, newTime, input, viewport, globalMagnification)
 
     def withInput(newInput: InputState): Frame =
-      new Frame(dice, time, newInput)
+      new Frame(dice, time, newInput, viewport, globalMagnification)
+
+    def withViewport(newViewport: GameViewport): Frame =
+      new Frame(dice, time, input, newViewport, globalMagnification)
+
+    def withGlobalMagnification(newGlobalMagnification: Int): Frame =
+      new Frame(dice, time, input, viewport, newGlobalMagnification)
 
   object Frame:
-    def apply(dice: Dice, time: GameTime, input: InputState): Frame =
-      new Frame(dice, time, input)
+    def apply(dice: Dice, time: GameTime, input: InputState, viewport: GameViewport, globalMagnification: Int): Frame =
+      new Frame(dice, time, input, viewport, globalMagnification)
 
     val initial: Frame =
-      new Frame(Dice.default, GameTime.zero, InputState.default)
+      new Frame(Dice.default, GameTime.zero, InputState.default, GameViewport(Size.zero), 1)
 
   /** The services that are available to the game, such as the ability to capture the screen, measure text, find the
     * bounds of anything on screen, or access a long running Random instance. Services are side-effecting, long running,

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/SandboxGame.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/SandboxGame.scala
@@ -22,7 +22,7 @@ object SandboxGame extends IndigoGame[SandboxBootData, SandboxStartupData, Sandb
   val viewportHeight: Int     = gameHeight * magnificationLevel // 256
 
   def initialScene(bootData: SandboxBootData): Option[SceneName] =
-    Some(PerformerPhysicsScene.name)
+    Some(ViewportResizeScene.name)
 
   def scenes(bootData: SandboxBootData): NonEmptyList[Scene[SandboxStartupData, SandboxGameModel, SandboxViewModel]] =
     NonEmptyList(
@@ -59,7 +59,8 @@ object SandboxGame extends IndigoGame[SandboxBootData, SandboxStartupData, Sandb
       ActorPoolScene,
       ActorPoolPhysicsScene,
       PerformerScene,
-      PerformerPhysicsScene
+      PerformerPhysicsScene,
+      ViewportResizeScene
     )
 
   val eventFilters: EventFilters = EventFilters.Permissive

--- a/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/ViewportResizeScene.scala
+++ b/indigo/sandbox/src/main/scala/com/example/sandbox/scenes/ViewportResizeScene.scala
@@ -1,0 +1,60 @@
+package com.example.sandbox.scenes
+
+import com.example.sandbox.SandboxAssets
+import com.example.sandbox.SandboxGameModel
+import com.example.sandbox.SandboxStartupData
+import com.example.sandbox.SandboxViewModel
+import indigo.*
+import indigo.scenes.*
+
+object ViewportResizeScene extends Scene[SandboxStartupData, SandboxGameModel, SandboxViewModel] {
+
+  type SceneModel     = SandboxGameModel
+  type SceneViewModel = SandboxViewModel
+
+  def eventFilters: EventFilters =
+    EventFilters.Restricted
+
+  def modelLens: Lens[SandboxGameModel, SandboxGameModel] =
+    Lens.keepOriginal
+
+  def viewModelLens: Lens[SandboxViewModel, SandboxViewModel] =
+    Lens.keepOriginal
+
+  def name: SceneName =
+    SceneName("viewport resize scene")
+
+  def subSystems: Set[SubSystem[SandboxGameModel]] =
+    Set()
+
+  def updateModel(
+      context: SceneContext[SandboxStartupData],
+      model: SandboxGameModel
+  ): GlobalEvent => Outcome[SandboxGameModel] =
+    _ => Outcome(model)
+
+  def updateViewModel(
+      context: SceneContext[SandboxStartupData],
+      model: SandboxGameModel,
+      viewModel: SandboxViewModel
+  ): GlobalEvent => Outcome[SandboxViewModel] =
+    _ => Outcome(viewModel)
+
+  def present(
+      context: SceneContext[SandboxStartupData],
+      model: SandboxGameModel,
+      viewModel: SandboxViewModel
+  ): Outcome[SceneUpdateFragment] =
+    Outcome(
+      SceneUpdateFragment.empty
+        .addLayers(
+          Layer(
+            Graphic(
+              context.frame.viewport.giveDimensions(context.frame.globalMagnification).size,
+              Material.Bitmap(SandboxAssets.nineSlice).nineSlice(Rectangle(16, 16, 32, 32))
+            )
+          )
+        )
+    )
+
+}


### PR DESCRIPTION
It's only taken me all these years to think of doing this...

You can now access the viewport size (does not factor in magnification), i.e. canvas size / screen size, in the `Context` object using `context.frame.viewport`. For bonus points, you also get the global magnification value.

No more listening to `ViewportResize` unless you really want to!

Video attached, I'm not using any debounce here so it looks stuttery, but.. 🤷 😄 


https://github.com/user-attachments/assets/ce7bc398-91ec-482d-8155-44069b09bfb3
