### PR TITLE
Added tests and fixed bugs around duplicates messages in performers

### DIFF
--- a/indigo/indigo-extras/src/test/scala/indigoextras/actors/ActorPoolTests.scala
+++ b/indigo/indigo-extras/src/test/scala/indigoextras/actors/ActorPoolTests.scala
@@ -1,0 +1,81 @@
+package indigoextras.actors
+
+import indigo.*
+
+class ActorPoolTests extends munit.FunSuite {
+
+  test("ActorPool should be created with an empty list of actors") {
+    val actorPool = ActorPool.empty[Unit, String]
+
+    assertEquals(actorPool.toBatch.length, 0)
+  }
+
+  test("spawn") {
+    val actorPool = ActorPool.empty[Unit, String]
+    val newActors = Batch("Actor1", "Actor2", "Actor3")
+
+    val updatedPool = actorPool.spawn(newActors)
+
+    assertEquals(updatedPool.toBatch, newActors)
+  }
+
+  test("find") {
+    val actorPool = ActorPool.empty[Unit, String].spawn("Actor1", "Actor2", "Actor3")
+
+    val foundActor = actorPool.find(_ == "Actor2")
+
+    assertEquals(foundActor, Some("Actor2"))
+  }
+  test("filter") {
+    val actorPool = ActorPool.empty[Unit, String].spawn("Actor1", "Actor2", "Actor3")
+
+    val filteredActors = actorPool.filter(_ == "Actor2")
+
+    assertEquals(filteredActors, Batch("Actor2"))
+  }
+
+  test("filterNot") {
+    val actorPool = ActorPool.empty[Unit, String].spawn("Actor1", "Actor2", "Actor3")
+
+    val filteredActors = actorPool.filterNot(_ == "Actor2")
+
+    assertEquals(filteredActors, Batch("Actor1", "Actor3"))
+  }
+
+  test("kill") {
+    val actorPool = ActorPool.empty[Unit, String].spawn("Actor1", "Actor2", "Actor3")
+
+    val updatedPool = actorPool.kill(_ == "Actor2")
+
+    assertEquals(updatedPool.toBatch, Batch("Actor1", "Actor3"))
+  }
+
+  test("update") {
+    val actorPool = ActorPool.empty[Unit, String].spawn("Actor1", "Actor2", "Actor3")
+
+    val ctx: Context[Unit] =
+      Context.initial
+
+    val updatedPool = actorPool.update(ctx, ())(FrameTick)
+
+    assertEquals(updatedPool.unsafeGet.toBatch, Batch("Actor1!", "Actor2!", "Actor3!"))
+  }
+
+  test("present") {
+    val actorPool = ActorPool.empty[Unit, String].spawn("Actor1", "Actor2", "Actor3")
+
+    val ctx: Context[Unit] =
+      Context.initial
+
+    val presented = actorPool.present(ctx, ())
+
+    assertEquals(presented.unsafeGet.length, 3)
+  }
+
+  given Actor[Unit, String] with
+    def update(context: ActorContext[Unit, String], actor: String): GlobalEvent => Outcome[String] =
+      _ => Outcome(actor + "!")
+
+    def present(context: ActorContext[Unit, String], actor: String): Outcome[Batch[SceneNode]] =
+      Outcome(Batch(Text(actor, FontKey("test"), Material.Bitmap(AssetName("test")))))
+}

--- a/indigo/indigo-extras/src/test/scala/indigoextras/performers/StageManagerTests.scala
+++ b/indigo/indigo-extras/src/test/scala/indigoextras/performers/StageManagerTests.scala
@@ -1,0 +1,148 @@
+package indigoextras.performers
+
+import indigo.*
+
+class StageManagerTests extends munit.FunSuite {
+
+  val layerKey: LayerKey = LayerKey("testLayer")
+  val ctx                = SubSystemContext.fromContext(Context.initial)
+  val text               = Text("", FontKey("test"), Material.Bitmap(AssetName("test")))
+
+  test("StageManager add and present") {
+    val model        = StageManager.Model[Unit](WorldOptions.default)
+    val stageManager = StageManager[Unit](SubSystemId("test"))
+
+    val updatedModel = stageManager.update(ctx, model)(PerformerEvent.Add(layerKey, TestPerformer("a", "This is 'a'")))
+    val presented    = stageManager.present(ctx, updatedModel.unsafeGet)
+
+    val expected =
+      Batch(
+        LayerEntry(layerKey, Layer.Content(Batch(text.withText("This is 'a'"))))
+      )
+
+    assertEquals(presented.unsafeGet.layers, expected)
+  }
+
+  test("StageManager add and present, no duplicates with the same id") {
+    val model        = StageManager.Model[Unit](WorldOptions.default)
+    val stageManager = StageManager[Unit](SubSystemId("test"))
+
+    val actual =
+      for {
+        a <- stageManager.update(ctx, model)(PerformerEvent.Add(layerKey, TestPerformer("a", "This is 'a'")))
+        b <- stageManager.update(ctx, a)(PerformerEvent.Add(layerKey, TestPerformer("a", "This is 'a'")))
+        p <- stageManager.present(ctx, b)
+      } yield p
+
+    val expected =
+      Batch(
+        LayerEntry(layerKey, Layer.Content(Batch(text.withText("This is 'a'"))))
+      )
+
+    assertEquals(actual.unsafeGet.layers, expected)
+  }
+
+  test("StageManager does not present empty layers") {
+    val model        = StageManager.Model[Unit](WorldOptions.default)
+    val stageManager = StageManager[Unit](SubSystemId("test"))
+
+    val actual =
+      for {
+        a <- stageManager.update(ctx, model)(PerformerEvent.Add(layerKey, TestPerformer("a", "This is 'a'")))
+        b <- stageManager.update(ctx, a)(
+          PerformerEvent.Add(LayerKey("another layer"), TestPerformer("b", "This is 'b'"))
+        )
+        r <- stageManager.update(ctx, b)(PerformerEvent.Remove(PerformerId("a")))
+        p <- stageManager.present(ctx, r)
+      } yield p
+
+    val expected =
+      Batch(
+        LayerEntry(LayerKey("another layer"), Layer.Content(Batch(text.withText("This is 'b'"))))
+      )
+
+    assertEquals(actual.unsafeGet.layers, expected)
+  }
+
+  test("StageManager add, remove, and present") {
+    val model        = StageManager.Model[Unit](WorldOptions.default)
+    val stageManager = StageManager[Unit](SubSystemId("test"))
+
+    val updatedModelAdded =
+      stageManager.update(ctx, model)(PerformerEvent.Add(layerKey, TestPerformer("a", "This is 'a'")))
+    val updatedModelRemoved =
+      stageManager.update(ctx, updatedModelAdded.unsafeGet)(PerformerEvent.Remove(PerformerId("a")))
+    val presented = stageManager.present(ctx, updatedModelRemoved.unsafeGet)
+
+    val expected =
+      Batch.empty
+
+    assertEquals(presented.unsafeGet.layers, expected)
+  }
+
+  test("StageManager, a support performer can remove itself") {
+    val model        = StageManager.Model[Unit](WorldOptions.default)
+    val stageManager = StageManager[Unit](SubSystemId("test"))
+
+    val updatedModel: Outcome[StageManager.Model[Unit]] =
+      for {
+        added <- stageManager.update(ctx, model)(PerformerEvent.Add(layerKey, TestSupportPerformer("a", "This is 'a'")))
+        tick  <- stageManager.update(ctx, added)(FrameTick)
+      } yield tick
+
+    val events = updatedModel.globalEventsOrNil
+
+    assert(events.length == 1)
+    assertEquals(events, Batch(PerformerEvent.Remove(PerformerId("a"))))
+
+    // Just to show it really was there.
+    val presentBeforeRemoved = stageManager.present(ctx, updatedModel.unsafeGet)
+
+    val expectedBeforeRemoved =
+      Batch(
+        LayerEntry(layerKey, Layer.Content(Batch(text.withText("This is 'a'!"))))
+      )
+
+    assertEquals(presentBeforeRemoved.unsafeGet.layers, expectedBeforeRemoved)
+
+    val updatedModelRemoved =
+      updatedModel.flatMap { m =>
+        stageManager.update(ctx, m)(events.head)
+      }
+
+    val presented = stageManager.present(ctx, updatedModelRemoved.unsafeGet)
+
+    val expected =
+      Batch.empty
+
+    assertEquals(presented.unsafeGet.layers, expected)
+  }
+
+  final case class TestPerformer(_id: String, value: String) extends Performer.Extra[Unit]:
+    val id: PerformerId       = PerformerId(_id)
+    val depth: PerformerDepth = PerformerDepth(0)
+
+    def update(context: PerformerContext[Unit]): Performer.Extra[Unit] =
+      this.copy(value = value + "!")
+
+    def present(context: PerformerContext[Unit]): Batch[SceneNode] =
+      Batch(text.withText(value))
+
+  final case class TestSupportPerformer(_id: String, value: String) extends Performer.Support[Unit]:
+    val id: PerformerId       = PerformerId(_id)
+    val depth: PerformerDepth = PerformerDepth(0)
+
+    def update(context: PerformerContext[Unit]): GlobalEvent => Outcome[Performer.Support[Unit]] =
+      case FrameTick =>
+        Outcome(this.copy(value = value + "!"))
+          .addGlobalEvents(
+            PerformerEvent.Remove(id)
+          )
+
+      case _ =>
+        Outcome(this)
+
+    def present(context: PerformerContext[Unit]): Outcome[Batch[SceneNode]] =
+      Outcome(Batch(text.withText(value)))
+
+}


### PR DESCRIPTION
Mea culpa.

Found issues while sorting out the docs for performers (and Actors, but Actors are fine).

I should have written ...ya know ...some unit tests. The manual test cases / examples that I did set up, did not show the issues.

The problems stem from the fact that PerformerPools are based on ActorPools which do not have the concept of ids, nor are they wired into the physics code, and they don't use events.

