### PR TITLE
Added module name in generator to ensure unique CharBatch object name

### DIFF
--- a/indigo-plugin/indigo-plugin/src/indigoplugin/generators/FontGen.scala
+++ b/indigo-plugin/indigo-plugin/src/indigoplugin/generators/FontGen.scala
@@ -241,7 +241,7 @@ object FontGen {
           .mkString("\n")
           .dropRight(1) // Drops the last ','
         // language=scala
-        s"""private object CharBatch$index {
+        s"""private object ${moduleName}CharBatch$index {
            |  val batch = Batch(
            |${chars}
            |  )
@@ -250,7 +250,7 @@ object FontGen {
       }
       .mkString("\n")
     val charBatchAdditions = (0 until (chars.length / CharBatchSize) + 1)
-      .map(index => s"      .addChars(CharBatch${index}.batch)")
+      .map(index => s"      .addChars(${moduleName}CharBatch${index}.batch)")
       .mkString("\n")
 
     val dx = default.x.toString


### PR DESCRIPTION
Previously generators were failing when more than one font was added due to the CharBatch object clashing across multiple fonts due to a non-unique name. All were being created in the "fullyQualifiedPackage" package.

Added module name before generated CharBatch object to ensure unique object name. This would result in ModuleNameCharBatch0, rather than CharBatch0.

This shouldn't impact any imports.