### PR TITLE
Cross-builds indigo-plugin module for Scala 3

### DIFF
--- a/indigo-plugin/build.ps1
+++ b/indigo-plugin/build.ps1
@@ -8,11 +8,16 @@ Remove-Item -Recurse -Force -Path .\out
 RunMill -i clean
 RunMill -i clean indigo-plugin[2.12]
 RunMill -i clean indigo-plugin[2.13]
+RunMill -i clean indigo-plugin[3]
 RunMill -i indigo-plugin[2.12].compile
 RunMill -i indigo-plugin[2.13].compile
+RunMill -i indigo-plugin[3].compile
 RunMill -i indigo-plugin[2.12].test
 RunMill -i indigo-plugin[2.13].test
+RunMill -i indigo-plugin[3].test
 RunMill -i indigo-plugin[2.12].checkFormat
 RunMill -i indigo-plugin[2.13].checkFormat
+RunMill -i indigo-plugin[3].checkFormat
 RunMill -i indigo-plugin[2.12].publishLocal
 RunMill -i indigo-plugin[2.13].publishLocal
+RunMill -i indigo-plugin[3].publishLocal

--- a/indigo-plugin/build.sc
+++ b/indigo-plugin/build.sc
@@ -9,7 +9,7 @@ import mill.scalalib.scalafmt._
 import coursier.maven.MavenRepository
 import publish._
 
-object `indigo-plugin` extends Cross[IndigoPluginModule]("2.12", "2.13")
+object `indigo-plugin` extends Cross[IndigoPluginModule]("2.12", "2.13", "3")
 
 trait IndigoPluginModule extends CrossScalaModule with PublishModule with ScalafmtModule {
 
@@ -19,6 +19,7 @@ trait IndigoPluginModule extends CrossScalaModule with PublishModule with Scalaf
     crossScalaVersion match {
       case "2.12" => "2.12.20"
       case "2.13" => "2.13.16"
+      case "3"    => "3.7.1"
       case _      => "2.13.16"
     }
 

--- a/indigo-plugin/build.sh
+++ b/indigo-plugin/build.sh
@@ -7,11 +7,16 @@ rm -fr out/
 ./mill clean
 ./mill clean indigo-plugin[2.12]
 ./mill clean indigo-plugin[2.13]
+./mill clean indigo-plugin[3]
 ./mill indigo-plugin[2.12].compile
 ./mill indigo-plugin[2.13].compile
+./mill indigo-plugin[3].compile
 ./mill indigo-plugin[2.12].test
 ./mill indigo-plugin[2.13].test
+./mill indigo-plugin[3].test
 ./mill indigo-plugin[2.12].checkFormat
 ./mill indigo-plugin[2.13].checkFormat
+./mill indigo-plugin[3].checkFormat
 ./mill indigo-plugin[2.12].publishLocal
 ./mill indigo-plugin[2.13].publishLocal
+./mill indigo-plugin[3].publishLocal

--- a/indigo-plugin/indigo-plugin/src/indigoplugin/core/IndigoRun.scala
+++ b/indigo-plugin/indigo-plugin/src/indigoplugin/core/IndigoRun.scala
@@ -41,7 +41,7 @@ object IndigoRun {
     println(s"Starting '${indigoOptions.metadata.title}'")
 
     sys.props("os.name").toLowerCase match {
-      case x if x contains "windows" =>
+      case x if x.contains("windows") =>
         indigoOptions.electron.electronInstall match {
           case ElectronInstall.Global =>
             IndigoProc.Windows.npmStart(outputDir)

--- a/indigo-plugin/indigo-plugin/src/indigoplugin/generators/AssetListing.scala
+++ b/indigo-plugin/indigo-plugin/src/indigoplugin/generators/AssetListing.scala
@@ -44,8 +44,10 @@ object AssetListing {
     Seq(file)
   }
 
-  def renderContent(paths: List[os.RelPath], toSafeName: (String, String) => String): String =
-    (convertPathsToTree _ andThen renderTree(0, toSafeName))(paths)
+  def renderContent(paths: List[os.RelPath], toSafeName: (String, String) => String): String = {
+    val pathTree = convertPathsToTree(paths)
+    renderTree(0, toSafeName)(pathTree)
+  }
 
   def convertPathsToTree(paths: List[os.RelPath]): PathTree =
     PathTree

--- a/indigo-plugin/indigo-plugin/src/indigoplugin/generators/EmbedData.scala
+++ b/indigo-plugin/indigo-plugin/src/indigoplugin/generators/EmbedData.scala
@@ -171,14 +171,14 @@ final case class DataFrame(data: Array[Array[DataType]], columnCount: Int) {
     )
   }
 
-  def toSafeName: String => String = { name: String =>
+  def toSafeName: String => String = { (name: String) =>
     name.replaceAll("[^a-zA-Z0-9]", "-").split("-").toList.filterNot(_.isEmpty) match {
       case h :: t if h.take(1).matches("[0-9]") => ("_" :: h :: t.map(_.capitalize)).mkString
       case l                                    => l.map(_.capitalize).mkString
     }
   }
 
-  def toSafeNameCamel: String => String = { name: String =>
+  def toSafeNameCamel: String => String = { (name: String) =>
     name.replaceAll("[^a-zA-Z0-9]", "-").split("-").toList.filterNot(_.isEmpty) match {
       case h :: t if h.take(1).matches("[0-9]") => ("_" :: h :: t.map(_.capitalize)).mkString
       case h :: t                               => (h.toLowerCase :: t.map(_.capitalize)).mkString

--- a/indigo-plugin/release.sh
+++ b/indigo-plugin/release.sh
@@ -11,16 +11,20 @@ rm -fr out/
 ./mill clean
 ./mill clean indigo-plugin[2.12]
 ./mill clean indigo-plugin[2.13]
+./mill clean indigo-plugin[3]
 
 ./mill indigo-plugin[2.12].compile
 ./mill indigo-plugin[2.13].compile
+./mill indigo-plugin[3].compile
 
 ./mill indigo-plugin[2.12].test
 ./mill indigo-plugin[2.13].test
+./mill indigo-plugin[3].test
 
 # Build all artifacts
 ./mill indigo-plugin[2.12].publishArtifacts
 ./mill indigo-plugin[2.13].publishArtifacts
+./mill indigo-plugin[3].publishArtifacts
 
 # Publish all artifacts
 ./mill -i \
@@ -40,6 +44,18 @@ rm -fr out/
     --sonatypeCreds "$SONATYPE_USERNAME":"$SONATYPE_PASSWORD" \
     --gpgArgs --passphrase="$PGP_PASSPHRASE",--no-tty,--pinentry-mode,loopback,--batch,--yes,-a,-b \
     --publishArtifacts indigo-plugin[2.13].publishArtifacts \
+    --readTimeout  3600000 \
+    --awaitTimeout 3600000 \
+    --release true \
+    --signed  true \
+    --sonatypeUri https://oss.sonatype.org/service/local \
+    --sonatypeSnapshotUri https://oss.sonatype.org/content/repositories/snapshots
+
+./mill -i \
+    mill.scalalib.PublishModule/publishAll \
+    --sonatypeCreds "$SONATYPE_USERNAME":"$SONATYPE_PASSWORD" \
+    --gpgArgs --passphrase="$PGP_PASSPHRASE",--no-tty,--pinentry-mode,loopback,--batch,--yes,-a,-b \
+    --publishArtifacts indigo-plugin[3].publishArtifacts \
     --readTimeout  3600000 \
     --awaitTimeout 3600000 \
     --release true \


### PR DESCRIPTION
Indigo provides plugins for both sbt and mill. Both plugins have a common `indigo-plugin` dependency that allows avoiding code duplication. For now it's cross-built for Scala 2.12 (sbt) and Scala 2.13 (mill 0.12.x). This PR adds cross-build for Scala 3.3 LTS (which is a preferred version for libraries) to support mill 1.0 migration https://github.com/PurpleKingdomGames/indigo/issues/949